### PR TITLE
Resolve helm deployment failure 

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - name: SENTRY_ENVIRONMENT
               value: {{ .Values.application.sentry_environment }}
             - name: SENTRY_RELEASE
-              value: {{ .Values.application.sentry_release }}
+              value: {{ quote .Values.application.sentry_release }}
           ports:
             - name: http
               containerPort: {{ .Values.application.port }}


### PR DESCRIPTION
In https://app.circleci.com/pipelines/github/ministryofjustice/prisoner-content-hub-backend/188/workflows/b964127a-d7c6-4351-9358-068e79fea19c/jobs/126 the build fails because a value is unquoted:

```
ReadString: expects " or n, but found 1, error found in #10 byte of ...|,"value":126}],"imag|..., bigger context ...|lue":"*******"},{"name":"SENTRY_RELEASE","value":126}
```

This probably shouldn't be merged until the current upload issue is resolved, so I'll just leave it here :) 