### PR TITLE
fix copy/pasta error and enable TLS by default

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress.yaml
@@ -19,28 +19,12 @@ spec:
   {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: "/"
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
   {{- end }}
-
-  {{- range .Values.ingress.hosts }}
-  - hosts:
-    - {{ .host }}
-    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
-  {{- end }}
-
-  rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+{{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -1,5 +1,3 @@
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,6 +1,4 @@
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
     - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
     - host: manage.prisoner.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -1,5 +1,3 @@
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -59,9 +59,9 @@ service:
   port: 80
 
 ingress:
-  enabled: false
-  tlsEnabled: false
-  path: /
+  enabled: true
+  tlsEnabled: true
+  path: "/"
   annotations:
     kubernetes.io/ingress.class: "nginx"
     # nginx.ingress.kubernetes.io/enable-modsecurity: "true"


### PR DESCRIPTION
This PR 
- removes some duplicates config in the ingress which I missed
- defaults the ingress to enabled to simplify config (we enable TLS/ingress in all our CP environments)