### PR TITLE
Bugfix/vocabulary endpoint filtering

### DIFF
--- a/modules/custom/moj_resources/src/VocabularyApiClass.php
+++ b/modules/custom/moj_resources/src/VocabularyApiClass.php
@@ -9,8 +9,6 @@ use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 
-require_once('Utils.php');
-
 /**
  * PromotedContentApiClass
  */
@@ -109,7 +107,16 @@ class VocabularyApiClass
         ->condition('type', $types, 'IN')
         ->accessCheck(false);
 
-      $query = getPrisonResults($this->prisonId, $query);
+      $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
+      $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
+
+      $prisonCategoriesCondition = Utilities::filterByPrisonCategories(
+        $this->prisonId,
+        $prisonCategories,
+        $query
+      );
+
+      $query->condition($prisonCategoriesCondition);
 
       $group = $query
         ->orConditionGroup()

--- a/modules/custom/moj_resources/src/VocabularyApiClass.php
+++ b/modules/custom/moj_resources/src/VocabularyApiClass.php
@@ -141,10 +141,14 @@ class VocabularyApiClass
      */
     protected function getVocabularyTermIds($taxonomyName)
     {
+
+      $query = $this->entityQuery->get('taxonomy_term');
+      $query->condition('vid', $taxonomyName);
+
+      if ($taxonomyName == "series") {
+
         $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
         $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
-
-        $query = $this->entityQuery->get('taxonomy_term');
 
         $prisonCategoriesCondition = Utilities::filterByPrisonCategories(
           $this->prisonId,
@@ -153,10 +157,10 @@ class VocabularyApiClass
           true
         );
 
-        $query
-            ->condition('vid', $taxonomyName)
-            ->condition($prisonCategoriesCondition);
+        $query->condition($prisonCategoriesCondition);
 
-        return $query->execute();
+      }
+
+      return $query->execute();
     }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/l6Rr4q7X/1870-all-topics-page-categories-secondary-tags

> If this is an issue, do we have steps to reproduce?

- Visit `Browse All Topics` page for a prison
- Only relevant `Secondary Tags` should be displayed for that prison

Note: this can be compared against Production which is not affected by this issue

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Taxonomies fetched via the `/api/v1/vocabulary/{type}` endpoint in Drupal should not be filtered by `Prison Category` unless it is a `Series`
- When validating a `Secondary Tag` has content (in order to be displayed for the `All Topics` page) we use `Prison Category` filtering

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

N/A

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
