### PR TITLE
Use namespace-specific nginx for non-production environments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,7 +9,6 @@ CONTENTS OF THIS FILE
  * Developing for Drupal
  * More information
 
-
 ABOUT DRUPAL
 ------------
 

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -2,5 +2,7 @@ image:
   pullPolicy: Always
 
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-development
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,4 +1,6 @@
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
   hosts:
     - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -1,3 +1,5 @@
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-staging
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -66,7 +66,6 @@ ingress:
   tlsEnabled: true
   path: "/"
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     # nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     # nginx.ingress.kubernetes.io/modsecurity-snippet: |
     #   Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf


### PR DESCRIPTION
For https://trello.com/c/9w8hYZJQ/1380-add-annotation-to-ingress-controllers.

This PR updates the kubernetes ingress annotation following https://mojdt.slack.com/archives/CH6D099DF/p1598372708002900.

This only applies to non-production environments initially. Once we're ready to roll it out across the board we should probably refactor this to remove the environment-specific annotations into something like:

```
{{- $namespace_name := .Release.Namespace }}
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:

  ... removed for brevity

  {{- with .Values.ingress.annotations }}
  annotations:
    kubernetes.io/ingress.class: {{ $namespace_name }}
    {{- toYaml . | nindent 4 }}
  {{- end }}
```
