### PR TITLE
113 implement prison category rule on topics page 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
         "drupal/govuk_design_system": "^1.0@beta",
         "drupal/govuk_inline_form_errors": "^1.0@beta",
         "drupal/health_check": "^1.1",
+        "drupal/jsonapi_cross_bundles": "^1.0@alpha",
+        "drupal/jsonapi_extras": "^3.17",
         "drupal/memcache": "^2.0",
         "drupal/migrate_plus": "^4.2",
         "drupal/migrate_source_csv": "^2.2",
@@ -110,6 +112,9 @@
             },
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch"
+            },
+            "drupal/jsonapi_cross_bundles": {
+                "Issue #3070430 - Incompatible with JSON:API Extras": "https://www.drupal.org/files/issues/2020-09-23/3070430-15.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "drupal/admin_toolbar": "^3.0",
         "drupal/autocomplete_id": "^1.4",
         "drupal/backup_migrate": "^4.0",
+        "drupal/cer": "^4.0@alpha",
         "drupal/core-composer-scaffold": "^8.9",
         "drupal/core-project-message": "^8.9",
         "drupal/core-recommended": "^8.9",
@@ -25,7 +26,6 @@
         "drupal/govuk_inline_form_errors": "^1.0@beta",
         "drupal/health_check": "^1.1",
         "drupal/jsonapi_cross_bundles": "^1.0@alpha",
-        "drupal/jsonapi_extras": "^3.17",
         "drupal/memcache": "^2.0",
         "drupal/migrate_plus": "^4.2",
         "drupal/migrate_source_csv": "^2.2",
@@ -111,10 +111,8 @@
                 "[FEATURE] Enable pre-signed links": "patches/flysystem_s3_2.0.0-rc1_enable_pre-signed_downloads.patch"
             },
             "drupal/core": {
-                "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch"
-            },
-            "drupal/jsonapi_cross_bundles": {
-                "Issue #3070430 - Incompatible with JSON:API Extras": "https://www.drupal.org/files/issues/2020-09-23/3070430-15.patch"
+                "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch",
+                "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "https://www.drupal.org/files/issues/2021-02-20/3036593-118.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "drupal/govuk_inline_form_errors": "^1.0@beta",
         "drupal/health_check": "^1.1",
         "drupal/jsonapi_cross_bundles": "^1.0@alpha",
+        "drupal/jsonapi_page_limit": "^1.0@beta",
         "drupal/memcache": "^2.0",
         "drupal/migrate_plus": "^4.2",
         "drupal/migrate_source_csv": "^2.2",
@@ -113,6 +114,9 @@
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch",
                 "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "https://www.drupal.org/files/issues/2021-02-20/3036593-118.patch"
+            },
+            "drupal/jsonapi_page_limit": {
+                "Add option to set a global limit": "https://gitlab.com/drupalspoons/jsonapi_page_limit/uploads/dd22406df90d355cbf4e1a6e0b649826/1-add-option-to-set-global-limit.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36b56d46f5a9f0206102196da661ca21",
+    "content-hash": "cec7489e06fd90b85bde35faa9a1247f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3095,6 +3095,127 @@
             }
         },
         {
+            "name": "drupal/jsonapi_cross_bundles",
+            "version": "1.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jsonapi_cross_bundles.git",
+                "reference": "8.x-1.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_cross_bundles-8.x-1.0-alpha3.zip",
+                "reference": "8.x-1.0-alpha3",
+                "shasum": "5598292bb49db5dacb5ef22b2c86d7375b18b5c5"
+            },
+            "require": {
+                "drupal/core": "^8.8@alpha"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-alpha3",
+                    "datestamp": "1597680650",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches_applied": {
+                    "Issue #3070430 - Incompatible with JSON:API Extras": "https://www.drupal.org/files/issues/2020-09-23/3070430-15.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "API-First Initiative",
+                    "homepage": "https://www.drupal.org/user/3616626"
+                },
+                {
+                    "name": "gabesullice",
+                    "homepage": "https://www.drupal.org/user/2287430"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
+                }
+            ],
+            "description": "Experimental code for adding cross-bundle resource collections for Drupal's JSON API module",
+            "homepage": "https://www.drupal.org/project/jsonapi_cross_bundles",
+            "keywords": [
+                "Drupal",
+                "JSON API"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/jsonapi_cross_bundles"
+            }
+        },
+        {
+            "name": "drupal/jsonapi_extras",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jsonapi_extras.git",
+                "reference": "8.x-3.17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_extras-8.x-3.17.zip",
+                "reference": "8.x-3.17",
+                "shasum": "2795865d847212f5b465445342118c1a6f57999e"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/jsonapi": "*",
+                "e0ipso/shaper": "^1"
+            },
+            "require-dev": {
+                "drupal/jsonapi": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.17",
+                    "datestamp": "1613848645",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mateu Aguiló Bosch",
+                    "homepage": "https://www.drupal.org/user/3366066",
+                    "email": "mateu.aguilo.bosch@gmail.com"
+                },
+                {
+                    "name": "Martin Kolar",
+                    "homepage": "https://www.drupal.org/u/mkolar"
+                },
+                {
+                    "name": "Karel Majzlik",
+                    "homepage": "https://www.drupal.org/u/karlos007"
+                },
+                {
+                    "name": "Björn Brala",
+                    "homepage": "https://www.drupal.org/u/bbrala"
+                }
+            ],
+            "description": "JSON:API Extras provides a means to override and provide limited configurations to the default zero-configuration implementation provided by the JSON:API module.",
+            "homepage": "https://www.drupal.org/project/jsonapi_extras",
+            "support": {
+                "source": "https://git.drupalcode.org/project/jsonapi_extras"
+            }
+        },
+        {
             "name": "drupal/memcache",
             "version": "2.3.0",
             "source": {
@@ -4569,6 +4690,48 @@
             "time": "2020-11-11T04:36:51+00:00"
         },
         {
+            "name": "e0ipso/shaper",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/e0ipso/shaper.git",
+                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/e0ipso/shaper/zipball/04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
+                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
+                "shasum": ""
+            },
+            "require": {
+                "justinrainbow/json-schema": "^5.2"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpcov": "^5.0",
+                "phpunit/phpunit": "^7.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Shaper\\": "src",
+                    "Shaper\\Tests\\": "tests/src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Mateu Aguiló Bosch",
+                    "email": "mateu.aguilo.bosch@gmail.com"
+                }
+            ],
+            "description": "Lightweight library to handle in and out transformations in PHP.",
+            "time": "2019-07-27T10:13:44+00:00"
+        },
+        {
             "name": "easyrdf/easyrdf",
             "version": "0.9.1",
             "source": {
@@ -5187,6 +5350,72 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -10939,72 +11168,6 @@
             "time": "2016-12-01T10:57:30+00:00"
         },
         {
-            "name": "justinrainbow/json-schema",
-            "version": "5.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-                "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "time": "2020-05-27T16:41:55+00:00"
-        },
-        {
             "name": "mikey179/vfsstream",
             "version": "v1.6.8",
             "source": {
@@ -13217,6 +13380,7 @@
     "stability-flags": {
         "drupal/govuk_design_system": 10,
         "drupal/govuk_inline_form_errors": 10,
+        "drupal/jsonapi_cross_bundles": 15,
         "drupal/taxonomy_machine_name": 20,
         "drupal/views_entity_form_field": 10
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cec7489e06fd90b85bde35faa9a1247f",
+    "content-hash": "eddbe9bd94785d093a1ba86b50dbade6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1968,6 +1968,70 @@
             }
         },
         {
+            "name": "drupal/cer",
+            "version": "4.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/cer.git",
+                "reference": "8.x-4.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/cer-8.x-4.0-alpha3.zip",
+                "reference": "8.x-4.0-alpha3",
+                "shasum": "3c508e842a2c17235e4c9909ab64ef1aeb9d3ebe"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-4.0-alpha3",
+                    "datestamp": "1620240213",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bmcclure",
+                    "homepage": "https://www.drupal.org/user/278485"
+                },
+                {
+                    "name": "chertzog",
+                    "homepage": "https://www.drupal.org/user/806366"
+                },
+                {
+                    "name": "gcb",
+                    "homepage": "https://www.drupal.org/user/1682976"
+                },
+                {
+                    "name": "gregcube",
+                    "homepage": "https://www.drupal.org/user/336930"
+                },
+                {
+                    "name": "jrglasgow",
+                    "homepage": "https://www.drupal.org/user/36590"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                }
+            ],
+            "description": "Allows user to create two-way references between entities.",
+            "homepage": "https://www.drupal.org/project/cer",
+            "support": {
+                "source": "https://git.drupalcode.org/project/cer"
+            }
+        },
+        {
             "name": "drupal/core",
             "version": "8.9.15",
             "source": {
@@ -2175,7 +2239,8 @@
                     }
                 },
                 "patches_applied": {
-                    "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch"
+                    "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch",
+                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "https://www.drupal.org/files/issues/2021-02-20/3036593-118.patch"
                 }
             },
             "autoload": {
@@ -3120,9 +3185,6 @@
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": {
-                    "Issue #3070430 - Incompatible with JSON:API Extras": "https://www.drupal.org/files/issues/2020-09-23/3070430-15.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3151,68 +3213,6 @@
             ],
             "support": {
                 "source": "https://git.drupalcode.org/project/jsonapi_cross_bundles"
-            }
-        },
-        {
-            "name": "drupal/jsonapi_extras",
-            "version": "3.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/jsonapi_extras.git",
-                "reference": "8.x-3.17"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi_extras-8.x-3.17.zip",
-                "reference": "8.x-3.17",
-                "shasum": "2795865d847212f5b465445342118c1a6f57999e"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9",
-                "drupal/jsonapi": "*",
-                "e0ipso/shaper": "^1"
-            },
-            "require-dev": {
-                "drupal/jsonapi": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-3.17",
-                    "datestamp": "1613848645",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Mateu Aguiló Bosch",
-                    "homepage": "https://www.drupal.org/user/3366066",
-                    "email": "mateu.aguilo.bosch@gmail.com"
-                },
-                {
-                    "name": "Martin Kolar",
-                    "homepage": "https://www.drupal.org/u/mkolar"
-                },
-                {
-                    "name": "Karel Majzlik",
-                    "homepage": "https://www.drupal.org/u/karlos007"
-                },
-                {
-                    "name": "Björn Brala",
-                    "homepage": "https://www.drupal.org/u/bbrala"
-                }
-            ],
-            "description": "JSON:API Extras provides a means to override and provide limited configurations to the default zero-configuration implementation provided by the JSON:API module.",
-            "homepage": "https://www.drupal.org/project/jsonapi_extras",
-            "support": {
-                "source": "https://git.drupalcode.org/project/jsonapi_extras"
             }
         },
         {
@@ -4690,48 +4690,6 @@
             "time": "2020-11-11T04:36:51+00:00"
         },
         {
-            "name": "e0ipso/shaper",
-            "version": "1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/e0ipso/shaper.git",
-                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/e0ipso/shaper/zipball/04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
-                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
-                "shasum": ""
-            },
-            "require": {
-                "justinrainbow/json-schema": "^5.2"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.0",
-                "phpunit/phpcov": "^5.0",
-                "phpunit/phpunit": "^7.0.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Shaper\\": "src",
-                    "Shaper\\Tests\\": "tests/src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Mateu Aguiló Bosch",
-                    "email": "mateu.aguilo.bosch@gmail.com"
-                }
-            ],
-            "description": "Lightweight library to handle in and out transformations in PHP.",
-            "time": "2019-07-27T10:13:44+00:00"
-        },
-        {
             "name": "easyrdf/easyrdf",
             "version": "0.9.1",
             "source": {
@@ -5350,72 +5308,6 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "5.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-                "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -11168,6 +11060,72 @@
             "time": "2016-12-01T10:57:30+00:00"
         },
         {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2020-05-27T16:41:55+00:00"
+        },
+        {
             "name": "mikey179/vfsstream",
             "version": "v1.6.8",
             "source": {
@@ -13378,6 +13336,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/cer": 15,
         "drupal/govuk_design_system": 10,
         "drupal/govuk_inline_form_errors": 10,
         "drupal/jsonapi_cross_bundles": 15,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eddbe9bd94785d093a1ba86b50dbade6",
+    "content-hash": "8ba406cca469b7a6ec0c38bf0faccdf0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3213,6 +3213,57 @@
             ],
             "support": {
                 "source": "https://git.drupalcode.org/project/jsonapi_cross_bundles"
+            }
+        },
+        {
+            "name": "drupal/jsonapi_page_limit",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jsonapi_page_limit.git",
+                "reference": "8.x-1.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_page_limit-8.x-1.0-beta1.zip",
+                "reference": "8.x-1.0-beta1",
+                "shasum": "0fc5a12e08dd3c51e827db8f5c6b0793713afcc4"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta1",
+                    "datestamp": "1578087183",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                },
+                "patches_applied": {
+                    "Add option to set a global limit": "https://gitlab.com/drupalspoons/jsonapi_page_limit/uploads/dd22406df90d355cbf4e1a6e0b649826/1-add-option-to-set-global-limit.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "drupalspoons",
+                    "homepage": "https://www.drupal.org/user/3647684"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                }
+            ],
+            "description": "Change the maximum number of items in a response for a given route.",
+            "homepage": "https://www.drupal.org/project/jsonapi_page_limit",
+            "support": {
+                "source": "https://git.drupalcode.org/project/jsonapi_page_limit"
             }
         },
         {
@@ -13340,6 +13391,7 @@
         "drupal/govuk_design_system": 10,
         "drupal/govuk_inline_form_errors": 10,
         "drupal/jsonapi_cross_bundles": 15,
+        "drupal/jsonapi_page_limit": 10,
         "drupal/taxonomy_machine_name": 20,
         "drupal/views_entity_form_field": 10
     },

