### PR TITLE
refactor: set config sync directory to live outside files/

### DIFF
--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -109,10 +109,10 @@ $config['raven.settings'] = [
   'fatal_error_handler' => true
 ];
 
-$config_directories['sync'] = 'sites/default/files/config/sync';
+$config_directories['sync'] = 'sites/default/config/sync';
 
 $config_directories = [
-  CONFIG_SYNC_DIRECTORY => 'sites/default/files/config/sync'
+  CONFIG_SYNC_DIRECTORY => 'sites/default/config/sync'
 ];
 
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/g7kGCSTL/1876-manage-drupal-config-as-code

### Intent

Following advice in https://www.drupal.org/docs/configuration-management/changing-the-storage-location-of-the-sync-directory, this PR moves the config sync directory out of `sites/default/files`.

This also gets us around our `.gitignore` ignoring the `files/` directory, and means when we do a config export it gets picked up straight away.

This is step one to get our config into code 🥳. 

### Considerations

> Is there any additional information that would help when reviewing this PR?
We don't use config sync at the moment, so this change shouldn't affect anything

> Are there any steps required when merging/deploying this PR?
Nope

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change - N/A
- [x] Documentation has been updated where appropriate - N/A, we'll update the docs as part of the config-as-code piece
- [x] Tested locally
