### PR TITLE
Update migration to move File entity reference

### DIFF
--- a/modules/custom/moj_video_item/moj_video_item.install
+++ b/modules/custom/moj_video_item/moj_video_item.install
@@ -235,17 +235,6 @@ function moj_video_item_update_8027(){
 */
 function moj_video_item_update_8030(){
 
-  function transform_video_to_file(File $video) {
-    $file_entity = File::create();
-    $file_entity->setFileUri($video->getFileUri());
-    $file_entity->setMimeType($video->getMimeType());
-    $file_entity->setFileName($video->getFileName());
-    $file_entity->setOwnerId($video->getOwnerId());
-    $file_entity->setPermanent();
-    $file_entity->save();
-    return $file_entity;
-  }
-
   function set_file_usage(File $file, File $video, $entity_id) {
     $file_usage = \Drupal::service('file.usage');
     $file_usage->add($file, 'file', 'node', $entity_id);
@@ -308,9 +297,9 @@ function moj_video_item_update_8030(){
     $video = $node->field_moj_video->entity;
     if (!empty($video)) {
       // Create the new File entity and assign it to the field_video
-      $file = $node->field_video->entity = transform_video_to_file($node->field_moj_video->entity);
+      $node->field_video->entity = $node->field_moj_video->entity;
       $node->save();
-      set_file_usage($file, $video, $node->id());
+      set_file_usage($node->field_video->entity, $video, $node->id());
       \Drupal::logger('chromatic_image')->notice(
         sprintf('Updated image for node "%s".', $node->getTitle())
       );


### PR DESCRIPTION
This PR changes the migration to move the underlying File entity rather than clone.
Reason for this PR is after an investigation in to files and usages in Drupal we noticed that we had duplicate references in the database to the same files on disk. This would have caused the following issues post-migration;

- Orphan File entities in the database
- Files on disk would be removed during a pre-delete hook on the File entity if we went to remove duplicate file entities (1)

(1) https://api.drupal.org/api/drupal/core%21modules%21file%21src%21Entity%21File.php/function/File%3A%3ApreDelete/8.7.x