### PR TITLE
Use hosts array for helm variables

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/NOTES.txt
+++ b/helm_deploy/prisoner-content-hub-backend/templates/NOTES.txt
@@ -2,5 +2,5 @@
 Ingress not enabled
 {{ else }}
 Application is running at:
-  http{{ if .Values.ingress.tlsEnabled}}s{{ end }}://{{ .Values.ingress.hostName }}{{ $.Values.ingress.path }}
+  {{ include "prisoner-content-hub-backend.externalHost" . }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -66,5 +66,5 @@ Create external Kubernetes hostname
 {{- if .Values.ingress.tlsEnabled }}
 {{- $protocol = "https" }}
 {{- end }}
-{{- printf "%s://%s" $protocol .Values.ingress.hostName }}
+{{- printf "%s://%s" $protocol (index .Values.ingress.hosts 0).host }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
                   name: {{ .Values.application.s3SecretName }}
                   key: bucket_name
             - name: FLYSYSTEM_S3_CNAME
-              value: {{ .Values.ingress.hostName }}/_flysystem/s3
+              value: {{ (index .Values.ingress.hosts 0).host }}/_flysystem/s3
             - name: HASH_SALT
               valueFrom:
                 secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -1,4 +1,3 @@
 ingress:
-  hostName: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.local.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.local.yaml
@@ -4,4 +4,5 @@ application:
 ingress:
   enabled: false
   tlsEnabled: true
-  hostName: content.pfs-digital-hub-stage.hmpps.dsd.io
+  hosts:
+    - host: content.pfs-digital-hub-stage.hmpps.dsd.io

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,9 +1,8 @@
 ingress:
-  hostName: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk # added to support migration work, will need to find better solution
   hosts:
-    - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
     - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate
+    - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
 
 application:
   # The S3 bucket for production exists in Ireland,

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -1,4 +1,3 @@
 ingress:
-  hostName: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
Following on from #50, this PR:

- Updates the templates to use the `hosts` array, taking the first host in the list as its canonical host name
- Reorders the production values file so `manage.content-hub.prisoner.service.justice.gov.uk` gets picked first
- Removes the `hostName` variable from all backend helm templates

Intent

It's a bit confusing to have `hostName` and `hosts` in the values file, and can lead to drift. This PR makes sure we've got a single definition for the host names in Helm.