### PR TITLE
46 add ability to sort series by oldest first

### DIFF
--- a/docroot/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/docroot/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -108,7 +108,7 @@ class SeriesContentApiClass
       $result = [];
       $result["episode_id"] = $episodeId;
       $result["last_updated"] = $curr->changed->value;
-      $result["date"] = $curr->field_moj_date->value;
+      $result["date"] = $curr->field_release_date->value;
       $result["content_type"] = $curr->type->target_id;
       $result["title"] = $curr->title->value;
       $result["id"] = $curr->nid->value;

--- a/docroot/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/docroot/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -191,9 +191,6 @@ class SeriesContentApiClass
     $sortByFieldValue = $seriesTerm->get('field_sort_by')->getValue();
     $sortByFieldValue = empty($sortByFieldValue) ? NULL : $sortByFieldValue[0]['value'];
 
-    $sortFields = [];
-    $sortDirection = '';
-
     switch ($sortByFieldValue) {
       case 'season_and_episode_asc':
         $sortFields = ['field_moj_season', 'field_moj_episode'];


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ThDYVbQ1/46-add-ability-to-sort-series-by-oldest-first

### Intent

This PR implements the new sorting methodology for our rest endpoints, which means that the sorting on series will be updated in the frontend.
The previous sorting function has been removed, and instead sorting is applied on the entity query itself (which is more performant, and will fix the issue where series with 40+ episodes have missing content).
The value of the `field_sort_by` (added in https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/190) is now used to determine the sorting method.

### Considerations

No automated tests have been added/updated for this change, (the previous unit tests for these rest endpoints no longer work, and we will be moving to JSON:API in the near future so not much value in fixing and updating these).

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