--- a/config/sync/cer.corresponding_reference.landing_page_back_reference.yml
+++ b/config/sync/cer.corresponding_reference.landing_page_back_reference.yml
@@ -1,0 +1,14 @@
+uuid: e0098c5f-e632-4b4f-a276-0725c28b1815
+langcode: en
+status: true
+dependencies: {  }
+id: landing_page_back_reference
+label: 'Landing page back reference'
+enabled: true
+first_field: field_legacy_landing_page
+second_field: field_moj_landing_page_term
+bundles:
+  node:
+    - '*'
+  taxonomy_term:
+    - '*'

--- a/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
@@ -1,22 +1,18 @@
-uuid: f0d8ab9c-88cd-4a12-a3a7-115391bf5f05
+uuid: 5f5583ce-5d33-41e8-b5f1-b1b4dbfc5dcb
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.taxonomy_term.tags.field_featured_image
-    - field.field.taxonomy_term.tags.field_moj_category_featured_item
-    - field.field.taxonomy_term.tags.field_moj_prisons
-    - field.field.taxonomy_term.tags.field_moj_promoted
-    - field.field.taxonomy_term.tags.field_prison_categories
-    - image.style.thumbnail
-    - taxonomy.vocabulary.tags
+    - field.field.taxonomy_term.moj_categories.field_legacy_landing_page
+    - field.field.taxonomy_term.moj_categories.field_moj_prisons
+    - field.field.taxonomy_term.moj_categories.field_prison_categories
+    - taxonomy.vocabulary.moj_categories
   module:
