### PR TITLE
Docker COPY needed a trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN composer install \
   --prefer-dist
 
 # Copy Project
-COPY flysystem/flysystem.* /var/www/html/modules/contrib/flysystem
-COPY flysystem/FieldMigration.php /var/www/html/modules/contrib/flysystem/src/Form
+COPY flysystem/flysystem.* /var/www/html/modules/contrib/flysystem/
+COPY flysystem/FieldMigration.php /var/www/html/modules/contrib/flysystem/src/Form/
 COPY modules/custom modules/custom
 COPY sites/ sites/
 


### PR DESCRIPTION
```
Step 9/17 : COPY flysystem/flysystem.* /var/www/html/modules/contrib/flysystem
 
When using COPY with more than one source file, the destination must be a directory and end with a /
 ```