### PR TITLE
(Re)introduce prison category filtering

### DIFF
--- a/modules/custom/moj_resources/moj_resources.services.yml
+++ b/modules/custom/moj_resources/moj_resources.services.yml
@@ -1,38 +1,28 @@
 services:
+  moj_resources.category_featured_content_api_class:
+    class: Drupal\moj_resources\CategoryFeaturedContentApiClass
+    arguments: ["@entity_type.manager", "@entity.query"]
+  moj_resources.category_menu_api_class:
+    class: Drupal\moj_resources\CategoryMenuApiClass
+    arguments: ["@entity_type.manager", "@entity.query"]
   moj_resources.content_api_class:
     class: Drupal\moj_resources\ContentApiClass
     arguments: ["@entity_type.manager", "@entity.query"]
   moj_resources.new_featured_content_api_class:
     class: Drupal\moj_resources\NewFeaturedContentApiClass
     arguments: ["@entity_type.manager", "@entity.query"]
-  moj_resources.category_featured_content_api_class:
-    class: Drupal\moj_resources\CategoryFeaturedContentApiClass
-    arguments: ["@entity_type.manager", "@entity.query"]
   moj_resources.related_content_api_class:
     class: Drupal\moj_resources\RelatedContentApiClass
-    arguments: ["@entity_type.manager", "@entity.query"]
-  moj_resources.suggested_content_api_class:
-    class: Drupal\moj_resources\SuggestedContentApiClass
-    arguments: ["@entity_type.manager", "@entity.query"]
-  moj_resources.category_menu_api_class:
-    class: Drupal\moj_resources\CategoryMenuApiClass
     arguments: ["@entity_type.manager", "@entity.query"]
   moj_resources.series_content_api_class:
     class: Drupal\moj_resources\SeriesContentApiClass
     arguments: ["@entity_type.manager", "@entity.query"]
-  moj_resources.vocabulary_api_class:
-    class: Drupal\moj_resources\VocabularyApiClass
-    arguments:
-      [
-        "@entity_type.manager",
-        "@entity.query",
-        "@moj_pdf_item.link.serializer.default",
-      ]
+  moj_resources.suggested_content_api_class:
+    class: Drupal\moj_resources\SuggestedContentApiClass
+    arguments: ["@entity_type.manager", "@entity.query"]
   moj_resources.term_api_class:
     class: Drupal\moj_resources\TermApiClass
-    arguments:
-      [
-        "@entity_type.manager",
-        "@entity.query",
-        "@moj_pdf_item.link.serializer.default",
-      ]
+    arguments: ["@entity_type.manager", "@entity.query"]
+  moj_resources.vocabulary_api_class:
+    class: Drupal\moj_resources\VocabularyApiClass
+    arguments: ["@entity_type.manager", "@entity.query"]

--- a/modules/custom/moj_resources/src/CategoryMenuApiClass.php
+++ b/modules/custom/moj_resources/src/CategoryMenuApiClass.php
@@ -5,8 +5,7 @@ namespace Drupal\moj_resources;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-
-require_once('Utils.php');
+use Drupal\moj_resources\Utilities;
 
 /**
  * CategoryMenuApiClass
@@ -44,6 +43,8 @@ class CategoryMenuApiClass
   protected $categoryId;
 
   protected $prisonId;
+
+  protected $prisonCategories;
 
   /**
      * Class Constructor
@@ -92,21 +93,25 @@ class CategoryMenuApiClass
   private function getCategoryMenuItems()
   {
     $contentTypes = array('page', 'moj_pdf_item', 'moj_radio_item', 'moj_video_item', );
+    $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
+    $this->prisonCategories = Utilities::getPrisonCategoriesFor($prison);
 
     $query = $this->entityQuery->get('node')
       ->condition('status', 1)
       ->condition('type', $contentTypes, 'IN')
       ->accessCheck(false);
 
-    if ($this->categoryId !== 0) {
-      $categoryIdCondition = $query
-        ->orConditionGroup()
-        ->condition('field_moj_top_level_categories', $this->categoryId)
-        ->condition('field_moj_tags', $this->categoryId);
-      $query->condition($categoryIdCondition);
-    }
+    $categoryIdCondition = $query
+      ->orConditionGroup()
+      ->condition('field_moj_top_level_categories', $this->categoryId)
+      ->condition('field_moj_tags', $this->categoryId);
+    $query->condition($categoryIdCondition);
 
-    $query = getPrisonResults($this->prisonId, $query);
+    $query->condition(Utilities::filterByPrisonCategories(
+      $this->prisonId,
+      $this->prisonCategories,
+      $query
+    ));
 
     $results = $query->execute();
     $content = $this->loadContentDetails($results);
@@ -125,9 +130,32 @@ class CategoryMenuApiClass
   {
     $response = array();
     $response['secondary_tag_ids'] = array_map($this->translateNode, $this->loadTermDetails($menuIds['secondary_tag_ids']));
-    $response['series_ids'] = array_map($this->translateNode, $this->loadTermDetails($menuIds['series_ids']));
+    $filteredSeries = array();
 
-    return $response;
+    $series = array_map($this->translateNode, $this->loadTermDetails($menuIds['series_ids']));
+
+    foreach ($series as $singleSeries) {
+      $seriesPrison = $singleSeries->get('field_promoted_to_prison');
+      $seriesHasPrisonSelected = !$seriesPrison->isEmpty();
+
+      if ($seriesHasPrisonSelected) {
+        if ($this->prisonId == $seriesPrison->target_id) {
+          array_push($filteredSeries, $singleSeries);
+        }
+      } else {
+        $seriesPrisonCategories = Utilities::getPrisonCategoriesFor($singleSeries, false);
+        $matchingPrisonCategories = array_intersect($this->prisonCategories, $seriesPrisonCategories);
+
+        if (!empty($matchingPrisonCategories)) {
+          array_push($filteredSeries, $singleSeries);
+        }
+      }
+    }
+
+    return array(
+      'secondary_tag_ids' => $response['secondary_tag_ids'],
+      'series_ids' => $filteredSeries
+    );
   }
 
   private function generateMenuFrom($content)

--- a/modules/custom/moj_resources/src/ContentApiClass.php
+++ b/modules/custom/moj_resources/src/ContentApiClass.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\moj_resources;
 
+use Drupal\moj_resources\Utilities;
 use Drupal\node\NodeInterface;
-use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * ContentApiClass
@@ -13,214 +15,260 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 class ContentApiClass
 {
   /**
-   * Node IDs
-   *
-   * @var array
-   */
-  protected $nid = array();
-
-  /**
-   * Nodes
-   *
-   * @var array
-   */
-  protected $node = array();
-  /**
    * Language Tag
    *
    * @var string
    */
-  protected $lang;
+  protected $languageId;
   /**
    * Prison Id
    *
    * @var integer
    */
-  protected $prison;
+  protected $prisonId;
+  /**
+   * Content Id
+   *
+   * @var integer
+   */
+  protected $contentId;
   /**
    * Node_storage object
    *
-   * @var Drupal\Core\Entity\EntityManagerInterface
+   * @var EntityManagerInterface
    */
-  protected $node_storage;
+  protected $nodeStorage;
+
   /**
-   * Entitity Query object
+   * TermStorage object
    *
-   * @var Drupal\Core\Entity\Query\QueryFactory
-   *
-   * Instance of querfactory
-   */
-  protected $entity_query;
-  /**
-   * Class Constructor
-   *
-   * @param EntityTypeManagerInterface $entityTypeManager
-   * @param QueryFactory $entityQuery
-   */
+   * @var EntityManagerInterface
+  */
+  protected $termStorage;
+
   public function __construct(
-    EntityTypeManagerInterface $entityTypeManager,
-    QueryFactory $entityQuery
+    EntityTypeManagerInterface $entityTypeManager
   ) {
-    $this->node_storage = $entityTypeManager->getStorage('node');
-    $this->entity_query = $entityQuery;
+    $this->nodeStorage = $entityTypeManager->getStorage('node');
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
   }
   /**
    * API resource function
    *
-   * @param [string] $lang
+   * @param string $languageId
+   * @param string $contentId
+   * @param string $prisonId
    * @return array
    */