-    - image
     - path
     - text
-id: taxonomy_term.tags.default
+id: taxonomy_term.moj_categories.default
 targetEntityType: taxonomy_term
-bundle: tags
+bundle: moj_categories
 mode: default
 content:
   description:
@@ -27,36 +23,24 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
-  field_featured_image:
-    weight: 4
+  field_legacy_landing_page:
+    weight: 3
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: image_image
-    region: content
-  field_moj_category_featured_item:
-    weight: 5
-    settings:
-      display_label: true
-    third_party_settings: {  }
-    type: boolean_checkbox
+    type: entity_reference_autocomplete
     region: content
   field_moj_prisons:
-    weight: 6
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
-  field_moj_promoted:
-    weight: 3
-    settings:
-      display_label: true
-    third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
   field_prison_categories:
-    weight: 7
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -79,7 +63,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 6
     region: content
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
@@ -1,0 +1,49 @@
+uuid: 7a005dfe-9507-4eaa-a008-d843e50723aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.moj_categories.field_legacy_landing_page
+    - field.field.taxonomy_term.moj_categories.field_moj_prisons
+    - field.field.taxonomy_term.moj_categories.field_prison_categories
+    - taxonomy.vocabulary.moj_categories
+  module:
+    - text
+id: taxonomy_term.moj_categories.default
+targetEntityType: taxonomy_term
+bundle: moj_categories
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_legacy_landing_page:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_moj_prisons:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_prison_categories:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.field.taxonomy_term.tags.field_featured_image
     - field.field.taxonomy_term.tags.field_moj_category_featured_item
