### PR TITLE
Installing drush global launcher.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,12 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php composer-setup.php --install-dir=/bin --filename=composer --version=1.10.16 \
   && php -r "unlink('composer-setup.php');"
 
+# Install the global drush launcher
+RUN curl -O https://github.com/drush-ops/drush-launcher/releases/latest/download/drush.phar \
+  && chmod +x drush.phar \
+  && mv drush.phar /usr/local/bin/drush
+
+
 # Set Timezone
 RUN echo "date.timezone = Europe/London" > /usr/local/etc/php/conf.d/timezone_set.ini
 # Set no memory limit (for PHP running as cli only).

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "unlink('composer-setup.php');"
 
 # Install the global drush launcher
-RUN curl -O https://github.com/drush-ops/drush-launcher/releases/latest/download/drush.phar \
+RUN curl -OL https://github.com/drush-ops/drush-launcher/releases/latest/download/drush.phar \
   && chmod +x drush.phar \
   && mv drush.phar /usr/local/bin/drush
 

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
@@ -22,7 +22,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./vendor/bin/drush", "deploy"]
+          command: ["drush", "deploy"]
 {{ include "drupal-deployment.envs" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a very small change that doesn't warrant a card.

### Intent

Currently to run drush you need to type in `vendor/bin/drush` which is obviously way too long and causes hours of wasted time and effort.

This PR installs https://github.com/drush-ops/drush-launcher which allows drush to be run from anywhere, and just by typing `drush`.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