-  public function ContentApiEndpoint($lang, $nid, $prison = 0)
+  public function ContentApiEndpoint($languageId, $contentId, $prisonId)
   {
-    $this->lang = $lang;
-    $this->prison = $prison;
-    $node = $this->loadNodesDetails($nid);
+    $this->languageId = $languageId;
+    $this->prisonId = $prisonId;
+    $this->contentId = $contentId;
 
-    if (is_null($node)) {
-      return array();
+    $content = $this->getMatchingContent();
+
+    return $this->createReturnObject($content);
+  }
+
+  /**
+   * Validate the content is OK for prison/prison categories
+   *
+   * @return NodeInterface
+   */
+  private function getMatchingContent() {
+    $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
+    $content = Utilities::getNodeFor($this->contentId, $this->nodeStorage);
+    $contentPrisons = Utilities::getPrisonsFor($content);
+
+    if (empty($contentPrisons)) {
+      $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
+      $contentPrisonCategories = Utilities::getPrisonCategoriesFor($content);
+      $matchingPrisonCategories = array_intersect($prisonCategories, $contentPrisonCategories);
+
+      if (empty($matchingPrisonCategories)) {
+        throw new BadRequestHttpException(
+          'The content does not have a matching prison category for this prison',
+          null,
+          400
+        );
+      }
+    } else {
+      $matchingPrisons = in_array($this->prisonId, $contentPrisons);
+
+      if (!$matchingPrisons) {
+        throw new BadRequestHttpException(
+          'The content is not available for this prison',
+          null,
+          400
+        );
+      }
     }
 
-    $translatedNodes = $this->translateNode($node);
+    $translatedContent = $this->translateNode($content);
 
-    return $this->decorateContent($translatedNodes);
+    return $translatedContent;
   }
   /**
    * TranslateNode function
    *
-   * @param NodeInterface $node
+   * @param NodeInterface $content
    *
-   * @return $node
+   * @return NodeInterface
    */
-  private function translateNode(NodeInterface $node)
+  private function translateNode(NodeInterface $content)
   {
-    return $node->hasTranslation($this->lang) ? $node->getTranslation($this->lang) : $node;
+    return $content->hasTranslation($this->languageId) ? $content->getTranslation($this->languageId) : $content;
   }
 
   /**
-   * Load full node details
+   * Return the content data
    *
-   * @param array $nids
+   * @param NodeInterface $content
+   *
    * @return array
    */
-  private function loadNodesDetails($nid)
+  private function createReturnObject($content)
   {
-    return $this->node_storage->load($nid);
+    $response = $this->createItemResponse($content);
+    $contentType = $content->type->target_id;
+
+    switch ($contentType) {
+      case 'moj_radio_item':
+        return array_merge($response, $this->createAudioItemResponse($content));
+      case 'moj_video_item':
+        return array_merge($response, $this->createVideoItemResponse($content));
+      case 'moj_pdf_item':
+        return array_merge($response, $this->createPDFItemResponse($content));
+      case 'page':
+        return array_merge($response, $this->createPageItemResponse($content));
+      case 'landing_page':
+        return array_merge($response, $this->createLandingPageItemResponse($content));
+
+      default:
+        return $response;
+    }
   }
 
   /**
+   * Return the default content data
    *
+   * @param NodeInterface $content
+   *
+   * @return array
    */
-  private function decorateContent($node)
+  private function createItemResponse($content)
   {
-    $content_type = $node->type->target_id;
+    $response = [];
+    $response["content_type"] =  $content->type->target_id;
+    $response["title"] =  $content->title->value;
+    $response["id"] =  $content->nid->value;
+    $response["image"] =  $content->field_moj_thumbnail_image[0];
+    $response["description"] =  $content->field_moj_description[0];
+    $response["categories"] =  $content->field_moj_top_level_categories;
+    $response["secondary_tags"] = $content->field_moj_secondary_tags ? $content->field_moj_secondary_tags : $content->field_moj_tags;
+    $response["prisons"] =  $content->field_moj_prisons;
 
-    if (($this->prison != 0) && (count($node->field_moj_prisons) > 0)) {
-      $found = false;
-
-      foreach ($node->field_moj_prisons as $key => $n) {
-        if ($this->prison == $n->target_id) {
-          $found = true;
-          break;
-        }
-      }
-
-      if (!$found) {
-        return [];
-      }
-    }
-
-    $defaults = $this->createItemResponse($node);
-
-    switch ($content_type) {
-      case 'moj_radio_item':
-        return array_merge($defaults, $this->createAudioItemResponse($node));
-      case 'moj_video_item':
-        return array_merge($defaults, $this->createVideoItemResponse($node));
-      case 'moj_pdf_item':
-        return array_merge($defaults, $this->createPDFItemResponse($node));
-      case 'page':
-        return array_merge($defaults, $this->createPageItemResponse($node));
-      case 'landing_page':
-        return array_merge($defaults, $this->createLandingPageItemResponse($node));
-
-      default:
-        return $defaults;
-    }
+    return  $response;
   }
 
-  private function createItemResponse($node)
+  /**
+   * Return the audio item specific content data
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createAudioItemResponse($content)
   {
-    $result = [];
-    $result["content_type"] =  $node->type->target_id;
-    $result["title"] =  $node->title->value;
-    $result["id"] =  $node->nid->value;
-    $result["image"] =  $node->field_moj_thumbnail_image[0];
-    $result["description"] =  $node->field_moj_description[0];
-    $result["categories"] =  $node->field_moj_top_level_categories;
-    if ($node->field_moj_secondary_tags) {
-      $result["secondary_tags"] =  $node->field_moj_secondary_tags;
-    } else {
-      $result["secondary_tags"] =  $node->field_moj_tags;
-    }
-    $result["prisons"] =  $node->field_moj_prisons;
+    $response = [];
+    $response['media'] = $content->field_moj_audio[0];
+    $response["episode_id"] = $this->createEpisodeId($content);
+    $response["series_id"] = $content->field_moj_series[0]->target_id;
+    $response["season"] = $content->field_moj_season->value;
+    $response["episode"] = $content->field_moj_episode->value;
+    $response["duration"] = $content->field_moj_duration->value;
+    $response["programme_code"] = $content->field_moj_programme_code->value;
 
-    return  $result;
+    return $response;
   }
 
-  private function createAudioItemResponse($node)
+  /**
+   * Return the video item specific content data
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createVideoItemResponse($content)
   {
-    $result = [];
+    $response = [];
+    $response['media'] = $content->field_video[0];
+    $response["episode_id"] = $this->createEpisodeId($content);
+    $response["series_id"] = $content->field_moj_series[0]->target_id;
+    $response["season"] = $content->field_moj_season->value;
+    $response["episode"] = $content->field_moj_episode->value;
+    $response["duration"] = $content->field_moj_duration->value;
 
-    $result['media'] = $node->field_moj_audio[0];
-    $result["episode_id"] = $this->createEpisodeId($node);
-    $result["series_id"] = $node->field_moj_series[0]->target_id;
-    $result["season"] = $node->field_moj_season->value;
-    $result["episode"] = $node->field_moj_episode->value;
-    $result["duration"] = $node->field_moj_duration->value;
-    $result["programme_code"] = $node->field_moj_programme_code->value;
-
-    return $result;
+    return $response;
   }
 
-  private function createVideoItemResponse($node)
+  /**
+   * Return the page item specific content data
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createPageItemResponse($content)
   {
-    $result = [];
-    $result['media'] = $node->field_video[0];
-    $result["episode_id"] = $this->createEpisodeId($node);
-    $result["series_id"] = $node->field_moj_series[0]->target_id;
-    $result["season"] = $node->field_moj_season->value;
-    $result["episode"] = $node->field_moj_episode->value;
-    $result["duration"] = $node->field_moj_duration->value;
+    $response = [];
+    $response['stand_first'] = $content->field_moj_stand_first->value;
 
-    return $result;
+    return $response;
   }
 
-  private function createPageItemResponse($node)
+  /**
+   * Return the PDF item specific content data
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createPDFItemResponse($content)
   {
-    $result = [];
-    $result['stand_first'] = $node->field_moj_stand_first->value;
-    return $result;
+    $response = [];
+    $response['media'] = $content->field_moj_pdf[0];
+
+    return $response;
   }
 
-
-  private function createPDFItemResponse($node)
+  /**
+   * Return the episode if for a piece of content
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createEpisodeId($content)
   {
-    $result = [];
-    $result['media'] = $node->field_moj_pdf[0];
-
-    return $result;
+    return ($content->field_moj_season->value * 1000) + $content->field_moj_episode->value;
   }
 
-  private function createEpisodeId($node)
+  /**
+   * Return the landing page item specific content data
+   *
+   * @param NodeInterface $content
+   *
+   * @return array
+   */
+  private function createLandingPageItemResponse($content)
   {
-    return ($node->field_moj_season->value * 1000) + ($node->field_moj_episode->value);
-  }
+    $response = [];
 
-  private function createLandingPageItemResponse($node)
-  {
-    $result = [];
-    $result['featured_content_id'] =  $node->field_moj_landing_feature_contet[0]->target_id;
-    $result['category_id'] =  $node->field_moj_landing_page_term[0]->target_id;
-    return  $result;
+    // IMPORTANT: DO NOT change the incorrectly spelt field name, it is incorrect in Drupal
+    $response['featured_content_id'] =  $content->field_moj_landing_feature_contet[0]->target_id;
+    $response['category_id'] =  $content->field_moj_landing_page_term[0]->target_id;
+    return $response;
   }
 }

--- a/modules/custom/moj_resources/src/NewFeaturedContentApiClass.php
+++ b/modules/custom/moj_resources/src/NewFeaturedContentApiClass.php
@@ -5,8 +5,8 @@ namespace Drupal\moj_resources;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-
-require_once('Utils.php');
+use Drupal\moj_resources\Utilities;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * NewFeaturedContentApiClass
@@ -20,6 +20,13 @@ class NewFeaturedContentApiClass
    * @var Drupal\Core\Entity\EntityManagerInterface
    */
   protected $nodeStorage;
+
+  /**
+   * TermStorage object
+   *
+   * @var EntityManagerInterface
+  */
+  protected $termStorage;
   /**
    * Entitity Query object
    *
@@ -28,6 +35,8 @@ class NewFeaturedContentApiClass
    * Instance of querfactory
    */
   protected $entityQuery;
+  protected $prisonId;
+  protected $prisonCategories;
 
   /**
    * Class Constructor
@@ -40,6 +49,7 @@ class NewFeaturedContentApiClass
     QueryFactory $entityQuery
   ) {
     $this->nodeStorage = $entityTypeManager->getStorage('node');
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
     $this->entityQuery = $entityQuery;
   }
   /**
@@ -48,9 +58,12 @@ class NewFeaturedContentApiClass
    * @param [string] $prisonId
    * @return array
    */
-  public function FeaturedContentApiEndpoint($prisonId = 0)
+  public function FeaturedContentApiEndpoint($prisonId)
   {
-    $results = $this->getFeaturedContent($prisonId);
+    $this->prisonId = $prisonId;
+    $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
+    $this->prisonCategories = Utilities::getPrisonCategoriesFor($prison);
+    $results = $this->getFeaturedContent();
 
     return array_slice($results, 0, 1);
   }
@@ -74,8 +87,22 @@ class NewFeaturedContentApiClass
     for ($i = 0; $i < $numberOfTiles; $i++) {
       array_push($tileIds, $tiles[$i]->target_id);
     }
-    $results = $this->loadNodesDetails($tileIds);
-    return array_values(array_map(array($this, 'decorateTile'), $results));
+
+    $query = $this->entityQuery->get('node')
+      ->condition('nid', array_values($tileIds), 'IN')
+      ->condition('status', 1)
+      ->accessCheck(false);
+
+    $query->condition(Utilities::filterByPrisonCategories(
+      $this->prisonId,
+      $this->prisonCategories,
+      $query
+    ));
+
+    $filteredTiles = $query->execute();
+    $filteredResults = $this->loadNodesDetails($filteredTiles);
+
+    return array_values(array_map(array($this, 'decorateTile'), $filteredResults));
   }
 
   private function decorateTile($tile)
@@ -91,14 +118,18 @@ class NewFeaturedContentApiClass
     return $response;
   }
 
-  private function getFeaturedContent($prisonId)
+  private function getFeaturedContent()
   {
     $query = $this->entityQuery->get('node')
       ->condition('type', 'featured_articles')
       ->condition('status', 1)
       ->accessCheck(false);
 
-    $query = getPrisonResults($prisonId, $query);
+    $query->condition(Utilities::filterByPrisonCategories(
+      $this->prisonId,
+      $this->prisonCategories,
+      $query
+    ));
 
     $results = $query->execute();
 
@@ -118,15 +149,4 @@ class NewFeaturedContentApiClass
     return $this->nodeStorage->loadMultiple($nodeIds);
   }
 
-  /**
-   * Sanitise node
-   *
-   * @param [type] $item
-   * @return void
-   */
-  protected function serialize($item)
-  {
-    $serializer = \Drupal::service($item->getType() . '.serializer.default');
-    return $serializer->serialize($item, 'json', ['plugin_id' => 'entity']);
-  }
 }

--- a/modules/custom/moj_resources/src/Plugin/rest/resource/ContentResource.php
+++ b/modules/custom/moj_resources/src/Plugin/rest/resource/ContentResource.php
@@ -74,21 +74,21 @@ class ContentResource extends ResourceBase
 
     protected $currentRequest;
 
-    protected $availableLangs;
+    protected $availableLanguages;
 
     protected $languageManager;
 
-    protected $parameter_prison;
+    protected $prisonId;
 
-    protected $nid;
+    protected $contentId;
 
