### PR TITLE
🧹 Remove unused setting from settings.php.

### DIFF
--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -75,7 +75,6 @@ $flysystem_schemes = [
 
 $settings['flysystem'] = $flysystem_schemes;
 
-$settings['install_profile'] = 'standard';
 $settings['hash_salt'] = getenv('HASH_SALT', true);
 $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
Nope, it's a tiny cleanup issue, with no user-facing effects.

> If this is an issue, do we have steps to reproduce?
The Drupal status report (https://manage.content-hub.prisoner.service.justice.gov.uk/admin/reports/status) points out that this is an unnecessary config option now:

<img width="916" alt="Screenshot 2021-01-14 at 14 07 08" src="https://user-images.githubusercontent.com/464482/104601162-cd43d500-5671-11eb-9938-b7e77385191d.png">

### Intent

> What changes are introduced by this PR that correspond to the above card?

This PR removes the redundant line from `settings.php`.

> Would this PR benefit from screenshots?
No 🙂

### Considerations

> Is there any additional information that would help when reviewing this PR?

To review this you can pull the branch locally, start Drupal, and see that the site loads.

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