+    - field.field.taxonomy_term.tags.field_moj_prisons
     - field.field.taxonomy_term.tags.field_moj_promoted
+    - field.field.taxonomy_term.tags.field_prison_categories
     - taxonomy.vocabulary.tags
   module:
     - image
@@ -41,6 +43,14 @@ content:
     third_party_settings: {  }
     type: boolean
     region: content
+  field_moj_prisons:
+    weight: 4
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_moj_promoted:
     weight: 1
     label: above
@@ -51,5 +61,13 @@ content:
     third_party_settings: {  }
     type: boolean
     region: content
+  field_prison_categories:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
 hidden:
-  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,6 +5,7 @@ module:
   autocomplete_id: 0
   block: 0
   breakpoint: 0
+  cer: 0
   ckeditor: 0
   config: 0
   datetime: 0
@@ -25,6 +26,8 @@ module:
   image: 0
   inline_form_errors: 0
   jsonapi: 0
+  jsonapi_cross_bundles: 0
+  jsonapi_page_limit: 0
   link: 0
   menu_ui: 0
   moj: 0

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_legacy_landing_page.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_legacy_landing_page.yml
@@ -1,0 +1,28 @@
+uuid: 274f0087-7490-44dd-bcc1-629c0195e292
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_legacy_landing_page
+    - node.type.landing_page
+    - taxonomy.vocabulary.moj_categories
+id: taxonomy_term.moj_categories.field_legacy_landing_page
+field_name: field_legacy_landing_page
+entity_type: taxonomy_term
+bundle: moj_categories
+label: 'Landing page'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      landing_page: landing_page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_moj_prisons.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_moj_prisons.yml
@@ -1,0 +1,29 @@
+uuid: 9c461f34-edb9-4e3f-9bfd-492932a45993
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_moj_prisons
+    - taxonomy.vocabulary.moj_categories
+    - taxonomy.vocabulary.prisons
+id: taxonomy_term.moj_categories.field_moj_prisons
+field_name: field_moj_prisons
+entity_type: taxonomy_term
+bundle: moj_categories
+label: Prisons
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prisons: prisons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_prison_categories.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_prison_categories.yml
@@ -1,0 +1,29 @@
+uuid: 3972a92a-a6df-4651-9849-b058670cf64a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_prison_categories
+    - taxonomy.vocabulary.moj_categories
+    - taxonomy.vocabulary.prison_category
+id: taxonomy_term.moj_categories.field_prison_categories
+field_name: field_prison_categories
+entity_type: taxonomy_term
+bundle: moj_categories
+label: 'Prison Categories'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prison_category: prison_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.taxonomy_term.tags.field_moj_prisons.yml
+++ b/config/sync/field.field.taxonomy_term.tags.field_moj_prisons.yml
@@ -1,0 +1,29 @@
+uuid: 5c334912-7cd2-4bda-abb0-1e906aaea235
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_moj_prisons
+    - taxonomy.vocabulary.prisons
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.field_moj_prisons
+field_name: field_moj_prisons
+entity_type: taxonomy_term
+bundle: tags
+label: Prisons
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prisons: prisons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.taxonomy_term.tags.field_prison_categories.yml
+++ b/config/sync/field.field.taxonomy_term.tags.field_prison_categories.yml
@@ -1,0 +1,29 @@
+uuid: b0554fe7-bbb4-401a-8605-9ee382adb3a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_prison_categories
+    - taxonomy.vocabulary.prison_category
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.field_prison_categories
+field_name: field_prison_categories
+entity_type: taxonomy_term
+bundle: tags
+label: 'Prison Categories'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prison_category: prison_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.taxonomy_term.field_legacy_landing_page.yml
+++ b/config/sync/field.storage.taxonomy_term.field_legacy_landing_page.yml
@@ -1,0 +1,20 @@
+uuid: cf7d720f-1d3e-49cd-967a-b9cc38d3929b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: taxonomy_term.field_legacy_landing_page
+field_name: field_legacy_landing_page
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_moj_prisons.yml
+++ b/config/sync/field.storage.taxonomy_term.field_moj_prisons.yml
@@ -1,0 +1,19 @@
+uuid: 108de389-a502-4f20-bd22-e6a808777800
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_moj_prisons
+field_name: field_moj_prisons
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/prisoner_hub_entity_access/prisoner_hub_entity_access.services.yml
+++ b/docroot/modules/custom/prisoner_hub_entity_access/prisoner_hub_entity_access.services.yml
@@ -7,6 +7,6 @@ services:
     arguments: ['@entity_type.manager']
   prisoner_hub_entity_access.query_access_subscriber:
     class: Drupal\prisoner_hub_entity_access\EventSubscriber\QueryAccessSubscriber