-    Protected $lang;
+    protected $languageId;
 
     public function __construct(
         array $configuration,
-        $plugin_id,
-        $plugin_definition,
-        array $serializer_formats,
+        $pluginId,
+        $pluginDefinition,
+        array $serializerFormats,
         LoggerInterface $logger,
         ContentApiClass $contentApiClass,
         Request $currentRequest,
@@ -97,25 +97,25 @@ class ContentResource extends ResourceBase
         $this->contentApiClass = $contentApiClass;
         $this->currentRequest = $currentRequest;
         $this->languageManager = $languageManager;
-        $this->availableLangs = $this->languageManager->getLanguages();
-        $this->parameter_prison = self::setPrison();
-        $this->nid = $this->currentRequest->get('nid');
-        $this->lang =self::setLanguage();
-        self::checklanguageParameterIsValid();
-        self::checkPrisonIsNumeric();
-        parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+        $this->availableLanguages = $this->languageManager->getLanguages();
+        $this->prisonId = self::setPrisonId();
+        $this->contentId = $this->currentRequest->get('nid');
+        $this->languageId =self::setLanguageId();
+        self::checkLanguageIdIsValid();
+        self::checkPrisonIdIsNumeric();
+        parent::__construct($configuration, $pluginId, $pluginDefinition, $serializerFormats, $logger);
     }
 
     public static function create(
         ContainerInterface $container,
         array $configuration,
-        $plugin_id,
-        $plugin_definition
+        $pluginId,
+        $pluginDefinition
     ) {
         return new static(
             $configuration,
-            $plugin_id,
-            $plugin_definition,
+            $pluginId,
+            $pluginDefinition,
             $container->getParameter('serializer.formats'),
             $container->get('logger.factory')->get('rest'),
             $container->get('moj_resources.content_api_class'),
@@ -126,8 +126,8 @@ class ContentResource extends ResourceBase
 
     public function get()
     {
-        self::checkContentIdParameterIsNumeric();
-        $content = $this->contentApiClass->ContentApiEndpoint($this->lang, $this->nid, $this->parameter_prison);
+        self::checkContentIdIsNumeric();
+        $content = $this->contentApiClass->ContentApiEndpoint($this->languageId, $this->contentId, $this->prisonId);
         if (!empty($content)) {
             $response = new ResourceResponse($content);
             $response->addCacheableDependency($content);
@@ -136,21 +136,21 @@ class ContentResource extends ResourceBase
         throw new NotFoundHttpException(t('No content found'));
     }
 
-    protected function setLanguage()
+    protected function setLanguageId()
     {
         return is_null($this->currentRequest->get('_lang')) ? 'en' : $this->currentRequest->get('_lang');
     }
 
-    protected function setPrison()
+    protected function setPrisonId()
     {
         return is_null($this->currentRequest->get('_prison')) ? 0 : intval($this->currentRequest->get('_prison'));
     }
 
-    protected function checklanguageParameterIsValid()
+    protected function checkLanguageIdIsValid()
     {
-        foreach($this->availableLangs as $lang)
+        foreach($this->availableLanguages as $language)
         {
-            if ($lang->getid() === $this->lang) {
+            if ($language->getid() === $this->languageId) {
                 return true;
             }
         }
@@ -161,9 +161,9 @@ class ContentResource extends ResourceBase
         );
     }
 
-    protected function checkContentIdParameterIsNumeric()
+    protected function checkContentIdIsNumeric()
     {
-        if (is_numeric($this->nid)) {
+        if (is_numeric($this->contentId)) {
             return true;
         }
         throw new NotFoundHttpException(
@@ -173,9 +173,9 @@ class ContentResource extends ResourceBase
         );
     }
 
-    protected function checkPrisonIsNumeric()
+    protected function checkPrisonIdIsNumeric()
     {
-        if (is_numeric($this->parameter_prison)) {
+        if (is_numeric($this->prisonId)) {
             return true;
         }
         throw new NotFoundHttpException(
@@ -185,5 +185,3 @@ class ContentResource extends ResourceBase
         );
     }
 }
-
-

--- a/modules/custom/moj_resources/src/Plugin/rest/resource/SeriesContentResource.php
+++ b/modules/custom/moj_resources/src/Plugin/rest/resource/SeriesContentResource.php
@@ -29,11 +29,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *          description="Response format, should be 'json'",
  *      ),
  *      @SWG\Parameter(
- *          name="_number",
+ *          name="_sort_order",
  *          in="query",
  *          required=false,
- *          type="integer",
- *          description="Number of results to bring back, the default is all",
+ *          type="string",
+ *          description="The order of the results to return, default DESC",
  *      ),
  *      @SWG\Parameter(
  *          name="id",
@@ -41,6 +41,27 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *          required=false,
  *          type="integer",
  *          description="Term ID of category to return, the default is to being back all categories.",
+ *      ),
+ *      @SWG\Parameter(
+ *          name="_number",
+ *          in="query",
+ *          required=false,
+ *          type="integer",
+ *          description="Number of results to bring back, the default is all",
+ *      ),
+ *      @SWG\Parameter(
+ *          name="_prison",
+ *          in="query",
+ *          required=true,
+ *          type="integer",
+ *          description="The ID of the prison to return content for",
+ *      ),
+ *      @SWG\Parameter(
+ *          name="seriesId",
+ *          in="path",
+ *          required=false,
+ *          type="integer",
+ *          description="The ID for the Series to return content for",
  *      ),
  *      @SWG\Parameter(
  *          name="_lang",
@@ -68,25 +89,32 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SeriesContentResource extends ResourceBase
 {
-  protected $seriesContentApiController;
+  protected $seriesContentApiClass;
 
   protected $currentRequest;
 
-  protected $availableLangs;
+  protected $availableLanguages;
 
   protected $languageManager;
 
-  protected $parameter_category;
+  protected $categoryId;
 
-  protected $parameter_language_tag;
+  protected $languageId;
 
-  protected $parameter_number_results;
+  protected $numberOfResults;
+
+  protected $resultsOffset;
+
+  protected $prisonId;
+
+  protected $sortOrder;
+
 
   public function __construct(
     array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    array $serializer_formats,
+    $pluginId,
+    $pluginDefinition,
+    array $serializerFormats,
     LoggerInterface $logger,
     SeriesContentApiClass $SeriesContentApiClass,
     Request $currentRequest,
@@ -95,31 +123,29 @@ class SeriesContentResource extends ResourceBase
     $this->seriesContentApiClass = $SeriesContentApiClass;
     $this->currentRequest = $currentRequest;
     $this->languageManager = $languageManager;
-    $this->availableLangs = $this->languageManager->getLanguages();
-    //$this->parameter_category = self::setCategory();
-    $this->parameter_number_results = self::setNumberOfResults();
-    $this->parameter_language_tag = self::setLanguage();
-    $this->parameter_offset = self::setOffsetOfResults();
-    $this->parameter_prison = self::setPrison();
-    $this->parameter_sort_order = self::setSortOrder();
+    $this->availableLanguages = $this->languageManager->getLanguages();
+    $this->numberOfResults = self::setNumberOfResults();
+    $this->languageId = self::setLanguage();
+    $this->resultsOffset = self::setOffsetOfResults();
+    $this->prisonId = self::setPrisonId();
+    $this->sortOrder = self::setSortOrder();
 
-
-    self::checklanguageParameterIsValid();
+    self::checkLanguageIdIsValid();
     self::checkNumberOfResultsIsNumeric();
-    // self::checkCatgeoryIsNumeric();
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+    self::checkPrisonIdIsNumeric();
+    parent::__construct($configuration, $pluginId, $pluginDefinition, $serializerFormats, $logger);
   }
 
   public static function create(
     ContainerInterface $container,
     array $configuration,
-    $plugin_id,
-    $plugin_definition
+    $pluginId,
+    $pluginDefinition
   ) {
     return new static(
       $configuration,
-      $plugin_id,
-      $plugin_definition,
+      $pluginId,
+      $pluginDefinition,
       $container->getParameter('serializer.formats'),
       $container->get('logger.factory')->get('rest'),
       $container->get('moj_resources.series_content_api_class'),
@@ -130,43 +156,43 @@ class SeriesContentResource extends ResourceBase
 
   public function get()
   {
-    $seriesContent = $this->seriesContentApiClass->SeriesContentApiEndpoint(
-      $this->parameter_language_tag,
+    $contentForSeries = $this->seriesContentApiClass->SeriesContentApiEndpoint(
+      $this->languageId,
       $this->currentRequest->get('id'),
-      $this->parameter_number_results,
-      $this->parameter_offset,
-      $this->parameter_prison,
-      $this->parameter_sort_order
+      $this->numberOfResults,
+      $this->resultsOffset,
+      $this->prisonId,
+      $this->sortOrder
     );
-    if (!empty($seriesContent)) {
-      $response = new ResourceResponse($seriesContent);
-      $response->addCacheableDependency($seriesContent);
+    if (!empty($contentForSeries)) {
+      $response = new ResourceResponse($contentForSeries);
+      $response->addCacheableDependency($contentForSeries);
       return $response;
     }
     throw new NotFoundHttpException(t('No series content found'));
   }
 
-  protected function checklanguageParameterIsValid()
+  protected function checkLanguageIdIsValid()
   {
-    foreach ($this->availableLangs as $lang) {
-      if ($lang->getid() === $this->parameter_language_tag) {
+    foreach ($this->availableLanguages as $language) {
+      if ($language->getid() === $this->languageId) {
         return true;
       }
     }
     throw new NotFoundHttpException(
-      t('The language tag invalid or translation for this tag is not avilable'),
+      t('The language tag invalid or translation for this tag is not available'),
       null,
       404
     );
   }
 
-  protected function checkCatgeoryIsNumeric()
+  protected function checkPrisonIdIsNumeric()
   {
-    if (is_numeric($this->parameter_category)) {
+    if (is_numeric($this->prisonId)) {
       return true;
     }
     throw new NotFoundHttpException(
-      t('The category parameter must be a numeric'),
+      t('The category parameter must be numeric'),
       null,
       404
     );
@@ -174,11 +200,11 @@ class SeriesContentResource extends ResourceBase
 
   protected function checkNumberOfResultsIsNumeric()
   {
-    if (is_numeric($this->parameter_number_results)) {
+    if (is_numeric($this->numberOfResults)) {
       return true;
     }
     throw new NotFoundHttpException(
-      t('The number of results parameter must be a numeric'),
+      t('The number of results parameter must be numeric'),
       null,
       404
     );
@@ -200,7 +226,7 @@ class SeriesContentResource extends ResourceBase
     return is_null($this->currentRequest->get('_offset')) ? 0 : $this->currentRequest->get('_offset');
   }
 
-  protected function setPrison()
+  protected function setPrisonId()
   {
     return is_null($this->currentRequest->get('_prison')) ? 0 : $this->currentRequest->get('_prison');
   }

--- a/modules/custom/moj_resources/src/Plugin/rest/resource/VocabularyResource.php
+++ b/modules/custom/moj_resources/src/Plugin/rest/resource/VocabularyResource.php
@@ -97,11 +97,13 @@ class VocabularyResource extends ResourceBase
         $this->languageManager = $languageManager;
 
         $this->availableLanguages = $this->languageManager->getLanguages();
+        $this->prisonId = self::setPrisonId();
         $this->languageId = self::setLanguageId();
         $this->prisonId = self::setPrisonId();
         $this->taxonomyName = $this->currentRequest->get('category');
 
         self::checkLanguageIdIsValid();
+        self::checkPrisonIdIsNumeric();
 
         parent::__construct($configuration, $pluginId, $pluginDefinition, $serializerFormats, $logger);
     }

--- a/modules/custom/moj_resources/src/RelatedContentApiClass.php
+++ b/modules/custom/moj_resources/src/RelatedContentApiClass.php
@@ -5,8 +5,7 @@ namespace Drupal\moj_resources;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-
-require_once('Utils.php');
+use Drupal\moj_resources\Utilities;
 
 /**
  * RelatedContentApiClass
@@ -26,6 +25,7 @@ class RelatedContentApiClass
    * @var Drupal\Core\Entity\EntityManagerInterface
    */
   protected $nodeStorage;
+  protected $termStorage;
   /**
    * Entitity Query object
    *
@@ -34,6 +34,8 @@ class RelatedContentApiClass
    * Instance of querfactory
    */
   protected $entityQuery;
+  protected $categoryId;
+  protected $prisonId;
   /**
    * Class Constructor
    *
@@ -45,6 +47,7 @@ class RelatedContentApiClass
     QueryFactory $entityQuery
   ) {
     $this->nodeStorage = $entityTypeManager->getStorage('node');
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
     $this->entityQuery = $entityQuery;
   }
   /**
@@ -56,7 +59,9 @@ class RelatedContentApiClass
   public function RelatedContentApiEndpoint($languageId, $categoryId, $numberOfResults, $offsetIntoNumberOfResults, $prisonId, $sortOrder = 'ASC')
   {
     $this->languageId = $languageId;
-    $relatedContentIds = $this->getRelatedContentIds($categoryId, $numberOfResults, $offsetIntoNumberOfResults, $prisonId, $sortOrder);
+    $this->categoryId = $categoryId;
+    $this->prisonId = $prisonId;
+    $relatedContentIds = $this->getRelatedContentIds($numberOfResults, $offsetIntoNumberOfResults, $sortOrder);
     $populatedContent = $this->loadRelatedContentDetail($relatedContentIds);
     $translatedContent = array_map([$this, 'translateNode'], $populatedContent);
 
@@ -78,26 +83,30 @@ class RelatedContentApiClass
    *
    * @return void
    */
-  private function getRelatedContentIds($categoryId, $numberOfResults, $offsetIntoNumberOfResults, $prisonId, $sortOrder = 'ASC')
+  private function getRelatedContentIds($numberOfResults, $offsetIntoNumberOfResults, $sortOrder = 'ASC')
   {
     $contentTypes = array('page', 'moj_pdf_item', 'moj_radio_item', 'moj_video_item');
+    $prison = Utilities::getTermFor($this->prisonId, $this->termStorage);
+    $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
 
     $query = $this->entityQuery->get('node')
       ->condition('status', 1)
       ->condition('type', $contentTypes, 'IN')
       ->accessCheck(false);
 
-    if ($categoryId !== 0) {
-      $categoryCondition = $query
-        ->orConditionGroup()
-        ->condition('field_moj_top_level_categories', $categoryId)
-        ->condition('field_moj_tags', $categoryId)
-        ->condition('field_moj_secondary_tags', $categoryId);
+    $query->condition(Utilities::filterByPrisonCategories(
+      $this->prisonId,
+      $prisonCategories,
+      $query
+    ));
 
-      $query->condition($categoryCondition);
-    }
+    $categoryCondition = $query
+      ->orConditionGroup()
+      ->condition('field_moj_top_level_categories', $this->categoryId)
+      ->condition('field_moj_tags', $this->categoryId)
+      ->condition('field_moj_secondary_tags', $this->categoryId);
 
-    $query = getPrisonResults($prisonId, $query);
+    $query->condition($categoryCondition);
 
     $relatedContent = $query
       ->sort('nid', $sortOrder)

--- a/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -5,46 +5,59 @@ namespace Drupal\moj_resources;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-
-require_once('Utils.php');
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Database\StatementInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\moj_resources\Utilities;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * PromotedContentApiClass
- */
-
+*/
 class SeriesContentApiClass
 {
   /**
    * Node IDs
    *
    * @var array
-   */
-  protected $nids = array();
+  */
+  protected $nodeIds = array();
+
   /**
    * Nodes
    *
    * @var array
-   */
+  */
   protected $nodes = array();
+
   /**
-   * Language Tag
+   * language Tag
    *
    * @var string
-   */
-  protected $lang;
+  */
+  protected $language;
+
   /**
-   * Node_storage object
+   * NodeStorage object
    *
-   * @var Drupal\Core\Entity\EntityManagerInterface
-   */
-  protected $node_storage;
+   * @var EntityManagerInterface
+  */
+  protected $nodeStorage;
+
+  /**
+   * TermStorage object
+   *
+   * @var EntityManagerInterface
+  */
+  protected $termStorage;
+
   /**
    * Entity Query object
    *
-   * @var Drupal\Core\Entity\Query\QueryFactory
-   *
-   * Instance of queryfactory
-   */
+   * @var QueryFactory
+  */
   protected $entity_query;
 
   /**
@@ -52,96 +65,112 @@ class SeriesContentApiClass
    *
    * @param EntityTypeManagerInterface $entityTypeManager
    * @param QueryFactory $entityQuery
-   */
+  */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
     QueryFactory $entityQuery
   ) {
-    $this->node_storage = $entityTypeManager->getStorage('node');
+    $this->nodeStorage = $entityTypeManager->getStorage('node');
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
     $this->entity_query = $entityQuery;
   }
+
   /**
    * API resource function
    *
-   * @param [string] $lang
+   * @param string $language
+   * @param int $seriesId
+   * @param int $numberOfResults
+   * @param int $resultsOffset
+   * @param int $prisonId
+   * @param string $sortOrder
+   *
    * @return array
-   */
-  public function SeriesContentApiEndpoint($lang, $seriesId, $number, $offset, $prison, $sortOrder)
-  {
-    $this->lang = $lang;
-    $this->nids = $this->getSeriesContentNodeIds($seriesId, $number, $offset, $prison);
-    $this->nodes = $this->loadNodesDetails($this->nids);
+  */
+  public function SeriesContentApiEndpoint($language, $seriesId, $numberOfResults, $resultsOffset, $prisonId, $sortOrder) {
+    $this->language = $language;
+    $this->nodeIds = $this->getSeriesContentIds($seriesId, $numberOfResults, $resultsOffset, $prisonId);
+    $this->nodes = $this->loadContent($this->nodeIds);
 
-    $series = $this->decorateSeries($this->nodes);
-    $series = $this->sortSeries($series, $sortOrder, $number);
+    $series = $this->createReturnObject($this->nodes);
+    $series = $this->sortSeries($series, $sortOrder, $numberOfResults);
 
     return $series;
   }
+
   /**
    * API resource function
    *
-   * @param [string] $lang
+   * @param string $language
+   * @param int $seriesId
+   * @param int $numberOfResults
+   * @param int $episodeId
+   * @param int $prisonId
+   * @param string $sortOrder
+   *
    * @return array
-   */
-  public function SeriesNextEpisodeApiEndpoint($lang, $seriesId, $number, $episodeId, $prison, $sortOrder)
-  {
-    $this->lang = $lang;
-    $this->nids = $this->getSeriesContentNodeIds($seriesId, null, null, $prison);
-    $this->nodes = $this->loadNodesDetails($this->nids);
-    $series = $this->decorateSeries($this->nodes);
+  */
+  public function SeriesNextEpisodeApiEndpoint($language, $seriesId, $numberOfResults, $episodeId, $prisonId, $sortOrder) {
+    $this->language = $language;
+    $this->nodeIds = $this->getSeriesContentIds($seriesId, null, null, $prisonId);
+    $this->nodes = $this->loadContent($this->nodeIds);
+
+    $series = $this->createReturnObject($this->nodes);
     $series = $this->sortSeries($series, $sortOrder);
-    $series = $this->getNextEpisodes($episodeId, $series, $number);
+    $nextEpisodes = $this->getNextEpisodes($episodeId, $series, $numberOfResults);
 
-    return $series;
+    return $nextEpisodes;
   }
+
   /**
-   * decorateSeries
+   * Creates the object to return
    *
-   */
-  private function decorateSeries($node)
-  {
-    $results = array_reduce($node, function ($acc, $curr) {
+   * @param NodeInterface[] $seriesContent
+   *
+   * @return array
+  */
+  private function createReturnObject($seriesContent) {
+    return array_map(function ($node) {
       $episodeId = 0;
-      $season = $curr->field_moj_season->value;
-      $episode = $curr->field_moj_episode->value;
+      $season = $node->field_moj_season->value;
+      $episode = $node->field_moj_episode->value;
       if (intval($season) > 0 && intval($episode) > 0) {
         $episodeId = ($season * 1000) + $episode;
       }
-      $result = [];
-      $result["episode_id"] = $episodeId;
-      $result["last_updated"] = $curr->changed->value;
-      $result["date"] = $curr->field_moj_date->value;
-      $result["content_type"] = $curr->type->target_id;
-      $result["title"] = $curr->title->value;
-      $result["id"] = $curr->nid->value;
-      $result["image"] = $curr->field_moj_thumbnail_image[0];
-      $result["season"] = $curr->field_moj_season->value;
-      $result["episode"] = $curr->field_moj_episode->value;
-      $result["duration"] = $curr->field_moj_duration ? $curr->field_moj_duration->value : 0;
-      $result["description"] = $curr->field_moj_description[0];
-      $result["categories"] = $curr->field_moj_top_level_categories;
-      if ($curr->field_moj_secondary_tags) {
-        $result["secondary_tags"] = $curr->field_moj_secondary_tags;
-      } else {
-        $result["secondary_tags"] = $curr->field_moj_tags;
-      }
-      $result["prisons"] = $curr->field_moj_prisons;
+      $content = [];
+      $content["episode_id"] = $episodeId;
+      $content["content_type"] = $node->type->target_id;
+      $content["title"] = $node->title->value;
+      $content["id"] = $node->nid->value;
+      $content["image"] = $node->field_moj_thumbnail_image[0];
+      $content["season"] = $node->field_moj_season->value;
+      $content["episode"] = $node->field_moj_episode->value;
+      $content["duration"] = $node->field_moj_duration ? $node->field_moj_duration->value : 0;
+      $content["description"] = $node->field_moj_description[0];
+      $content["categories"] = $node->field_moj_top_level_categories;
+      $content["prison_categories"] = $node->field_prison_categories;
 
-      if ($result["content_type"] === 'moj_radio_item') {
-        $result["media"] = $curr->field_moj_audio[0];
+      if ($node->field_moj_secondary_tags) {
+        $content["secondary_tags"] = $node->field_moj_secondary_tags;
       } else {
-        $result["media"] = $curr->field_video[0];
+        $content["secondary_tags"] = $node->field_moj_tags;
       }
 
-      $acc[] = $result;
+      if ($content["content_type"] === 'moj_radio_item') {
+        $content["media"] = $node->field_moj_audio[0];
+      } else {
+        $content["media"] = $node->field_video[0];
+      }
 
-      return $acc;
-    }, []);
-
-    return $results;
+      return $content;
+    }, $seriesContent);
   }
+
   /**
-   * sortSeries
+   * Sort series
+   *
+   * @param array $series
+   * @param string $sortOrder
    *
    */
 
@@ -180,11 +209,15 @@ class SeriesContentApiClass
   }
 
   /**
-   * getNextEpisodes
+   * Get next episodes for a series
    *
-   */
-  private function getNextEpisodes($episodeId, $series, $number)
-  {
+   * @param int $episodeId
+   * @param array $series
+   * @param int $numberOfNextEpisodes
+   *
+   * @return array
+  */
+  private function getNextEpisodes($episodeId, $series, $numberOfNextEpisodes) {
     function indexOf($comp, $array)
     {
       foreach ($array as $key => $value) {
@@ -204,68 +237,131 @@ class SeriesContentApiClass
 
     $episodeOffset = $episodeIndex + 1;
 
-    $episodes = array_slice($series, $episodeOffset, $number);
+    $episodes = array_slice($series, $episodeOffset, $numberOfNextEpisodes);
 
     return $episodes;
   }
+
   /**
    * TranslateNode function
    *
    * @param NodeInterface $node
    *
-   * @return $node
-   */
-  private function translateNode(NodeInterface $node)
-  {
-    return $node->hasTranslation($this->lang) ? $node->getTranslation($this->lang) : $node;
+   * @return NodeInterface
+  */
+  private function translateNode($node) {
+    return $node->hasTranslation($this->language) ? $node->getTranslation($this->language) : $node;
   }
 
   /**
-   * Get nids
+   * Filter content by Prison
    *
-   * @return void
-   */
-  private function getSeriesContentNodeIds($seriesId, $number, $offset, $prison)
-  {
-    $results = $this->entity_query->get('node')
-      ->condition('status', 1)
-      ->accessCheck(false);
-
-    $results->condition('field_moj_series', $seriesId);
-
-    $results = getPrisonResults($prison, $results);
-
-    if ($number) {
-      $results->range($offset, $number);
+   * @param int $prisonId
+   * @param int $seriesPrisonId
+   * @param int[] $prisonCategories
+   * @param QueryInterface $query
+   *
+   * @return QueryInterface
+  */
+  private function filterByPrison($prisonId, $seriesPrisonId, $prisonCategories, $query) {
+    if ($prisonId !== $seriesPrisonId) {
+      throw new BadRequestHttpException(
+        'The prison for the series does no match the supplied prison',
+        null,
+        400
+      );
     }
 
-    return $results
-      ->execute();
+    return Utilities::filterByPrisonCategories($prisonId, $prisonCategories, $query);
   }
+
+  /**
+   * Filter content by Prison Categories
+   *
+   * @param int $prisonId
+   * @param int[] $seriesPrisonCategories
+   * @param int[] $prisonCategories
+   * @param QueryInterface $query
+   *
+   * @return QueryInterface
+  */
+  private function filterByPrisonCategories($prisonId, $seriesPrisonCategories, $prisonCategories, $query) {
+    $matchingPrisonCategories = array_intersect($prisonCategories, $seriesPrisonCategories);
+    $hasNoMatchingPrisonCategories = empty($matchingPrisonCategories);
+
+    if ($hasNoMatchingPrisonCategories) {
+      throw new BadRequestHttpException(
+        'The Series does not have a matching prison category for this prison',
+        null,
+        400
+      );
+    }
+
+    return Utilities::filterByPrisonCategories($prisonId, $matchingPrisonCategories, $query);
+  }
+
+  /**
+   * Returns a prepared statement for selecting Series Content
+   *
+   * @param int $seriesId
+   * @param int $numberOfResultsToReturn
+   * @param int $resultsOffset
+   * @param int $prisonId
+   *
+   * @return int[]
+  */
+  private function getSeriesContentIds($seriesId, $numberOfResultsToReturn, $resultsOffset, $prisonId) {
+    $series = Utilities::getTermFor($seriesId, $this->termStorage);
+    $prison = Utilities::getTermFor($prisonId, $this->termStorage);
+
+    $query = $this->entity_query->get('node')
+    ->condition('status', 1)
+    ->accessCheck(false);
+
+    $seriesPrison = $series->get('field_promoted_to_prison');
+    $seriesHasPrisonSelected = !$seriesPrison->isEmpty();
+
+    $prisonCategories = Utilities::getPrisonCategoriesFor($prison);
+
+    if ($seriesHasPrisonSelected) {
+      $query->condition($this->filterByPrison(
+        $prisonId,
+        $seriesPrison->target_id,
+        $prisonCategories,
+        $query
+      ));
+    } else {
+      $seriesPrisonCategories = Utilities::getPrisonCategoriesFor($series);
+
+      $query->condition($this->filterByPrisonCategories(
+        $prisonId,
+        $seriesPrisonCategories,
+        $prisonCategories,
+        $query
+      ));
+    }
+
+    $query->condition('field_moj_series', $seriesId);
+
+    if ($numberOfResultsToReturn) {
+      $query->range($resultsOffset, $numberOfResultsToReturn);
+    }
+
+    return $query->execute();
+  }
+
   /**
    * Load full node details
    *
-   * @param array $nids
-   * @return array
-   */
-  private function loadNodesDetails(array $nids)
-  {
+   * @param int[] $nodeIds
+   * @return NodeInterface[]
+  */
+  private function loadContent($nodeIds) {
     return array_filter(
-      $this->node_storage->loadMultiple($nids),
+      $this->nodeStorage->loadMultiple($nodeIds),
       function ($item) {
         return $item->access();
       }
     );
-  }
-  /**
-   * Sanitise node
-   *
-   * @param [type] $item
-   * @return void
-   */
-  private function serialize($item)
-  {
-    $serializer = \Drupal::service($item->getType() . '.serializer.default'); // TODO: Inject dependency
-    return $serializer->serialize($item, 'json', ['plugin_id' => 'entity']);
   }
 }

--- a/modules/custom/moj_resources/src/TermApiClass.php
+++ b/modules/custom/moj_resources/src/TermApiClass.php
@@ -3,10 +3,12 @@
 namespace Drupal\moj_resources;
 
 use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Entity\Query\QueryFactory;
-use Symfony\Component\Serializer\Serializer;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * PromotedContentApiClass
@@ -15,38 +17,11 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 class TermApiClass
 {
   /**
-   * Term
-   *
-   * @var array
-   */
-  protected $term;
-  /**
-   * Language Tag
-   *
-   * @var string
-   */
-  protected $lang;
-  /**
-   * Node_storage object
+   * Term storage object
    *
    * @var Drupal\Core\Entity\EntityTypeManager
    */
-  protected $node_storage;
-  /**
-   * Entitity Query object
-   *
-   * @var Drupal\Core\Entity\Query\QueryFactory
-   *
-   * Instance of querfactory
-   */
-  protected $entity_query;
-
-  /**
-   * The custom serializer for terms.
-   *
-   * @var \Symfony\Component\Serializer\Serializer
-   */
-  protected $termSerializer;
+  protected $termStorage;
 
   /**
    * Class Constructor
@@ -55,58 +30,147 @@ class TermApiClass
    * @param QueryFactory $entityQuery
    */
   public function __construct(
-    EntityTypeManagerInterface $entityTypeManager,
-    QueryFactory $entityQuery,
-    Serializer $termSerializer
+    EntityTypeManagerInterface $entityTypeManager
   ) {
-    $this->term_storage = $entityTypeManager->getStorage('taxonomy_term');
-    $this->entity_query = $entityQuery;
-    $this->termSerializer = $termSerializer;
+    $this->termStorage = $entityTypeManager->getStorage('taxonomy_term');
   }
   /**
    * API resource function
    *
-   * @param [string] $lang
-   * @param [string] $category
+   * @param int $termId
    * @return array
    */
-  public function TermApiEndpoint($lang, $term_id)
+  public function TermApiEndpoint($termId, $prisonId)
   {
-    $this->lang = $lang;
-    $terms = $this->term_storage->load($term_id);
-    return $this->decorateResponse($terms);
+    $term = $this->getTerm($termId, $prisonId);
+
+    return $this->createReturnObject($term);
   }
+
+
+  /**
+   * Get Term and filter by Prison/Prison Categories
+   *
+   * @param int $termId
+   * @param int $prisonId
+   *
+   * @return EntityInterface
+  */
+  private function getTerm($termId, $prisonId) {
+    $prison = $this->getPrison($prisonId);
+    $term = $this->termStorage->load($termId);
+
+    if (is_null($term)) {
+      throw new NotFoundHttpException(
+        'Term not found',
+        null,
+        404
+      );
+    }
+
+    if ($term->hasField('field_promoted_to_prison') && !$term->get('field_promoted_to_prison')->isEmpty()) {
+      $selectedPrisonDoesNotMatchRequest = intval($term->get('field_promoted_to_prison')->target_id) !== intval($prisonId);
+
+      if ($selectedPrisonDoesNotMatchRequest) {
+        throw new BadRequestHttpException(
+          "The prison for the term does not match the supplied prison",
+          null,
+          400
+        );
+      }
+
+      return $term;
+    }
+
+    if ($term->hasField('field_prison_categories')
+      && !$term->get('field_prison_categories')->isEmpty()) {
+      $prisonCategories = [];
+
+      foreach($prison->get('field_prison_categories') as $prison_category) {
+        array_push($prisonCategories, intval($prison_category->target_id));
+      }
+
+      $termPrisonCategories = [];
+
+      foreach($term->get('field_prison_categories') as $prison_category) {
+        array_push($termPrisonCategories, intval($prison_category->target_id));
+      }
+
+      $matchingPrisonCategories = array_intersect($prisonCategories, $termPrisonCategories);
+      $hasNoMatchingPrisonCategories = empty($matchingPrisonCategories);
+
+      if ($hasNoMatchingPrisonCategories) {
+        throw new BadRequestHttpException(
+          'The Term does not have a matching prison category for this prison',
+          null,
+          400
+        );
+      }
+    }
+
+    return $term;
+  }
+
+  /**
+   * Get Prison by a Prison ID
+   *
+   * @param int $prisonId
+   *
+   * @return EntityInterface
+  */
+  private function getPrison($prisonId) {
+    $prison = $this->termStorage->load($prisonId);
+
+    if(is_null($prison)) {
+      throw new BadRequestHttpException(
+        'Prison does not exist',
+        null,
+        400
+      );
+    }
+
+    return $prison;
+  }
+
   /**
    * Decorate term response
    *
    * @param Node $term
    * @return array
    */
-  private function decorateResponse($term)
+  private function createReturnObject($term)
   {
-    $result = [];
-    $result['id'] = $term->tid->value;
-    $result['content_type'] = $term->vid[0]->target_id;
-    $result['title'] = $term->name->value;
-    $result['description'] = $term->description[0];
-    $result['summary'] = $term->field_content_summary ? $term->field_content_summary->value : '';
-    $result['image'] = $term->field_featured_image[0];
-    $result['video'] = $term->field_featured_video[0];
-    $result['audio'] = $term->field_featured_audio[0];
-    $result['programme_code'] = $term->field_feature_programme_code ? $term->field_feature_programme_code->value : '';
+    $response = [];
+    $response['id'] = $term->tid->value;
+    $response['content_type'] = $term->vid[0]->target_id;
+    $response['title'] = $term->name->value;
+    $response['description'] = $term->description ? $term->description[0] : null;
+    $response['summary'] = $term->field_content_summary ? $term->field_content_summary->value : '';
+    $response['image'] = $term->field_featured_image ? $term->field_featured_image[0] : null;
+    $response['video'] = $term->field_featured_video ? $term->field_featured_video[0] : null;
+    $response['audio'] = $term->field_featured_audio ? $term->field_featured_audio[0] : null;
+    $response['programme_code'] = $term->field_feature_programme_code ? $term->field_feature_programme_code->value : '';
 
-    return $result;
-  }
+    if ($term->hasField('field_prison_categories')) {
+      $prisonCategories = [];
 
-  /**
-   * TranslateNode function
-   *
-   * @param NodeInterface $term
-   *
-   * @return $term
-   */
-  protected function translateNode($term)
-  {
-    return $term->hasTranslation($this->lang) ? $term->getTranslation($this->lang) : $term;
+      foreach($term->get('field_prison_categories') as $prisonCategory) {
+        array_push($prisonCategories, $prisonCategory->target_id);
+      }
+
+      $response['prison_categories'] = $prisonCategories;
+    }
+
+    if ($term->hasField('field_promoted_to_prison')) {
+      $prisons = [];
+
+      foreach($term->get('field_promoted_to_prison') as $prison) {
+        array_push($prisons, $prison->target_id);
+      }
+
+      $response['prisons'] = $prisons;
+    }
+
+    return $response;
   }
 }

--- a/modules/custom/moj_resources/src/Utilities.php
+++ b/modules/custom/moj_resources/src/Utilities.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\moj_resources;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Utility class for Prisoner Content Hub endpoints
+ *
+*/
+class Utilities {
+  /**
+    * Add filter by prison categories to a query object
+    *
+    * @param int $prisonId
+    * @param int[] $prisonCategories
+    * @param QueryInterface $query
+    * @param bool $isTerm
+    *
+    * @return QueryInterface
+  */
+  public static function filterByPrisonCategories($prisonId, $prisonCategories, $query, $isTerm = false) {
+    $filterByPrisonId = null;
+
+    if ($isTerm) {
+      $filterByPrisonId = $query
+        ->andConditionGroup()
+        ->exists('field_promoted_to_prison')
+        ->condition('field_promoted_to_prison', $prisonId, '=');
+    } else {
+      $filterByPrisonId = $query
+        ->andConditionGroup()
+        ->exists('field_moj_prisons')
+        ->condition('field_moj_prisons', $prisonId, '=');
+    }
+
+    $filterByPrisonCategories = $query
+      ->andConditionGroup()
+      ->exists('field_prison_categories')
+      ->condition('field_prison_categories', $prisonCategories, 'IN');
+
+    return $query
+      ->orConditionGroup()
+      ->condition($filterByPrisonId)
+      ->condition($filterByPrisonCategories);
+  }
+
+  /**
+   * Loads term for ID
+   *
+   * @param int $termId
+   * @param EntityTypeManagerInterface $termStorage
+   *
+   * @return EntityInterface
+  */
+  public static function getTermFor($termId, $termStorage) {
+    $term = $termStorage->load($termId);
+
+    if (!$term) {
+      throw new NotFoundHttpException(
+        'Term not found',
+        null,
+        404
+      );
+    }
+
+    return $term;
+  }
+
+  /**
+   * Loads node for ID
+   *
+   * @param int $nodeId
+   * @param EntityTypeManagerInterface $nodeStorage
+   *
+   * @return EntityInterface
+  */
+  public static function getNodeFor($nodeId, $nodeStorage) {
+    $node = $nodeStorage->load($nodeId);
+
+    if (!$node) {
+      throw new NotFoundHttpException(
+        'Node not found',
+        null,
+        404
+      );
+    }
+
+    return $node;
+  }
+
+  /**
+   * Get Prisons for a Drupal node object
+   *
+   * @param EntityInterface $node
+   * @return int[]
+  */
+  public static function getPrisonsFor($node) {
+    $prisons = array();
+
+    foreach ($node->field_moj_prisons as $prison) {
+      array_push($prisons, intval($prison->target_id));
+    }
+
+    return $prisons;
+  }
+
+  /**
+   * Get Prison Categories for a Drupal node object
+   *
+   * @param EntityInterface $term
+   * @param bool $throwError
+   * @return int[]
+  */
+  public static function getPrisonCategoriesFor($node, $throwError = true) {
+    $prisonCategories = array();
+
+    foreach ($node->field_prison_categories as $prisonCategory) {
+      array_push($prisonCategories, intval($prisonCategory->target_id));
+    }
+
+    if ($throwError && empty($prisonCategories)) {
+      throw new BadRequestHttpException(
+        'The node does not have any prison categories selected',
+        null,
+        400
+      );
+    }
+
+    return $prisonCategories;
+  }
+}

--- a/modules/custom/moj_resources/tests/src/Unit/SeriesContentApiClassTest.php
+++ b/modules/custom/moj_resources/tests/src/Unit/SeriesContentApiClassTest.php
@@ -1,0 +1,510 @@
+<?php
+
+namespace Drupal\Tests\moj_resources\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+use Drupal\Tests\moj_resources\Unit\Supports\VideoContent;
+use Drupal\Tests\moj_resources\Unit\Supports\AudioContent;
+use Drupal\Tests\moj_resources\Unit\Supports\Prison;
+use Drupal\Tests\moj_resources\Unit\Supports\Series;
+use Drupal\moj_resources\SeriesContentApiClass;
+
+/**
+ * Series Content API Unit tests
+ *
+ * @group unit_moj_resources
+ */
+class SeriesContentApiClassTest extends UnitTestCase
+{
+    public function testGetSeriesContentVideoFormat() {
+      $testContent = VideoContent::createWithNodeId($this, 123)
+        ->setSeason(1)
+        ->setEpisode(1)
+        ->addPrison(123)
+        ->addSeries(456)
+        ->addSecondaryTag(789)
+        ->addCategory(123);
+
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234);
+
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+          array("node", $nodeStorage),
+          array("taxonomy_term", $termStorage)
+      ));
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+
+      $this->assertEquals(count($series), 1);
+      $content = $series[0];
+      $this->assertEquals($content["id"], 123);
+      $this->assertEquals($content["content_type"], "moj_video_item");
+      $this->assertEquals($content["title"], "Test Content");
+      $this->assertEquals($content["season"], 1);
+      $this->assertEquals($content["episode"], 1);
+      $this->assertEquals($content["episode_id"], 1001);
+      $this->assertEquals($content["duration"], 60);
+      $this->assertEquals($content["media"]->url, "/foo.mp4");
+      $this->assertEquals($content["image"]->url, "/foo.jpg");
+      $this->assertEquals(count($content["secondary_tags"]), 1);
+      $this->assertEquals($content["secondary_tags"][0]->target_id, 789);
+      $this->assertEquals(count($content["categories"]), 1);
+      $this->assertEquals($content["categories"][0]->target_id, 123);
+    }
+
+    public function testGetSeriesContentAudioFormat() {
+      $testContent = AudioContent::createWithNodeId($this, 123)
+        ->setSeason(1)
+        ->setEpisode(1)
+        ->addPrison(123)
+        ->addSeries(456)
+        ->addSecondaryTag(789)
+        ->addCategory(123);
+
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234);
+
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+
+      $this->assertEquals(count($series), 1);
+      $content = $series[0];
+      $this->assertEquals($content["id"], 123);
+      $this->assertEquals($content["content_type"], "moj_radio_item");
+      $this->assertEquals($content["title"], "Test Content");
+      $this->assertEquals($content["season"], 1);
+      $this->assertEquals($content["episode"], 1);
+      $this->assertEquals($content["episode_id"], 1001);
+      $this->assertEquals($content["duration"], 60);
+      $this->assertEquals($content["media"]->url, "/foo.mp3");
+      $this->assertEquals($content["image"]->url, "/foo.jpg");
+      $this->assertEquals(count($content["secondary_tags"]), 1);
+      $this->assertEquals($content["secondary_tags"][0]->target_id, 789);
+      $this->assertEquals(count($content["categories"]), 1);
+      $this->assertEquals($content["categories"][0]->target_id, 123);
+    }
+
+    public function testFiltersByPrisonWhenSelectedForSeries() {
+      $testContent = AudioContent::createWithNodeId($this, 123)
+        ->setSeason(1)
+        ->setEpisode(1)
+        ->addPrison(123)
+        ->addSeries(456)
+        ->addSecondaryTag(789)
+        ->addCategory(123);
+
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->setPromotedPrison(123)
+        ->addPrisonCategory(1234);
+
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $entityQueryFactory->expects($this->any())
+        ->method('condition')
+        ->withConsecutive(
+          array('status', 1), // Default filter of published articles
+          array('field_moj_prisons', 123, '=')
+        );
+
+      $entityQueryFactory->expects($this->any())
+        ->method('notExists')
+        ->withConsecutive(array('field_moj_prisons'));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+
+      $this->assertEquals(count($series), 1);
+    }
+
+    public function testThrowsWhenPrisonAndSeriesPrisonDoNotMatch() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->setPromotedPrison(123)
+        ->addPrisonCategory(1234);
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+      $otherTestPrison = Prison::createWithNodeId($this, 0)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+      $otherPrison = TestHelpers::createMockNode($this, $otherTestPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison),
+        array(0, $otherPrison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        0,
+        "ASC"
+      );
+    }
+
+    public function testFiltersByPrisonCategoriesWhenNoPrisonSelectedForSeries() {
+      $testContent = AudioContent::createWithNodeId($this, 123)
+        ->setSeason(1)
+        ->setEpisode(1)
+        ->addPrison(123)
+        ->addSeries(456)
+        ->addSecondaryTag(789)
+        ->addCategory(123);
+
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234)
+        ->addPrisonCategory(4567);
+
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $entityQueryFactory->expects($this->any())
+        ->method('condition')
+        ->withConsecutive(
+          array('status', 1), // Default filter of published articles
+          array('field_moj_prisons', 123, '='),
+          array('field_prison_categories', array(1234), 'IN')
+        );
+
+      $entityQueryFactory->expects($this->any())
+        ->method('notExists')
+        ->withConsecutive(
+          array('field_moj_prisons'),
+          array('field_prison_categories')
+        );
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+
+      $this->assertEquals(count($series), 1);
+    }
+
+    public function testThrowsWhenPrisonAndSeriesHaveNoMatchingPrisonCategories() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234);
+        $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(5678);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+    }
+
+    public function testThrowsWhenSeriesDoesNotExist() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, null),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+    }
+
+    public function testThrowsWhenPrisonDoesNotExist() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, null)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+    }
+
+    public function testThrowsWhenSeriesHasNoPrisonCategory() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testSeries = Series::createWithNodeId($this, 456);
+      $testPrison = Prison::createWithNodeId($this, 123)
+        ->addPrisonCategory(1234);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+    }
+
+    public function testThrowsWhenPrisonHasNoPrisonCategory() {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+      $testSeries = Series::createWithNodeId($this, 456)
+        ->addPrisonCategory(1234);
+      $testPrison = Prison::createWithNodeId($this, 123);
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+      $series = TestHelpers::createMockNode($this, $testSeries);
+      $prison = TestHelpers::createMockNode($this, $testPrison);
+
+      $nodeStorage = TestHelpers::createMockNodeStorage($this, 'loadMultiple', array(
+        array(array(123), array($node))
+      ));
+
+      $termStorage = TestHelpers::createMockNodeStorage($this, 'load', array(
+        array(456, $series),
+        array(123, $prison)
+      ));
+
+      $entityManager = TestHelpers::createMockEntityManager($this, array( // Refactor this to return different NodeStorage objects
+        array("node", $nodeStorage),
+        array("taxonomy_term", $termStorage)
+      ));
+
+      $entityQueryFactory = TestHelpers::createMockQueryFactory($this, array(123));
+
+      $seriesContentApiClass = new SeriesContentApiClass($entityManager, $entityQueryFactory);
+
+      $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+      $series = $seriesContentApiClass->SeriesContentApiEndpoint(
+        "en/GB",
+        456,
+        null,
+        null,
+        123,
+        "ASC"
+      );
+    }
+}

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/AudioContent.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/AudioContent.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\moj_resources\Unit\Supports;
 
 use Drupal\Tests\moj_resources\Unit\Supports\Content;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
 
 /**
  * Test Helper for creating Audio Items
@@ -10,15 +11,15 @@ use Drupal\Tests\moj_resources\Unit\Supports\Content;
  * @group unit_moj_resources
  */
 class AudioContent extends Content {
-  public $type;
-  public $duration;
-  public $audio = [];
+  private $type;
+  private $duration;
+  private $audio = [];
 
-  public function __construct($nid) {
-    parent::__construct($nid);
-    array_push($this->audio, (object) array("url" => "/foo.mp3"));
-    $this->type = (object) array("target_id" => "moj_radio_item");
-    $this->duration = (object) array("value" => 60);
+  public function __construct($unitTestCase, $nid) {
+    parent::__construct($unitTestCase, $nid);
+    array_push($this->audio, $this->testHelpers->createFieldWith('url', '/foo.mp3'));
+    $this->type = $this->testHelpers->createFieldWith('target_id', 'moj_radio_item');
+    $this->duration = $this->testHelpers->createFieldWith('value', 60);
   }
 
   /**
@@ -27,8 +28,8 @@ class AudioContent extends Content {
    * @param string $title
    * @return Content
   */
-  static public function createWithNodeId($nid) {
-    $audioContent = new self($nid);
+  static public function createWithNodeId($unitTestCase, $nid) {
+    $audioContent = new self($unitTestCase, $nid);
     return $audioContent;
   }
 
@@ -50,6 +51,7 @@ class AudioContent extends Content {
         array("field_moj_top_level_categories", $this->categories),
         array("field_moj_secondary_tags", $this->secondaryTags),
         array("field_moj_prisons", $this->prisons),
+        array("field_prison_categories", $this->prisonCategories),
         array("field_moj_audio", $this->audio),
     );
   }

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/Content.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/Content.php
@@ -2,31 +2,35 @@
 
 namespace Drupal\Tests\moj_resources\Unit\Supports;
 
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+
 /**
  * Abstract base class for creating content helpers
  *
  * @group unit_moj_resources
  */
 abstract class Content {
+  protected $testHelpers;
+  protected $nid;
+  protected $title;
+  protected $description;
+  protected $season;
+  protected $episode;
+  protected $prisons = [];
+  protected $prisonCategories = [];
+  protected $series = [];
+  protected $secondaryTags = [];
+  protected $categories = [];
+  protected $image = [];
 
-  public $nid;
-  public $title;
-  public $description;
-  public $season;
-  public $episode;
-  public $prisons = [];
-  public $series = [];
-  public $secondaryTags = [];
-  public $categories = [];
-  public $image = [];
-
-  public function __construct($nid = 123) {
-    array_push($this->image, (object) array("url" => "/foo.jpg"));
-    $this->nid = (object) array("value" => $nid);
-    $this->title = (object) array("value" => "Test Content");
-    $this->description = $this->createDescription("This is some test content");
-    $this->season = (object) array("value" => 0);
-    $this->episode = (object) array("value" => 0);
+  public function __construct($unitTestCase, $nid = 123) {
+    $this->testHelpers = new TestHelpers($unitTestCase);
+    array_push($this->image, $this->testHelpers->createFieldWith('url', '/foo.jpg'));
+    $this->nid = $this->testHelpers->createFieldWith('value', $nid);
+    $this->title = $this->testHelpers->createFieldWith('value', 'Test Content');
+    $this->season = $this->testHelpers->createFieldWith('value', 0);
+    $this->episode = $this->testHelpers->createFieldWith('value', 0);
+    $this->description = $this->testHelpers->createDescriptionField("This is some test content");
   }
 
   /**
@@ -47,7 +51,7 @@ abstract class Content {
    * @return Content
   */
   public function setSeason($season) {
-    $this->season = (object) array("value" => $season);
+    $this->season = $this->testHelpers->createFieldWith('value', $season);
     return $this;
   }
 
@@ -58,7 +62,7 @@ abstract class Content {
    * @return Content
   */
   public function setEpisode($episode) {
-    $this->episode = (object) array("value" => $episode);
+    $this->episode = $this->testHelpers->createFieldWith('value', $episode);
     return $this;
   }
 
@@ -69,7 +73,18 @@ abstract class Content {
    * @return Content
   */
   public function addPrison($prisonId) {
-     array_push($this->prisons, (object) array("target_id" => $prisonId));
+     array_push($this->prisons, $this->testHelpers->createFieldWith('target_id', $prisonId));
+     return $this;
+  }
+
+  /**
+   * Add a prison ID
+   *
+   * @param int $prisonCategoryId
+   * @return Content
+  */
+  public function addPrisonCategory($prisonCategoryId) {
+     array_push($this->prisonCategories, $this->testHelpers->createFieldWith('target_id', $prisonCategoryId));
      return $this;
   }
 
@@ -80,7 +95,7 @@ abstract class Content {
    * @return Content
   */
   public function addSeries($seriesId) {
-     array_push($this->series, (object) array("target_id" => $seriesId));
+     array_push($this->series, $this->testHelpers->createFieldWith('target_id', $seriesId));
      return $this;
   }
 
@@ -91,7 +106,7 @@ abstract class Content {
    * @return Content
   */
   public function addSecondaryTag($secondaryTagId) {
-     array_push($this->secondaryTags, (object) array("target_id" => $secondaryTagId));
+     array_push($this->secondaryTags, $this->testHelpers->createFieldWith('target_id', $secondaryTagId));
      return $this;
   }
 
@@ -102,25 +117,8 @@ abstract class Content {
    * @return Content
   */
   public function addCategory($categoryId) {
-     array_push($this->categories, (object) array("target_id" => $categoryId));
+     array_push($this->categories, $this->testHelpers->createFieldWith('target_id', $categoryId));
      return $this;
-  }
-
-  /**
-   * Create a description object
-   *
-   * @param string $description
-   * @return array
-  */
-  private function createDescription($description) {
-    $description = (object) array(
-      "raw" => $description,
-      "processed" => $description,
-      "summary" => $description,
-      "sanitized" => $description
-    );
-
-    return array($description);
   }
 
   /**

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/Prison.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/Prison.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\moj_resources\Unit\Supports;
+
+use Drupal\Tests\moj_resources\Unit\Supports\Term;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+
+/**
+ * Test Helper for creating mock prisons
+ *
+ * @group unit_moj_resources
+ */
+class Prison extends Term {
+  private $type;
+
+  public function __construct($unitTestCase, $nid) {
+    parent::__construct($unitTestCase, $nid);
+    $this->type = $this->testHelpers->createFieldWith('target_id', 'prisons');
+  }
+
+  /**
+   * Create a new instance of Prison with a node ID
+   *
+   * @param string $title
+   * @return Term
+  */
+  static public function createWithNodeId($unitTestCase, $nid) {
+    $prisonTerm = new self($unitTestCase, $nid);
+    return $prisonTerm;
+  }
+
+  /**
+   * Create a returnValueMap object for testing
+   *
+   * @return array
+  */
+  public function createReturnValueMap() {
+     return array(
+        array("nid", $this->nid),
+        array("type", $this->type),
+        array("title", $this->title),
+        array("field_moj_description", $this->description),
+        array("field_prison_categories", $this->prisonCategories)
+    );
+  }
+}

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/Series.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/Series.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\Tests\moj_resources\Unit\Supports;
+
+use Drupal\Tests\moj_resources\Unit\Supports\Term;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+
+/**
+ * Test Helper for creating mock series
+ *
+ * @group unit_moj_resources
+ */
+class Series extends Term {
+  private $type;
+  private $prison;
+
+  public function __construct($unitTestCase, $nid) {
+    parent::__construct($unitTestCase, $nid);
+    $this->type = $this->testHelpers->createFieldWith('target_id', 'series');
+    $this->prison = $this->testHelpers->createEmptyField();
+  }
+
+  /**
+   * Create a new instance of Series with a node ID
+   *
+   * @param string $title
+   * @return Term
+  */
+  static public function createWithNodeId($unitTestCase, $nid) {
+    $prisonTerm = new self($unitTestCase, $nid);
+    return $prisonTerm;
+  }
+
+  /**
+   * Add a prison ID
+   *
+   * @param int $prisonId
+   * @return Term
+  */
+  public function setPromotedPrison($prisonId) {
+      $this->prison = $this->testHelpers->createFieldWith('target_id', $prisonId);
+      return $this;
+  }
+
+  /**
+   * Create a returnValueMap object for testing
+   *
+   * @return array
+  */
+  public function createReturnValueMap() {
+     return array(
+        array("nid", $this->nid),
+        array("type", $this->type),
+        array("title", $this->title),
+        array("field_moj_description", $this->description),
+        array("field_prison_categories", $this->prisonCategories),
+        array("field_promoted_to_prison", $this->prison)
+    );
+  }
+}

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/Term.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/Term.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\Tests\moj_resources\Unit\Supports;
+
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+
+/**
+ * Abstract base class for creating term helpers
+ *
+ * @group unit_moj_resources
+ */
+abstract class Term {
+  protected $testHelpers;
+  protected $nid;
+  protected $title;
+  protected $description;
+  protected $prisonCategories = [];
+
+  public function __construct($unitTestCase, $nid = 123) {
+    $this->testHelpers = new TestHelpers($unitTestCase);
+    $this->nid = $this->testHelpers->createFieldWith('value', $nid);
+    $this->title = $this->testHelpers->createFieldWith('Test Term', $nid);
+    $this->description = $this->testHelpers->createDescriptionField("This is a test term");
+  }
+
+  /**
+   * Set the title
+   *
+   * @param string $title
+   * @return Term
+  */
+  public function setTitle($title) {
+    $this->title = $title;
+    return $this;
+  }
+
+  /**
+   * Add a prison ID
+   *
+   * @param int $prisonId
+   * @return Term
+  */
+  public function addPrisonCategory($prisonCategoryId) {
+     array_push($this->prisonCategories, $this->testHelpers->createFieldWith('target_id', $prisonCategoryId));
+     return $this;
+  }
+
+  /**
+   * Create a returnValueMap object for testing
+   *
+   * @return array
+  */
+  abstract public function createReturnValueMap();
+
+}

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/TestHelpers.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/TestHelpers.php
@@ -5,6 +5,10 @@ namespace Drupal\Tests\moj_resources\Unit\Supports;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\moj_resources\SeriesContentApiClass;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Tests\moj_resources\Unit\Supports\Content;
+use Drupal\Tests\moj_resources\Unit\Supports\Term;
+use Drupal\Tests\UnitTestCase;
+
 
 /**
  * Test Helpers for Unit tests
@@ -13,11 +17,17 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
  */
 
 class TestHelpers {
+  public $unitTestCase;
+
+  public function __construct($unitTestCase) {
+    $this->unitTestCase = $unitTestCase;
+  }
 
   /**
    * Create a mock node
    *
-   * @param \Drupal\Tests\UnitTestCase $unitTestCase
+   * @param UnitTestCase $unitTestCase
+   * @param Content|Term $content
    * @return object
   */
   public static function createMockNode($unitTestCase, $content) {
@@ -29,9 +39,15 @@ class TestHelpers {
       ->method('access')
       ->willReturn(true);
 
+    $contentReturnValues = $content->createReturnValueMap();
+
     $node->expects($unitTestCase->any())
       ->method("__get")
-      ->will($unitTestCase->returnValueMap($content->createReturnValueMap()));
+      ->will($unitTestCase->returnValueMap($contentReturnValues));
+
+    $node->expects($unitTestCase->any())
+      ->method("get")
+      ->will($unitTestCase->returnValueMap($contentReturnValues));
 
     return $node;
   }
@@ -39,14 +55,14 @@ class TestHelpers {
   /**
    * Create a mock QueryFactory which returns an array of Node IDs
    *
-   * @param \Drupal\Tests\UnitTestCase $unitTestCase
+   * @param UnitTestCase $unitTestCase
    * @param int[] $nodeIdsToReturn
    * @return object
   */
   public static function createMockQueryFactory($unitTestCase, $nodeIdsToReturn) {
     $queryFactory = $unitTestCase->getMockBuilder('Drupal\Core\Entity\Query\QueryFactory')
       ->disableOriginalConstructor()
-      ->setMethods(array('get', 'condition', 'sort', 'range', 'execute', 'accessCheck'))
+      ->setMethods(array('get', 'condition', 'sort', 'range', 'execute', 'accessCheck', 'orConditionGroup', 'notExists', 'exists', 'andConditionGroup'))
       ->getMock();
 
     $queryFactory->expects($unitTestCase->any())
@@ -63,18 +79,18 @@ class TestHelpers {
   /**
    * Create a mock NodeStorage which returns an array of Nodes
    *
-   * @param \Drupal\Tests\UnitTestCase $unitTestCase
+   * @param UnitTestCase $unitTestCase
    * @param object[] $nodesToReturn
    * @return object
   */
-  public static function createMockNodeStorage($unitTestCase, $nodesToReturn) {
+  public static function createMockNodeStorage($unitTestCase, $method, $nodesToReturn) {
     $nodeStorage = $unitTestCase->getMockBuilder('Drupal\node\NodeStorage')
       ->disableOriginalConstructor()
       ->getMock();
 
     $nodeStorage->expects($unitTestCase->any())
-      ->method('loadMultiple')
-      ->will($unitTestCase->returnValue($nodesToReturn));
+      ->method($method)
+      ->will($unitTestCase->returnValueMap($nodesToReturn));
 
     return $nodeStorage;
   }
@@ -82,7 +98,7 @@ class TestHelpers {
   /**
    * Create a mock EntityManager
    *
-   * @param \Drupal\Tests\UnitTestCase $unitTestCase
+   * @param UnitTestCase $unitTestCase
    * @param array $returnValueMap
    * @return object
   */
@@ -98,4 +114,59 @@ class TestHelpers {
     return $entityManager;
   }
 
+  /**
+   * Create a mock Field Item
+   *
+   * @param string $key
+   * @param mixed $value
+   * @return object
+  */
+  public function createFieldWith($key, $value) {
+    $field = $this->unitTestCase->getMockBuilder('\Drupal\Core\Field\FieldItemListInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $field->expects($this->unitTestCase->any())
+      ->method('__get')
+      ->with($key)
+      ->willReturn($value);
+
+    return $field;
+  }
+
+  /**
+   * Create an empty Field Item
+   *
+   * @return object
+  */
+  public function createEmptyField() {
+    $field = $this->unitTestCase->getMockBuilder('\Drupal\Core\Field\FieldItemListInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $field->expects($this->unitTestCase->any())
+      ->method('isEmpty')
+      ->willReturn(true);
+
+    return $field;
+  }
+
+  /**
+   * Create a mock Description Field Item
+   *
+   * @param string $description
+   * @return object
+  */
+  public function createDescriptionField($description) {
+    $field = $this->unitTestCase->getMockBuilder('\Drupal\Core\Field\FieldItemListInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $field->expects($this->unitTestCase->any())
+      ->method('__get')
+      ->with('raw', 'processed', 'summary', 'sanitized')
+      ->willReturn($description);
+
+    return $field;
+  }
 }

--- a/modules/custom/moj_resources/tests/src/Unit/Supports/VideoContent.php
+++ b/modules/custom/moj_resources/tests/src/Unit/Supports/VideoContent.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\moj_resources\Unit\Supports;
 
 use Drupal\Tests\moj_resources\Unit\Supports\Content;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
 
 /**
  * Test Helper for creating Video Items
@@ -10,15 +11,15 @@ use Drupal\Tests\moj_resources\Unit\Supports\Content;
  * @group unit_moj_resources
  */
 class VideoContent extends Content {
-  public $type;
-  public $duration;
-  public $video = [];
+  private $type;
+  private $duration;
+  private $video = [];
 
-  public function __construct($nid) {
-    parent::__construct($nid);
-    array_push($this->video, (object) array("url" => "/foo.mp4"));
-    $this->type = (object) array("target_id" => "moj_video_item");
-    $this->duration = (object) array("value" => 60);
+  public function __construct($unitTestCase, $nid) {
+    parent::__construct($unitTestCase, $nid);
+    array_push($this->video, $this->testHelpers->createFieldWith('url', '/foo.mp4'));
+    $this->type = $this->testHelpers->createFieldWith('target_id', 'moj_video_item');
+    $this->duration = $this->testHelpers->createFieldWith('value', 60);
   }
 
   /**
@@ -27,8 +28,8 @@ class VideoContent extends Content {
    * @param string $title
    * @return Content
   */
-  static public function createWithNodeId($nid) {
-    $videoContent = new self($nid);
+  static public function createWithNodeId($unitTestCase, $nid) {
+    $videoContent = new self($unitTestCase, $nid);
     return $videoContent;
   }
 
@@ -50,6 +51,7 @@ class VideoContent extends Content {
         array("field_moj_top_level_categories", $this->categories),
         array("field_moj_secondary_tags", $this->secondaryTags),
         array("field_moj_prisons", $this->prisons),
+        array("field_prison_categories", $this->prisonCategories),
         array("field_video", $this->video),
     );
   }

--- a/modules/custom/moj_resources/tests/src/Unit/UtilitiesTest.php
+++ b/modules/custom/moj_resources/tests/src/Unit/UtilitiesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\Tests\moj_resources\Unit;
+
+use Drupal\moj_resources\Utilities;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\moj_resources\Unit\Supports\AudioContent;
+use Drupal\Tests\moj_resources\Unit\Supports\TestHelpers;
+use Drupal\Tests\moj_resources\Unit\Supports\VideoContent;
+
+/**
+ * MOJ Resources Utilities
+ *
+ * @group unit_moj_resources
+ */
+
+class UtilitiesTest extends UnitTestCase
+{
+  public $entityQueryFactory;
+
+  public function setUp() {
+      $this->entityQueryFactory = $this->getMockBuilder('Drupal\Core\Entity\Query\QueryFactory')
+        ->disableOriginalConstructor()
+        ->setMethods(array('get', 'condition','andConditionGroup', 'orConditionGroup', 'notExists', 'exists'))
+        ->getMock();
+
+      $this->entityQueryFactory->expects($this->any())
+        ->method($this->anything())
+        ->will($this->returnSelf());
+  }
+
+  /*
+  * Test filter by prison
+  *
+  * @return void
+  */
+  public function testFilterByPrisonCategories() {
+    $this->entityQueryFactory->expects($this->atLeastOnce())
+      ->method('andConditionGroup');
+
+      $this->entityQueryFactory->expects($this->once())
+      ->method('orConditionGroup');
+
+    $this->entityQueryFactory->expects($this->atLeastOnce())
+      ->method('condition')
+      ->withConsecutive(
+        array('field_moj_prisons', 123, '='),
+        array('field_prison_categories', [456], 'IN')
+      );
+
+    $this->entityQueryFactory->expects($this->atLeastOnce())
+      ->method('exists')
+      ->withConsecutive(
+        array('field_moj_prisons'),
+        array('field_prison_categories')
+      );
+
+    $query = Utilities::filterByPrisonCategories(123, [456], $this->entityQueryFactory->get('node'));
+
+    $this->assertInstanceOf('Drupal\Core\Entity\Query\QueryFactory', $query);
+  }
+
+  /*
+  * Test get prisons for a node
+  *
+  * @return void
+  */
+  public function testGetPrisonsFor() {
+    $tests = array(
+      array(123, 456),
+      array(123),
+      array(123, 456, 789),
+      array()
+    );
+
+    foreach ($tests as $testData) {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+
+      foreach ($testData as $prisonId) {
+        $testContent->addPrison($prisonId);
+      }
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+
+      $prisons = Utilities::getPrisonsFor($node);
+      $this->assertEquals(count($prisons), count($testData));
+      $this->assertEquals($prisons, $testData);
+    }
+  }
+
+  /*
+  * Test get prison categories for a node
+  *
+  * @return void
+  */
+  public function testGetPrisonCategoriesFor() {
+    $tests = array(
+      array(123, 456),
+      array(123),
+      array(123, 456, 789),
+      array()
+    );
+
+    foreach ($tests as $testData) {
+      $testContent = AudioContent::createWithNodeId($this, 123);
+
+      foreach ($testData as $prisonCategoryId) {
+        $testContent->addPrisonCategory($prisonCategoryId);
+      }
+
+      $node = TestHelpers::createMockNode($this, $testContent);
+
+      if (empty($testData)) {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+        $prisonCategories = Utilities::getPrisonCategoriesFor($node);
+      } else {
+        $prisonCategories = Utilities::getPrisonCategoriesFor($node);
+        $this->assertEquals(count($prisonCategories), count($testData));
+        $this->assertEquals($prisonCategories, $testData);
+      }
+    }
+  }
+}


### PR DESCRIPTION
... or "revert the revert"...

This PR reintroduces #123 and #156, the prison categories long-lived branch.

We reverted the previous changes because of a number of issues which cropped up which _may_ have been caused by this branch:

- https://trello.com/c/K57OrSZm/133-drupal-oom-errors-production
- https://trello.com/c/tLZpDeb1/132-frontend-502
- https://trello.com/c/80ep6uVp/1889-homepage-content-sort-order
- https://trello.com/c/1yFZG7Pq/1890-series-content-sort-order 

So we'll want to test and resolve those before merging these changes back in.