### PR TITLE
Use www-data user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ RUN composer dump-autoload --optimize
 RUN composer clear-cache
 
 # Update permisions
-RUN chown -R 1000:1000 /var/www/html/
+RUN chown -R www-data:www-data /var/www/html/
 
-USER 1000
+USER www-data


### PR DESCRIPTION
Running an interactive shell with user `1000` highlights that the user isn't known.

I went to create the user, but found the Drupal Docker image already has `www-data`, so this PR updates the `chown` and user setting to `www-data`.