### PR TITLE
Move check for Series prison categories to after prison check

### DIFF
--- a/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -313,15 +313,15 @@ class SeriesContentApiClass
   private function getSeriesContentIds($seriesId, $numberOfResultsToReturn, $resultsOffset, $prisonId) {
     $series = Utilities::getTermFor($seriesId, $this->termStorage);
     $prison = Utilities::getTermFor($prisonId, $this->termStorage);
-    $seriesPrisonCategories = Utilities::getPrisonCategoriesFor($series);
-    $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
 
     $query = $this->entity_query->get('node')
-      ->condition('status', 1)
-      ->accessCheck(false);
+    ->condition('status', 1)
+    ->accessCheck(false);
 
     $seriesPrison = $series->get('field_promoted_to_prison');
     $seriesHasPrisonSelected = !$seriesPrison->isEmpty();
+
+    $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
 
     if ($seriesHasPrisonSelected) {
       $query->condition($this->filterByPrison(
@@ -331,6 +331,8 @@ class SeriesContentApiClass
         $query
       ));
     } else {
+      $seriesPrisonCategories = Utilities::getPrisonCategoriesFor($series);
+
       $query->condition($this->filterByPrisonCategories(
         $prisonId,
         $seriesPrisonCategories,


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No, this is a small fix to an issue

> If this is an issue, do we have steps to reproduce?

- Go to a series landing page, where the series has no prison category
- The page will have no content

### Intent

> What changes are introduced by this PR that correspond to the above card?

Moved the check for a Prison Category on a Series until after we check for a Prison

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

N/A

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
