### PR TITLE
Add Kubernetes cron for Drupal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,8 @@ commands:
               --install --wait --force --reset-values --timeout 360s \
               --namespace=${KUBE_NAMESPACE} \
               --values ~/git/helm_deploy/prisoner-content-hub-backend/values.<< parameters.environment >>.yaml \
-              --set image.tag=${VERSION_TO_DEPLOY}
+              --set image.tag=${VERSION_TO_DEPLOY} \
+              --set cronToken=${HELM_BACKEND_CRON_TOKEN}
 
 jobs:
   build_preview:

--- a/helm_deploy/prisoner-content-hub-backend/readme.md
+++ b/helm_deploy/prisoner-content-hub-backend/readme.md
@@ -42,6 +42,12 @@ helm upgrade [Release Name] . \
 
 The computed values and generated output will be displayed
 
+**Note:** The Drupal cron token is located in drupal path:
+
+Manage / configuration / cron
+or
+configuration / cron
+
 ### Perform the release
 
 Once tested and verified the release can be performed using the following

--- a/helm_deploy/prisoner-content-hub-backend/readme.md
+++ b/helm_deploy/prisoner-content-hub-backend/readme.md
@@ -36,7 +36,8 @@ helm upgrade [Release Name] . \
 --namespace [Kubernetes Namespace] \
 --values values.[Environment].yaml \
 --values secrets.yaml \
---set image.tag=[Image Tag]
+--set image.tag=[Image Tag] \
+--set cronToken=[Drupal cron token]
 ```
 
 The computed values and generated output will be displayed
@@ -51,7 +52,8 @@ helm upgrade [Release Name] . \
 --namespace [Kubernetes Namespace] \
 --values values.[Environment].yaml \
 --values secrets.yaml \
---set image.tag=[Image Tag]
+--set image.tag=[Image Tag] \
+--set cronToken=[Drupal cron token]
 ```
 
 ### Rolling back releases

--- a/helm_deploy/prisoner-content-hub-backend/secrets.example.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/secrets.example.yaml
@@ -1,1 +1,2 @@
 hashSalt: SuperSecret # Optional - Randomly generated if not provided
+cronToken: UNSET

--- a/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "prisoner-content-hub-backend.fullname" . }}
+  labels:
+    {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.cron.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: drupalCronJob
+            {{- with .Values.cron.image }}
+            image: "{{ .repository }}:{{ .tag }}"
+            {{- end }}
+            args:
+            - -s
+            - {{ include "prisoner-content-hub-backend.internalHost" . }}/cron/{{ .Values.cronToken }}
+          restartPolicy: OnFailure

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -77,5 +77,5 @@ ingress:
 cron:
   schedule: "*/* 3 * * *"
   image:
-    repository: byrnedo/alpine-curl
+    repository: docker pull curlimages/curl
     tag: 0.1

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -73,3 +73,9 @@ ingress:
     nginx.ingress.kubernetes.io/server-snippet: |
        add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
+
+cron:
+  schedule: "*/* 3 * * *"
+  image:
+    repository: byrnedo/alpine-curl
+    tag: 0.1


### PR DESCRIPTION
- Added Kubernetes cron Helm template
- Update values.yaml to include cron values
- Update secrets example
- Update circle CI deploy step
- Update circle CI contexts
- Update Helm Readme

**NOTE**

Drupal cron jobs will need to be disabled (set to Never) to ensure it is remotely managed by the Kubernetes cron in this PR