### PR TITLE
Add prison tagging action

### DIFF
--- a/modules/custom/custom_action_prison_tagging/config/install/system.action.node_prison_tag_action.yml
+++ b/modules/custom/custom_action_prison_tagging/config/install/system.action.node_prison_tag_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_prison_tag_action
+label: 'Tag content with prisons'
+type: node
+plugin: node_prison_tag_action
+configuration: {  }

--- a/modules/custom/custom_action_prison_tagging/config/schema/custom_action_prison_tagging.schema.yml
+++ b/modules/custom/custom_action_prison_tagging/config/schema/custom_action_prison_tagging.schema.yml
@@ -1,0 +1,3 @@
+action.configuration.custom_action_prison_tagging:
+  type: node_prison_tag_action
+  label: 'Tag content with prisons'

--- a/modules/custom/custom_action_prison_tagging/custom_action_prison_tagging.info.yml
+++ b/modules/custom/custom_action_prison_tagging/custom_action_prison_tagging.info.yml
@@ -1,0 +1,5 @@
+name: Prison tagging custom action
+description: A custom action to tag content that have no prisons tagged
+package: MoJ
+type: module
+core_version_requirement: ^8.8.0 || ^9.0

--- a/modules/custom/custom_action_prison_tagging/src/Plugin/Action/NodePrisonTagAction.php
+++ b/modules/custom/custom_action_prison_tagging/src/Plugin/Action/NodePrisonTagAction.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\custom_action_prison_tagging\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Messenger\Messenger;
+
+/**
+ * create custom action
+ *
+ * @Action(
+ *   id = "node_prison_tag_action",
+ *   label = @Translation("Tag content with prisons"),
+ *   type = "node"
+ * )
+ */
+class NodePrisonTagAction extends ActionBase {
+
+    private $prisonIds = [792,959,793]; // TODO: Pull from Taxonomy
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($node = NULL) {
+        if ($node) {
+            $this->updatePrisonEntityReference($node);
+        }
+    }
+    /**
+     * {@inheritdoc}
+     */
+    private function updatePrisonEntityReference($node) {
+        if($this->isPrisonReferanceEmpty($node)) {
+            $this->setPrisons($node);
+        } else {
+            \Drupal::messenger()->addError('prisons are already set');
+        }
+    }
+    /**
+     * {@inheritdoc}
+     */
+    private function setPrisons($node) {
+        foreach($this->prisonIds as $index => $fid) {
+            $node->field_moj_prisons[] = ['target_id' => $fid];
+            $node->save();
+            \Drupal::messenger()->addStatus('prisons updated');
+        }
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    private function isPrisonReferanceEmpty($node) {
+        return $node->get('field_moj_prisons')->isEmpty() ? TRUE : FALSE;
+    }
+
+        /**
+     * {@inheritdoc}
+     */
+    public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+        /** @var \Drupal\node\NodeInterface $object */
+        // TODO: write permissions
+        $result = $object->access('create', $account, TRUE);
+        return $return_as_object ? $result : $result->isAllowed();
+    }
+}


### PR DESCRIPTION
- Add custom action module
- Add install and scheme info
- Add a custom action to tag content will all prisons

### Context

> Does this issue have a Trello card?

https://trello.com/c/64dZUJsD/1852-spike-drupal-vbo

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?

> Would this PR benefit from screenshots?

<img width="1121" alt="Screenshot 2021-01-16 at 11 19 41" src="https://user-images.githubusercontent.com/25793145/104810504-ede46a00-57ec-11eb-8aad-3b95247afef6.png">

Adds a custom action to the content admin to tag content with all prisons. 

_Note it only tags content if there are no prisons currently checked._

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

An update to the content admin to allow the content to filtered by prison tags would add value b/c it would reduce the number of content to be tagged, therefore reducing the load on the CMS

The module can be installed using `drush en custom_action_prison_tagging` Ther are no DB updates with this module.

### Checklist

- [X ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
