### PR TITLE
Add missing config file for MoJ Resources module

### DIFF
--- a/modules/custom/moj_resources/config/install/rest.resource.category_featured_content_resource.yml
+++ b/modules/custom/moj_resources/config/install/rest.resource.category_featured_content_resource.yml
@@ -1,0 +1,9 @@
+id: category_featured_content_resource
+plugin_id: category_featured_content_resource
+granularity: method
+configuration:
+  GET:
+    supported_formats:
+      - json
+    supported_auth:
+      - cookie


### PR DESCRIPTION
Tested locally by uninstalling MoJ Rersources and reinstalling and checking the available endpoints.