### PR TITLE
Set Security Context to use www-data UID and GID

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -45,8 +45,8 @@ securityContext:
     drop:
     - ALL
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
+  runAsUser: 33
+  runAsGroup: 33
 
 resources: {}
 


### PR DESCRIPTION
The changes in #6 need to be applied to the Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) as well as the Docker image. 

This PR aligns the Helm charts and Docker image by using the same UID/GID.

No changes need to be made to the Docker Compose setup