### PR TITLE
Add composer bin to path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php composer-setup.php --install-dir=/bin --filename=composer --version=1.10.16 \
   && php -r "unlink('composer-setup.php');"
 
+# Add the composer bin directory to the path.
+ENV PATH="/var/www/html/vendor/bin:${PATH}"
+
 # Set Timezone
 RUN echo "date.timezone = Europe/London" > /usr/local/etc/php/conf.d/timezone_set.ini
 # Set no memory limit (for PHP running as cli only).

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
@@ -22,7 +22,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./vendor/bin/drush", "deploy"]
+          command: ["drush", "deploy"]
 {{ include "drupal-deployment.envs" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a very small change that doesn't warrant a card.

### Intent

Currently to run drush you need to type in vendor/bin/drush which is obviously way too long and causes hours/weeks/months of wasted time and effort.

This PR adds the composer bin directory to the $PATH.  Allowing drush to be run with just `drush` (and everything else in the vendor/bin directory).

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
