### PR TITLE
Cloud Platform development preview build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ workflows:
           <<: *main_branch
           type: approval
           requires:
-            - deploy_staging
+            - deploy_cloud_platform_staging
       - deploy_cloud_platform_production:
           <<: *main_branch
           context: prisoner-content-hub-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,12 +108,20 @@ jobs:
           root: /tmp/build-info
           paths:
             - version-to-deploy.txt
-  deploy_staging:
+
+  deploy_cloud_platform_development:
+    <<: *defaults
+    steps:
+      - release_to_namespace:
+          environment: "development"
+
+  deploy_cloud_platform_staging:
     <<: *defaults
     steps:
       - release_to_namespace:
           environment: "staging"
-  deploy_production:
+
+  deploy_cloud_platform_production:
     <<: *defaults
     steps:
       - release_to_namespace:
@@ -132,17 +140,25 @@ workflows:
             - approve_preview_build
       - build_production:
           <<: *main_branch
-      - deploy_staging:
+
+      - deploy_cloud_platform_development:
+          <<: *main_branch
+          context: prisoner-content-hub-development
+          requires:
+            - approve_preview_build
+
+      - deploy_cloud_platform_staging:
           <<: *main_branch
           context: prisoner-content-hub-staging
           requires:
             - build_production
+
       - approve_deploy_production:
           <<: *main_branch
           type: approval
           requires:
             - deploy_staging
-      - deploy_production:
+      - deploy_cloud_platform_production:
           <<: *main_branch
           context: prisoner-content-hub-prod
           requires:

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -1,0 +1,4 @@
+ingress:
+  enabled: true
+  tlsEnabled: true
+  hostName: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
This PR is the CMS complement to https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/28:

- Adds a gated deployment in the development namespace.
Intent:

To allow us to trivially deploy into the development environment for any branch.

This will overwrite any existing deployment, so there's a couple of caveats:

- Development can enter a broken state by moving back and forth with backend releases. If/when this happens, we'll restore a known good copy of the database.
- There's only one active deployment, so this approach won't work well for pull requests, where we often have many. This can easily be solved for the frontend, but for Drupal it's a bit trickier to spin up ephemeral databases.