### PR TITLE
Install mediainfo when creating docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM drupal:8.7.8-apache
 
 # Install Composer and it's dependencies
-RUN apt-get update && apt-get install curl -y && apt-get install git-core unzip -y && apt-get install mediainfo -y
+RUN apt-get update && apt-get install -y \
+      curl \
+      git-core \
+      mediainfo \
+      unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/bin --filename=composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM drupal:8.7.8-apache
 
 # Install Composer and it's dependencies
-RUN apt-get update && apt-get install curl -y && apt-get install git-core unzip -y
+RUN apt-get update
+RUN apt-get install curl -y
+RUN apt-get install git-core unzip -y
+RUN apt-get install mediainfo -y
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/bin --filename=composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM drupal:8.7.8-apache
 
 # Install Composer and it's dependencies
-RUN apt-get update
-RUN apt-get install curl -y
-RUN apt-get install git-core unzip -y
-RUN apt-get install mediainfo -y
+RUN apt-get update && apt-get install curl -y && apt-get install git-core unzip -y && apt-get install mediainfo -y
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/bin --filename=composer


### PR DESCRIPTION
- Install mediainfo
- Break apart apt-get commands, makes it easier to read what each is doing in the build