### PR TITLE
Adding role delegations to studio manager role.

### DIFF
--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -22,6 +22,8 @@ permissions:
   - 'administer taxonomy_term form display'
   - 'administer users'
   - 'assign gds_theme_user role'
+  - 'assign local_administrator role'
+  - 'assign moj_local_content_manager role'
   - 'bypass node access'
   - 'create featured_articles content'
   - 'create landing_page content'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/GTLzL2nt/16-allow-studio-admins-to-assign-roles-in-drupal

### Intent

Add ability for studio managers to assign local content manager and studio manager role to any user account.

### Considerations


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
