### PR TITLE
🐛 Using the production URL instead of a typo

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,7 +1,7 @@
 ingress:
   hosts:
     - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
-    - host: manage.prisoner.service.justice.gov.uk
+    - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate
 
 application:


### PR DESCRIPTION
Because Ryan didn't have enough coffee today