### PR TITLE
update S3 defaults to match Terraform

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -2,3 +2,8 @@ ingress:
   enabled: true
   tlsEnabled: true
   hostName: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+
+application:
+  # The S3 bucket for production exists in Ireland,
+  # but the default is London
+  s3Region: eu-west-1

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -1,8 +1,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
-replicaCount: 1
-maxReplicaCount: 3
+replicaCount: 3
+maxReplicaCount: 6
 
 image:
   repository: mojdigitalstudio/prisoner-content-hub-backend
@@ -16,9 +16,9 @@ application:
   liveness:
     endpoint: /api/health
     delaySeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 10
   readiness:
-    endpoint: /
+    endpoint: /api/health
     delaySeconds: 10
     timeoutSeconds: 5
   config:
@@ -30,7 +30,7 @@ application:
     elasticsearchServiceName: aws-es-proxy-service
   dbSecretName: drupal-rds
   s3SecretName: drupal-s3
-  s3Region: eu-west-1
+  s3Region: eu-west-2
 
 volumes:
   - name: apache-cache


### PR DESCRIPTION
Only the production S3 bucket exists in Ireland. All other resources live in the London AWS Region.

This PR make the helm config reflect that, with an override for prod S3.