### PR TITLE
Revert "Use namespace-specific nginx for non-production environments"

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,6 +9,7 @@ CONTENTS OF THIS FILE
  * Developing for Drupal
  * More information
 
+
 ABOUT DRUPAL
 ------------
 

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -2,7 +2,5 @@ image:
   pullPolicy: Always
 
 ingress:
-  annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-development
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,6 +1,4 @@
 ingress:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
   hosts:
     - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -1,5 +1,3 @@
 ingress:
-  annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-staging
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -66,6 +66,7 @@ ingress:
   tlsEnabled: true
   path: "/"
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     # nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     # nginx.ingress.kubernetes.io/modsecurity-snippet: |
     #   Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf


### PR DESCRIPTION
Reverts ministryofjustice/prisoner-content-hub-backend#73

Cloud Platform have abandoned the custom-ingress approach, so we can undo this change.