### PR TITLE
Add check for fields when accessing in the Term API endpoint

### DIFF
--- a/modules/custom/moj_resources/src/TermApiClass.php
+++ b/modules/custom/moj_resources/src/TermApiClass.php
@@ -144,11 +144,11 @@ class TermApiClass
     $response['id'] = $term->tid->value;
     $response['content_type'] = $term->vid[0]->target_id;
     $response['title'] = $term->name->value;
-    $response['description'] = $term->description[0];
+    $response['description'] = $term->description ? $term->description[0] : null;
     $response['summary'] = $term->field_content_summary ? $term->field_content_summary->value : '';
-    $response['image'] = $term->field_featured_image[0];
-    $response['video'] = $term->field_featured_video[0];
-    $response['audio'] = $term->field_featured_audio[0];
+    $response['image'] = $term->field_featured_image ? $term->field_featured_image[0] : null;
+    $response['video'] = $term->field_featured_video ? $term->field_featured_video[0] : null;
+    $response['audio'] = $$term->field_featured_audio ? $term->field_featured_audio[0] : null;
     $response['programme_code'] = $term->field_feature_programme_code ? $term->field_feature_programme_code->value : '';
 
     if ($term->hasField('field_prison_categories')) {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/4loln70n/1874-term-api-error-with-empty-fields

> If this is an issue, do we have steps to reproduce?

There should be no more warnings for accessing array indices on null values for the Term API endpoint in Drupal

### Intent

> What changes are introduced by this PR that correspond to the above card?

Add ternary operators to check for a value before accessing an array

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
