### PR TITLE
fixes to enable drupal cron jobs

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "prisoner-content-hub-backend.fullname" . }}
+  name: {{ include "prisoner-content-hub-backend.fullname" . }}-search-indexing
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
@@ -11,8 +11,10 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           containers:
-          - name: drupalCronJob
+          - name: drupal-search-indexing-job
             {{- with .Values.cron.image }}
             image: "{{ .repository }}:{{ .tag }}"
             {{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -75,7 +75,7 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
 
 cron:
-  schedule: "*/* 3 * * *"
+  schedule: "0 * * * *"
   image:
-    repository: docker pull curlimages/curl
-    tag: 0.1
+    repository: curlimages/curl
+    tag: 7.71.1


### PR DESCRIPTION
Pairing @davidthomas22 and @spikeheap, we fixed up the cron jobs, testing the `prisoner-content-hub-development` namespace.

This PR:
- Fixes a naming issue with the cron job that caused the deployment to fail
- Improves the name of the pods for clarity
- Adds a security context to run the `curl` container non-root
- Corrects the `curl` image version to the latest one
- Runs the cron job every hour. It was running every 3 hours, but there's no reason not to run it more frequently