### PR TITLE
Swtiching from US to normal date formats.

### DIFF
--- a/config/sync/core.date_format.medium.yml
+++ b/config/sync/core.date_format.medium.yml
@@ -7,4 +7,4 @@ _core:
 id: medium
 label: 'Default medium date'
 locked: false
-pattern: 'D, m/d/Y - H:i'
+pattern: 'D, d/m/Y - H:i'

--- a/config/sync/core.date_format.short.yml
+++ b/config/sync/core.date_format.short.yml
@@ -7,4 +7,4 @@ _core:
 id: short
 label: 'Default short date'
 locked: false
-pattern: 'm/d/Y - H:i'
+pattern: 'd/m/Y - H:i'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small issue that doesn't warrant a card.

### Intent

On the CMS pain points session an issue highlighted were the incorrect date formats.  

Drupal comes with default date formats that are in the US format i.e. month first, then date.   This PR updates those to be the "normal" format i.e. what the rest of the world uses, date and then month.

### Considerations

This should have no impact on the frontend, as none of the endpoints use Drupal's date formats (instead setting the date format directly in php).
The only change will be where dates are displayed in the Drupal CMS.  E.g. the `/admin/content` page.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
