### PR TITLE
Scheduled publishing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/raven": "^2.27",
         "drupal/rest_menu_items": "^2.6",
         "drupal/restui": "^1.18",
+        "drupal/scheduler": "^1.3",
         "drupal/search_api": "^1.17",
         "drupal/token": "^1.5",
         "drupal/video": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "642eb805c601859ef9fdca222ad7c758",
+    "content-hash": "ecb46289ca78acadd6853968dfa5e633",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2083,6 +2083,77 @@
             "homepage": "https://www.drupal.org/project/restui",
             "support": {
                 "source": "https://git.drupalcode.org/project/restui"
+            }
+        },
+        {
+            "name": "drupal/scheduler",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/scheduler.git",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/scheduler-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "704f9e289c7a42ddfb65297beb0be02e324f02c6"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "require-dev": {
+                "drupal/devel_generate": "^2.0 || 3.x-dev",
+                "drupal/rules": "^3",
+                "drush/drush": "^9.0 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1591436219",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Eric Schaefer (Eric Schaefer)",
+                    "homepage": "https://www.drupal.org/u/eric-schaefer",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jonathan Smith (jonathan1055)",
+                    "homepage": "https://www.drupal.org/u/jonathan1055",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Pieter Frenssen (pfrenssen)",
+                    "homepage": "https://www.drupal.org/u/pfrenssen",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Rick Manelius (rickmanelius)",
+                    "homepage": "https://www.drupal.org/u/rickmanelius",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Automatically publish and unpublish content at specified dates and times.",
+            "homepage": "https://drupal.org/project/scheduler",
+            "support": {
+                "source": "https://git.drupalcode.org/project/scheduler",
+                "issues": "https://www.drupal.org/project/issues/scheduler"
             }
         },
         {

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -78,7 +78,7 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
 
 cron:
-  schedule: "0 * * * *"
+  schedule: "*/5 * * * *"
   image:
     repository: curlimages/curl
     tag: 7.71.1


### PR DESCRIPTION
This PR adds the ability to schedule when a post will be published or unpublished, using the `drupal/scheduler` plugin. I spent an hour or so evaluating the plugin and testing it locally

<img width="807" alt="Screenshot 2020-08-11 at 16 37 05" src="https://user-images.githubusercontent.com/464482/90606150-522bdf00-e1f7-11ea-979b-683324863269.png">

We also update the cron trigger to run more frequently (every 5 minutes). Scheduled posts are evaluated each `cron` run, so a post scheduled for `10:00:01` would _actually_ be published at `10:05:00` when the next job runs.

## Additional steps

Once this PR is merged we need to:

- [ ] enable the module in the [production Drupal UI](https://manage.content-hub.prisoner.service.justice.gov.uk/admin/modules).
- [ ] enable scheduled publishing for each content type in `Structure -> Content Types -> * -> Edit -> Scheduler`, enabling publish/unpublish and setting it to use an inline fieldset:
<img width="1220" alt="Screenshot 2020-08-19 at 08 49 12" src="https://user-images.githubusercontent.com/464482/90607239-ddf23b00-e1f8-11ea-8b00-f9a96fb19ed5.png">

- [ ] let people know about it (maybe with a Confluence page?)

I had wanted to set configuration in `settings.php`, but the nested, dynamic nature of applying this to each content type made it prohibitively difficult. Given more time I'd like to get `drush` working so we could apply these changes programmatically.

## Intent

Scheduled publishing, alongside the change in publishing workflow to make "Published" content immediately available, reduces the need for the content team to work over the weekend.