### PR TITLE
Include uploadprogress PECL module. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 
+RUN pecl install uploadprogress \
+    && docker-php-ext-enable uploadprogress
+
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php composer-setup.php --install-dir=/bin --filename=composer --version=1.10.16 \
   && php -r "unlink('composer-setup.php');"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
For https://trello.com/c/9G8edxdb/95-install-pecl-uploadprogress-library-in-drupal-docker-image

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?
Drupal can show upload progress to users. It's not currently doing this because a PECL module (`uploadprogress`) is missing. This PR resolves that.

> Would this PR benefit from screenshots?
The [status page](https://manage.content-hub.prisoner.service.justice.gov.uk/admin/reports/status) shows us the module is missing:

<img width="1264" alt="Screenshot_2021-01-12_at_13 50 36" src="https://user-images.githubusercontent.com/464482/104479868-d2464d00-55bb-11eb-998c-1bcdb88a9997.png">

With this fix (tested locally with Docker Compose):

<img width="656" alt="Screenshot 2021-01-13 at 16 26 07" src="https://user-images.githubusercontent.com/464482/104480067-0de11700-55bc-11eb-9f68-04a545404504.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
It would be good to check this in staging once it's been merged

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
