### PR TITLE
Add configuration to set Trusted Hosts

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -79,4 +79,5 @@ Create trusted host pattern
 {{- range (slice .Values.ingress.hosts 1) -}}
 |^{{ (.host | replace "." "\\.")}}$
 {{- end }}
+{{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -68,3 +68,15 @@ Create external Kubernetes hostname
 {{- end }}
 {{- printf "%s://%s" $protocol (index .Values.ingress.hosts 0).host }}
 {{- end }}
+
+{{/*
+Create trusted host pattern
+*/}}
+{{- define "prisoner-content-hub-backend.trustedHosts" -}}
+{{- with (first .Values.ingress.hosts) -}}
+^{{ (.host | replace "." "\\.") }}$
+{{- end }}
+{{- range (slice .Values.ingress.hosts 1) -}}
+|^{{ (.host | replace "." "\\.")}}$
+{{- end }}
+{{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
@@ -117,12 +117,18 @@ spec:
             httpGet:
               path: {{ .Values.application.liveness.endpoint }}
               port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ (index .Values.ingress.hosts 0).host }}
             initialDelaySeconds: {{ .Values.application.liveness.delaySeconds }}
             timeoutSeconds: {{ .Values.application.liveness.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: {{ .Values.application.readiness.endpoint }}
               port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ (index .Values.ingress.hosts 0).host }}
             initialDelaySeconds: {{ .Values.application.readiness.delaySeconds }}
             timeoutSeconds: {{ .Values.application.readiness.timeoutSeconds }}
           resources:

--- a/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: {{ .Values.application.sentry_environment }}
             - name: SENTRY_RELEASE
               value: {{ quote .Values.application.sentry_release }}
+            - name: TRUSTED_HOSTS
+              value: {{ include "prisoner-content-hub-backend.trustedHosts" . }}
           ports:
             - name: http
               containerPort: {{ .Values.application.port }}

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -12,6 +12,12 @@ $databases['default']['default'] = array(
   'driver' => 'mysql',
 );
 
+$trusted_hosts = getenv('TRUSTED_HOSTS', true);
+
+$settings['trusted_host_patterns'] = [
+  $trusted_hosts
+];
+
 /**
  * Flysystem S3 filesystem configuration
  */
@@ -116,3 +122,4 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 
 // TODO: Remove, added for long execution time of moj_video_item migration
 ini_set('max_execution_time', 3000);
+


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Zu6RS41d/1774-trusted-host-settings-not-enabled-in-drupal

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Trusted host is configured in Drupal, the trusted host pattern is generated at deploy-time in Helm

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

We would need to validate both browser and service-to-service level interactions with Drupal

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