-    arguments: ['@entity_field.manager', '@entity_type.manager', '@current_route_match','%prisoner_hub_entity_access.prison_field_name%', '%prisoner_hub_entity_access.category_field_name%', '%prisoner_hub_prison_context.entity_type_ids%']
+    arguments: ['@entity_field.manager', '@entity_type.manager', '@current_route_match','%prisoner_hub_entity_access.prison_field_name%', '%prisoner_hub_entity_access.category_field_name%']
     tags:
       - { name: event_subscriber, priority: 100 }

--- a/docroot/modules/custom/prisoner_hub_entity_access/prisoner_hub_entity_access.services.yml
+++ b/docroot/modules/custom/prisoner_hub_entity_access/prisoner_hub_entity_access.services.yml
@@ -7,6 +7,6 @@ services:
     arguments: ['@entity_type.manager']
   prisoner_hub_entity_access.query_access_subscriber:
     class: Drupal\prisoner_hub_entity_access\EventSubscriber\QueryAccessSubscriber
-    arguments: ['@entity_field.manager', '@current_route_match','%prisoner_hub_entity_access.prison_field_name%', '%prisoner_hub_entity_access.category_field_name%']
+    arguments: ['@entity_field.manager', '@entity_type.manager', '@current_route_match','%prisoner_hub_entity_access.prison_field_name%', '%prisoner_hub_entity_access.category_field_name%', '%prisoner_hub_prison_context.entity_type_ids%']
     tags:
       - { name: event_subscriber, priority: 100 }

--- a/docroot/modules/custom/prisoner_hub_entity_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_entity_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -3,6 +3,8 @@
 namespace Drupal\prisoner_hub_entity_access\EventSubscriber;
 
 use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\entity\QueryAccess\ConditionGroup;
 use Drupal\entity\QueryAccess\QueryAccessEvent;
@@ -25,6 +27,13 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
   protected $entityFieldManager;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * The route match service.
    *
    * @var RouteMatchInterface
@@ -45,8 +54,9 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    */
   protected $prisonFieldName;
 
-  public function __construct(EntityFieldManagerInterface $entity_field_manager, RouteMatchInterface $route_match, string $prison_field_name, string $prison_category_field_name) {
+  public function __construct(EntityFieldManagerInterface $entity_field_manager, EntityTypeManagerInterface $entity_type_manager,RouteMatchInterface $route_match, string $prison_field_name, string $prison_category_field_name) {
     $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeManager = $entity_type_manager;
     $this->routeMatch = $route_match;
     $this->prisonFieldName = $prison_field_name;
     $this->prisonCategoryFieldName = $prison_category_field_name;
@@ -57,7 +67,7 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     // TODO: Do we want to run this for Taxonomy Terms?  Or other entity types?
-    $events['entity.query_access.node'] = ['entityQueryAccessPrisonCategories'];
+    $events['entity.query_access'] = ['entityQueryAccessPrisonCategories'];
 
     return $events;
   }
@@ -80,8 +90,9 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     $conditions = $event->getConditions();
     $conditions->alwaysFalse(FALSE);
 
-    $current_prison_condition_group = $this->getPrisonConditionGroup($current_prison);
-    $prison_categories_condition_group = $this->getPrisonCategoriesConditionGroup($current_prison);
+    $entity_type = $this->entityTypeManager->getDefinition($event->getEntityTypeId());
+    $current_prison_condition_group = $this->getPrisonConditionGroup($current_prison, $entity_type);
+    $prison_categories_condition_group = $this->getPrisonCategoriesConditionGroup($current_prison, $entity_type);
 
     // Only create an OR condition group if a prison categories condition is to
     // be added.
@@ -105,15 +116,15 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    * @return \Drupal\entity\QueryAccess\ConditionGroup
    *   The condition group, to be added to the entity query.
    */
-  protected function getPrisonConditionGroup(TermInterface $current_prison) {
+  protected function getPrisonConditionGroup(TermInterface $current_prison, EntityTypeInterface $entity_type) {
     $condition_group = new ConditionGroup('OR');
     $condition_group->addCondition($this->prisonFieldName, $current_prison->id());
 
     // Exclude bundles (e.g. content types, vocabs, etc).  That do not have the
     // field enabled.  To do this we get a list of all bundles the field is
     // enabled, and add a 'NOT IN' condition.
-    $bundles = $this->getFieldBundles('node', $this->prisonFieldName);
-    $condition_group->addCondition('type', $bundles, 'NOT IN');
+    $bundles = $this->getFieldBundles($entity_type->id(), $this->prisonFieldName);
+    $condition_group->addCondition($entity_type->getKey('bundle'), $bundles, 'NOT IN');
     return $condition_group;
   }
 
@@ -127,7 +138,7 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    *   The condition group, to be added to the entity query.  Or NULL if no
    *   condition should be added.
    */
-  protected function getPrisonCategoriesConditionGroup(TermInterface $current_prison) {
+  protected function getPrisonCategoriesConditionGroup(TermInterface $current_prison, EntityTypeInterface $entity_type) {
     $prison_categories = $this->getPrisonCategories($current_prison);
 
     // If a prison has been setup but has not categories, do not add anything
@@ -142,8 +153,8 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     // Exclude bundles (e.g. content types, vocabs, etc).  That do not have the
     // field enabled.  To do this we get a list of all bundles the field is
     // enabled, and add a 'NOT IN' condition.
-    $bundles = $this->getFieldBundles('node', $this->prisonCategoryFieldName);
-    $condition_group->addCondition('type', $bundles, 'NOT IN');
+    $bundles = $this->getFieldBundles($entity_type->id(), $this->prisonCategoryFieldName);
+    $condition_group->addCondition($entity_type->getKey('bundle'), $bundles, 'NOT IN');
     return $condition_group;
   }
 

--- a/docroot/modules/custom/prisoner_hub_entity_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_entity_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -3,8 +3,6 @@
 namespace Drupal\prisoner_hub_entity_access\EventSubscriber;
 
 use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\entity\QueryAccess\ConditionGroup;
 use Drupal\entity\QueryAccess\QueryAccessEvent;
@@ -27,13 +25,6 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
   protected $entityFieldManager;
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * The route match service.
    *
    * @var RouteMatchInterface
@@ -54,27 +45,20 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    */
   protected $prisonFieldName;
 
-  /**
-   * @var array
-   *
-   * List of entity type ids to apply the query access to.
-   */
-  protected $entityTypeIds;
-
-  public function __construct(EntityFieldManagerInterface $entity_field_manager, EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, string $prison_field_name, string $prison_category_field_name, array $entity_type_ids) {
+  public function __construct(EntityFieldManagerInterface $entity_field_manager, RouteMatchInterface $route_match, string $prison_field_name, string $prison_category_field_name) {
     $this->entityFieldManager = $entity_field_manager;
-    $this->entityTypeManager = $entity_type_manager;
     $this->routeMatch = $route_match;
     $this->prisonFieldName = $prison_field_name;
     $this->prisonCategoryFieldName = $prison_category_field_name;
-    $this->entityTypeIds = $entity_type_ids;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events['entity.query_access'] = ['entityQueryAccessPrisonCategories'];
+    // TODO: Do we want to run this for Taxonomy Terms?  Or other entity types?
+    $events['entity.query_access.node'] = ['entityQueryAccessPrisonCategories'];
+
     return $events;
   }
 
@@ -89,16 +73,15 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
 
     /* @var \Drupal\taxonomy\TermInterface $current_prison */
     $current_prison = $this->routeMatch->getParameter('prison');
-    if (!in_array($event->getOperation(), $operations) || !$current_prison || !in_array($event->getEntityTypeId(), $this->entityTypeIds)) {
+    if (!in_array($event->getOperation(), $operations) || !$current_prison) {
       return;
     }
 
     $conditions = $event->getConditions();
     $conditions->alwaysFalse(FALSE);
 
-    $entity_type = $this->entityTypeManager->getDefinition($event->getEntityTypeId());
-    $current_prison_condition_group = $this->getPrisonConditionGroup($current_prison, $entity_type);
-    $prison_categories_condition_group = $this->getPrisonCategoriesConditionGroup($current_prison, $entity_type);
+    $current_prison_condition_group = $this->getPrisonConditionGroup($current_prison);
+    $prison_categories_condition_group = $this->getPrisonCategoriesConditionGroup($current_prison);
 
     // Only create an OR condition group if a prison categories condition is to
     // be added.
@@ -122,15 +105,15 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    * @return \Drupal\entity\QueryAccess\ConditionGroup
    *   The condition group, to be added to the entity query.
    */
-  protected function getPrisonConditionGroup(TermInterface $current_prison, EntityTypeInterface $entity_type) {
+  protected function getPrisonConditionGroup(TermInterface $current_prison) {
     $condition_group = new ConditionGroup('OR');
     $condition_group->addCondition($this->prisonFieldName, $current_prison->id());
 
     // Exclude bundles (e.g. content types, vocabs, etc).  That do not have the
     // field enabled.  To do this we get a list of all bundles the field is
     // enabled, and add a 'NOT IN' condition.
-    $bundles = $this->getFieldBundles($entity_type->id(), $this->prisonFieldName);
-    $condition_group->addCondition($entity_type->getKey('bundle'), $bundles, 'NOT IN');
+    $bundles = $this->getFieldBundles('node', $this->prisonFieldName);
+    $condition_group->addCondition('type', $bundles, 'NOT IN');
     return $condition_group;
   }
 
@@ -144,7 +127,7 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
    *   The condition group, to be added to the entity query.  Or NULL if no
    *   condition should be added.
    */
-  protected function getPrisonCategoriesConditionGroup(TermInterface $current_prison, EntityTypeInterface $entity_type) {
+  protected function getPrisonCategoriesConditionGroup(TermInterface $current_prison) {
     $prison_categories = $this->getPrisonCategories($current_prison);
 
     // If a prison has been setup but has not categories, do not add anything
@@ -159,8 +142,8 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     // Exclude bundles (e.g. content types, vocabs, etc).  That do not have the
     // field enabled.  To do this we get a list of all bundles the field is
     // enabled, and add a 'NOT IN' condition.
-    $bundles = $this->getFieldBundles($entity_type->id(), $this->prisonCategoryFieldName);
-    $condition_group->addCondition($entity_type->getKey('bundle'), $bundles, 'NOT IN');
+    $bundles = $this->getFieldBundles('node', $this->prisonCategoryFieldName);
+    $condition_group->addCondition('type', $bundles, 'NOT IN');
     return $condition_group;
   }
 

--- a/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
+++ b/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
@@ -1,3 +1,7 @@
+parameters:
+  prisoner_hub_prison_context.entity_type_ids:
+    - node
+    - taxonomy_term
 services:
   prisoner_hub_prison_context.prison_context:
     class: Drupal\prisoner_hub_prison_context\PrisonContext
@@ -6,6 +10,6 @@ services:
       - { name: paramconverter }
   prisoner_hub_prison_context.route_subscriber:
     class: Drupal\prisoner_hub_prison_context\Routing\RouteSubscriber
-    arguments: ['%jsonapi.base_path%']
+    arguments: ['%jsonapi.base_path%', '%prisoner_hub_prison_context.entity_type_ids%']
     tags:
       - { name: event_subscriber }

--- a/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
+++ b/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
@@ -1,7 +1,3 @@
-parameters:
-  prisoner_hub_prison_context.entity_type_ids:
-    - node
-    - taxonomy_term
 services:
   prisoner_hub_prison_context.prison_context:
     class: Drupal\prisoner_hub_prison_context\PrisonContext
@@ -10,6 +6,6 @@ services:
       - { name: paramconverter }
   prisoner_hub_prison_context.route_subscriber:
     class: Drupal\prisoner_hub_prison_context\Routing\RouteSubscriber
-    arguments: ['%jsonapi.base_path%', '%prisoner_hub_prison_context.entity_type_ids%']
+    arguments: ['%jsonapi.base_path%']
     tags:
       - { name: event_subscriber }

--- a/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
@@ -3,7 +3,6 @@
 namespace Drupal\prisoner_hub_prison_context\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
-use Drupal\jsonapi\JsonApiResource\ResourceObject;
 use Drupal\jsonapi\Routing\Routes;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -19,16 +18,8 @@ class RouteSubscriber extends RouteSubscriberBase {
    */
   protected $jsonapiBasePath;
 
-  /**
-   * @var array
-   *
-   * List of entity type ids to apply prison context routing to.
-   */
-  protected $entityTypeIds;
-
-  public function __construct(string $jsonapi_base_path, array $entity_type_ids) {
+  public function __construct(string $jsonapi_base_path) {
     $this->jsonapiBasePath = $jsonapi_base_path;
-    $this->entityTypeIds = $entity_type_ids;
   }
 
   /**
@@ -39,19 +30,13 @@ class RouteSubscriber extends RouteSubscriberBase {
   public function alterRoutes(RouteCollection $collection) {
     foreach ($collection as $name => $route) {
       /* @var \Symfony\Component\Routing\Route $route */
-      if ($route->getDefault(Routes::JSON_API_ROUTE_FLAG_KEY)) {
-        $entity_type = isset($route->getOption('parameters')['entity']) ? $route->getOption('parameters')['entity']['type'] : NULL;
-        // Only copy jsonapi routes that are either:
-        // 1) For one of the entity types we have specified (in prisoner_hub_prison_context.services.yml)
-        // 2) Is a jsonapi_resources (contrib module) route.
-        if (in_array(str_replace('entity:', '', $entity_type), $this->entityTypeIds) || $route->getDefault('_jsonapi_resource')) {
-          $new_route = clone($route);
-          $new_route->setPath(str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
-          $parameters = $route->getOption('parameters');
-          $parameters['prison'] = ['type' => 'prison_context'];
-          $new_route->setOption('parameters', $parameters);
-          $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
-        }
+      if (Routes::isJsonApiRequest($route->getDefaults())) {
+        $new_route = clone($route);
+        $new_route->setPath(str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
+        $parameters = $route->getOption('parameters');
+        $parameters['prison'] = ['type' => 'prison_context'];
+        $new_route->setOption('parameters', $parameters);
+        $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
       }
     }
   }

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -29,6 +29,7 @@ function prisoner_content_hub_profile_deploy_copy_landing_page_values() {
       $referenced_entity->set('field_legacy_landing_page', $node->id());
       $referenced_entity->set('field_moj_prisons', $node->get('field_moj_prisons')->getValue());
       $referenced_entity->set('field_prison_categories', $node->get('field_prison_categories')->getValue());
+      $referenced_entity->set('description', $node->get('field_moj_description')->getValue());
 
       $referenced_entity->save();
     }

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This is a NAME.deploy.php file. It contains "deploy" functions. These are
+ * one-time functions that run *after* config is imported during a deployment.
+ * These are a higher level alternative to hook_update_n and hook_post_update_NAME
+ * functions. See https://www.drush.org/latest/deploycommand/#authoring-update-functions
+ * for a detailed comparison.
+ */
+
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Copy over values from landing page content types to categories.
+ */
+function prisoner_content_hub_profile_deploy_copy_landing_page_values() {
+  $query = \Drupal::entityQuery('node');
+  $query->condition('type', 'landing_page');
+  $query->accessCheck(FALSE);
+  $result = $query->execute();
+  $nodes = Node::loadMultiple($result);
+
+  foreach ($nodes as $node) {
+    $referenced_entities = $node->get('field_moj_landing_page_term')->referencedEntities();
+    foreach ($referenced_entities as $referenced_entity) {
+      /** @var \Drupal\taxonomy\TermInterface $referenced_entity */
+      $referenced_entity->set('field_legacy_landing_page', $node->id());
+      $referenced_entity->set('field_moj_prisons', $node->get('field_moj_prisons')->getValue());
+      $referenced_entity->set('field_prison_categories', $node->get('field_prison_categories')->getValue());
+
+      $referenced_entity->save();
+    }
+  }
+}

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -10,6 +10,7 @@
 
 
 use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Copy over values from landing page content types to categories.
@@ -32,4 +33,22 @@ function prisoner_content_hub_profile_deploy_copy_landing_page_values() {
       $referenced_entity->save();
     }
   }
+}
+
+/**
+ * Set all Secondary tags to have every prison category.
+ */
+function prisoner_content_hub_profile_deploy_set_tag_prisons() {
+  $query = \Drupal::entityQuery('taxonomy_term');
+  $query->condition('vid', 'tags');
+  $query->accessCheck(FALSE);
+  $result = $query->execute();
+  $terms = Term::loadMultiple($result);
+  foreach ($terms as $term) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    // Set all four prison category term ids.
+    $term->set('field_prison_categories', [1011 => 1011, 1012 => 1012, 1013 => 1013, 1014 => 1014]);
+    $term->save();
+  }
+
 }

--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -177,6 +177,8 @@ parameters:
   monolog.channel_handlers:
     default: ["stream", "errStream"]
 
+  jsonapi_page_limit.size_max: []
+  jsonapi_page_limit.global_size_max: 100
 services:
   monolog.handler.stream:
     class: Monolog\Handler\StreamHandler


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/X0y3aNeI/113-implement-prison-category-rule-on-topics-page

This PR replaces https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/200

### Intent

> What changes are introduced by this PR that correspond to the above card?

Introduces a new "cross-bundle" jsonapi resource /jsonapi/taxonomy_term (this can also be used on other entity types, e.g. `/jsonapi/node`)
This will also be available when using the prison in the url. E.g.
/jsonapi/prison/berwyn/taxonomy_term

### Considerations

As part of converting the /topics page to JSON:API, I've started the process of removing the landing_page content type (it won't be removed just yet, but the /topics JSON:API response will only return the taxonomy terms, and not the landing page node type).
To allow the urls to the existing landing pages to be generated, a new field has been added field_legacy_landing_page, which contains the reference back from category to landing page (this is also kept in sync by using the "Corresponding Entity References" module. Once we have converted the category pages (and removed the landing_page content type), we can remove this field.
<img width="916" alt="Screenshot 2021-05-13 at 16 25 15" src="https://user-images.githubusercontent.com/436483/118147831-e41feb80-b407-11eb-8dd6-f6a26ff40513.png">


Prison and Prison category fields have been added to Categories and Secondary tags. For categories the values of their corresponding landing pages have been copied across. 
For tags, all prison categories have been selected (for every tag).

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
