### PR TITLE
141 assign content for lindholme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
                 "Add option to set a global limit": "https://gitlab.com/drupalspoons/jsonapi_page_limit/uploads/9567e0aeedbf9b44713d9740ab30ccec/1-add-option-to-set-global-limit-2.patch"
             },
             "drupal/views_ef_fieldset": {
-                "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2020-09-29/3173822-views_ef_fieldset-operator_issue-2.patch"
+                "Issue #3173822: Exposed operators are not included in fieldsets": "patches/3173822-views_ef_fieldset-operator_issue-3.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "drupal/view_unpublished": "^1.0",
         "drupal/views_bulk_edit": "^2.5",
         "drupal/views_bulk_operations": "^3.10",
+        "drupal/views_ef_fieldset": "^1.5",
         "drupal/views_entity_form_field": "^1.0@beta",
         "drush/drush": "^10.3",
         "mhor/php-mediainfo": "^5.1.0",
@@ -117,6 +118,9 @@
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit": "https://gitlab.com/drupalspoons/jsonapi_page_limit/uploads/9567e0aeedbf9b44713d9740ab30ccec/1-add-option-to-set-global-limit-2.patch"
+            },
+            "drupal/views_ef_fieldset": {
+                "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2020-09-29/3173822-views_ef_fieldset-operator_issue-2.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30fe40cce5eb820fb8d31a41e5abbfdc",
+    "content-hash": "533b4fa746985fb6041043adb4ce0b97",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4594,7 +4594,7 @@
                     }
                 },
                 "patches_applied": {
-                    "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2020-09-29/3173822-views_ef_fieldset-operator_issue-2.patch"
+                    "Issue #3173822: Exposed operators are not included in fieldsets": "patches/3173822-views_ef_fieldset-operator_issue-3.patch"
                 }
             },
             "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceb1094e962d6ab9975445d15b265163",
+    "content-hash": "30fe40cce5eb820fb8d31a41e5abbfdc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2240,7 +2240,8 @@
                 },
                 "patches_applied": {
                     "Issue #1149078 - States API doesn't work with multiple select fields": "https://www.drupal.org/files/issues/2018-12-05/1149078-drupal-states_multiselect-104-drupal86.patch",
-                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "https://www.drupal.org/files/issues/2021-02-20/3036593-118.patch"
+                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "https://www.drupal.org/files/issues/2021-02-20/3036593-118.patch",
+                    "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch"
                 }
             },
             "autoload": {
@@ -4555,6 +4556,76 @@
                 "source": "https://git.drupalcode.org/project/views_bulk_operations/-/tree/8.x-3.x",
                 "issues": "https://www.drupal.org/project/issues/views_bulk_operations?version=8.x",
                 "docs": "https://www.drupal.org/docs/8/modules/views-bulk-operations-vbo"
+            }
+        },
+        {
+            "name": "drupal/views_ef_fieldset",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/views_ef_fieldset.git",
+                "reference": "8.x-1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/views_ef_fieldset-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "72ca0b63028d0fe65e13c8472546a8803aa0d079"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "php": ">=7"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.5",
+                    "datestamp": "1604567512",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "composer-exit-on-patch-failure": true,
+                "enable-patching": true,
+                "patches": {
+                    "drupal/core": {
+                        "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch"
+                    }
+                },
+                "patches_applied": {
+                    "Issue #3173822: Exposed operators are not included in fieldsets": "https://www.drupal.org/files/issues/2020-09-29/3173822-views_ef_fieldset-operator_issue-2.patch"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Drupal\\Tests\\views_ef_fieldset\\": "./tests/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "scripts": {
+                "grumphp": [
+                    "./vendor/bin/grumphp run"
+                ]
+            },
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pol Dellaiera",
+                    "homepage": "https://www.drupal.org/user/47194",
+                    "email": "pol.dellaiera@protonmail.com"
+                },
+                {
+                    "name": "ciss",
+                    "homepage": "https://www.drupal.org/user/1632364"
+                }
+            ],
+            "description": "Provide an option to render the 'exposed form widgets' in a fieldset.",
+            "homepage": "https://drupal.org/project/views_field_formatter",
+            "support": {
+                "source": "https://git.drupalcode.org/project/views_ef_fieldset"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -67,6 +67,7 @@ module:
   view_unpublished: 0
   views_bulk_edit: 0
   views_bulk_operations: 0
+  views_ef_fieldset: 0
   views_entity_form_field: 0
   views_ui: 0
   govuk_inline_form_errors: 1

--- a/config/sync/views.settings.yml
+++ b/config/sync/views.settings.yml
@@ -1,4 +1,5 @@
-display_extenders: {  }
+display_extenders:
+  - views_ef_fieldset
 skip_cache: false
 sql_signature: false
 ui:

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.storage.node.field_moj_series
     - field.storage.node.field_moj_top_level_categories
     - taxonomy.vocabulary.moj_categories
+    - taxonomy.vocabulary.prison_category
+    - taxonomy.vocabulary.prisons
     - taxonomy.vocabulary.series
     - taxonomy.vocabulary.tags
   module:
@@ -59,10 +61,10 @@ display:
             first: '« First'
             last: 'Last »'
           expose:
-            items_per_page: true
+            items_per_page: false
             items_per_page_label: 'Items per page'
             items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
@@ -1024,49 +1026,6 @@ display:
           plugin_id: string
           entity_type: node
           entity_field: title
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            identifier: langcode
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
         field_moj_top_level_categories_target_id:
           id: field_moj_top_level_categories_target_id
           table: node__field_moj_top_level_categories
@@ -1271,55 +1230,6 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
-        promote:
-          id: promote
-          table: node_field_data
-          field: promote
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Promoted
-            description: ''
-            use_operator: false
-            operator: promote_op
-            identifier: promote
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              prisoner: '0'
-              local_administrator: '0'
-              anonymous: '0'
-              administrator: '0'
-              moj_view_video: '0'
-              moj_view_pdf: '0'
-              moj_view_radio: '0'
-              moj_local_content_manager: '0'
-              moj_prison_officer: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: promote
-          plugin_id: boolean
         nid:
           id: nid
           table: node_field_data
@@ -1384,7 +1294,7 @@ display:
           expose:
             operator_id: uid_op
             label: 'Authored by'
-            description: ''
+            description: ' '
             use_operator: false
             operator: uid_op
             operator_limit_selection: false
@@ -1399,6 +1309,7 @@ display:
               moj_local_content_manager: '0'
               local_administrator: '0'
               administrator: '0'
+              gds_theme_user: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -1415,6 +1326,110 @@ display:
           entity_type: node
           entity_field: uid
           plugin_id: user_name
+        field_moj_prisons_target_id:
+          id: field_moj_prisons_target_id
+          table: node__field_moj_prisons
+          field: field_moj_prisons_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_moj_prisons_target_id_op
+            label: Prisons
+            description: ''
+            use_operator: true
+            operator: field_moj_prisons_target_id_op
+            operator_limit_selection: false
+            operator_list:
+              and: and
+            identifier: field_moj_prisons_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+              gds_theme_user: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: 'Prisons (field_moj_prisons)'
+            description: null
+            identifier: field_moj_prisons_target_id
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: prisons
+          hierarchy: true
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_prison_categories_target_id:
+          id: field_prison_categories_target_id
+          table: node__field_prison_categories
+          field: field_prison_categories_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_prison_categories_target_id_op
+            label: 'Prison categories'
+            description: ''
+            use_operator: false
+            operator: field_prison_categories_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_prison_categories_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+              gds_theme_user: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: prison_category
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       sorts: {  }
       title: Content
       empty:
@@ -1476,7 +1491,246 @@ display:
         description: 'Find and manage content'
         menu_name: admin
         weight: -10
-      display_extenders: {  }
+      display_extenders:
+        views_ef_fieldset:
+          views_ef_fieldset:
+            enabled: 1
+            options:
+              sort:
+                root:
+                  container_type: details
+                  title: Filter
+                  description: ''
+                  open: '1'
+                  weight: '0'
+                  id: root
+                  pid: ''
+                  depth: '0'
+                  type: container
+                container-2:
+                  container_type: details
+                  title: General
+                  description: ''
+                  open: '1'
+                  weight: '-29'
+                  id: container-2
+                  pid: root
+                  depth: '1'
+                  type: container
+                title:
+                  weight: '-27'
+                  id: title
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                nid:
+                  weight: '-26'
+                  id: nid
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                type:
+                  weight: '-25'
+                  id: type
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                status:
+                  weight: '-24'
+                  id: status
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                field_moj_category_featured_item_value:
+                  weight: '-23'
+                  id: field_moj_category_featured_item_value
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                uid:
+                  weight: '-22'
+                  id: uid
+                  pid: container-2
+                  depth: '2'
+                  type: filter
+                container-1:
+                  container_type: details
+                  title: Taxonomy
+                  description: ''
+                  open: '1'
+                  weight: '-28'
+                  id: container-1
+                  pid: root
+                  depth: '1'
+                  type: container
+                field_moj_top_level_categories_target_id:
+                  weight: '-31'
+                  id: field_moj_top_level_categories_target_id
+                  pid: container-1
+                  depth: '2'
+                  type: filter
+                field_moj_secondary_tags_target_id:
+                  weight: '-30'
+                  id: field_moj_secondary_tags_target_id
+                  pid: container-1
+                  depth: '2'
+                  type: filter
+                field_moj_series_target_id:
+                  weight: '-29'
+                  id: field_moj_series_target_id
+                  pid: container-1
+                  depth: '2'
+                  type: filter
+                container-0:
+                  container_type: details
+                  title: 'Prison and prison categories'
+                  description: ''
+                  open: '1'
+                  weight: '-27'
+                  id: container-0
+                  pid: root
+                  depth: '1'
+                  type: container
+                field_moj_prisons_target_id_op:
+                  weight: '-29'
+                  id: field_moj_prisons_target_id_op
+                  pid: container-0
+                  depth: '2'
+                  type: filter
+                field_moj_prisons_target_id:
+                  weight: '-28'
+                  id: field_moj_prisons_target_id
+                  pid: container-0
+                  depth: '2'
+                  type: filter
+                field_prison_categories_target_id:
+                  weight: '-27'
+                  id: field_prison_categories_target_id
+                  pid: container-0
+                  depth: '2'
+                  type: filter
+                container-3:
+                  container_type: details
+                  title: ''
+                  description: ''
+                  open: '1'
+                  weight: '-26'
+                  id: container-3
+                  pid: root
+                  depth: '1'
+                  type: container
+                submit:
+                  weight: '-29'
+                  id: submit
+                  pid: container-3
+                  depth: '2'
+                  type: buttons
+                reset:
+                  weight: '-28'
+                  id: reset
+                  pid: container-3
+                  depth: '2'
+                  type: buttons
+                container-5:
+                  container_type: details
+                  title: ''
+                  description: ''
+                  weight: '-25'
+                  open: 0
+                  id: container-5
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-6:
+                  container_type: details
+                  title: 'Container 6'
+                  description: ''
+                  weight: '-24'
+                  open: 0
+                  id: container-6
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-4:
+                  container_type: details
+                  title: ''
+                  description: ''
+                  weight: '-23'
+                  open: 0
+                  id: container-4
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-7:
+                  container_type: details
+                  title: 'Container 7'
+                  description: ''
+                  weight: '-22'
+                  open: 0
+                  id: container-7
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-8:
+                  container_type: details
+                  title: 'Container 8'
+                  description: ''
+                  weight: '-21'
+                  open: 0
+                  id: container-8
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-9:
+                  container_type: details
+                  title: 'Container 9'
+                  description: ''
+                  weight: '-20'
+                  open: 0
+                  id: container-9
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-10:
+                  container_type: details
+                  title: 'Container 10'
+                  description: ''
+                  weight: '-19'
+                  open: 0
+                  id: container-10
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-11:
+                  container_type: details
+                  title: 'Container 11'
+                  description: ''
+                  weight: '-18'
+                  open: 0
+                  id: container-11
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-12:
+                  container_type: details
+                  title: 'Container 12'
+                  description: ''
+                  weight: '-17'
+                  open: 0
+                  id: container-12
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-13:
+                  container_type: details
+                  title: 'Container 13'
+                  description: ''
+                  weight: '-16'
+                  open: 0
+                  id: container-13
+                  pid: root
+                  depth: '1'
+                  type: container
     display_plugin: page
     display_title: Page
     id: page_1

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -1395,7 +1395,7 @@ display:
             operator_id: field_prison_categories_target_id_op
             label: 'Prison categories'
             description: ''
-            use_operator: false
+            use_operator: true
             operator: field_prison_categories_target_id_op
             operator_limit_selection: false
             operator_list: {  }
@@ -1583,7 +1583,7 @@ display:
                   type: filter
                 container-0:
                   container_type: details
-                  title: 'Prison and prison categories'
+                  title: Prisons
                   description: ''
                   open: '1'
                   weight: '-27'
@@ -1603,10 +1603,26 @@ display:
                   pid: container-0
                   depth: '2'
                   type: filter
+                container-5:
+                  container_type: details
+                  title: 'Prison categories'
+                  description: ''
+                  open: '1'
+                  weight: '-26'
+                  id: container-5
+                  pid: root
+                  depth: '1'
+                  type: container
+                field_prison_categories_target_id_op:
+                  weight: '-29'
+                  id: field_prison_categories_target_id_op
+                  pid: container-5
+                  depth: '2'
+                  type: filter
                 field_prison_categories_target_id:
-                  weight: '-27'
+                  weight: '-28'
                   id: field_prison_categories_target_id
-                  pid: container-0
+                  pid: container-5
                   depth: '2'
                   type: filter
                 container-3:
@@ -1614,7 +1630,7 @@ display:
                   title: ''
                   description: ''
                   open: '1'
-                  weight: '-26'
+                  weight: '-24'
                   id: container-3
                   pid: root
                   depth: '1'
@@ -1625,27 +1641,11 @@ display:
                   pid: container-3
                   depth: '2'
                   type: buttons
-                reset:
-                  weight: '-28'
-                  id: reset
-                  pid: container-3
-                  depth: '2'
-                  type: buttons
-                container-5:
-                  container_type: details
-                  title: ''
-                  description: ''
-                  weight: '-25'
-                  open: 0
-                  id: container-5
-                  pid: root
-                  depth: '1'
-                  type: container
                 container-6:
                   container_type: details
-                  title: 'Container 6'
+                  title: 'Container 5'
                   description: ''
-                  weight: '-24'
+                  weight: '-23'
                   open: 0
                   id: container-6
                   pid: root
@@ -1653,9 +1653,9 @@ display:
                   type: container
                 container-4:
                   container_type: details
-                  title: ''
+                  title: 'Container 6'
                   description: ''
-                  weight: '-23'
+                  weight: '-22'
                   open: 0
                   id: container-4
                   pid: root
@@ -1665,7 +1665,7 @@ display:
                   container_type: details
                   title: 'Container 7'
                   description: ''
-                  weight: '-22'
+                  weight: '-21'
                   open: 0
                   id: container-7
                   pid: root
@@ -1675,7 +1675,7 @@ display:
                   container_type: details
                   title: 'Container 8'
                   description: ''
-                  weight: '-21'
+                  weight: '-20'
                   open: 0
                   id: container-8
                   pid: root
@@ -1685,7 +1685,7 @@ display:
                   container_type: details
                   title: 'Container 9'
                   description: ''
-                  weight: '-20'
+                  weight: '-19'
                   open: 0
                   id: container-9
                   pid: root
@@ -1695,7 +1695,7 @@ display:
                   container_type: details
                   title: 'Container 10'
                   description: ''
-                  weight: '-19'
+                  weight: '-18'
                   open: 0
                   id: container-10
                   pid: root
@@ -1705,7 +1705,7 @@ display:
                   container_type: details
                   title: 'Container 11'
                   description: ''
-                  weight: '-18'
+                  weight: '-17'
                   open: 0
                   id: container-11
                   pid: root
@@ -1715,7 +1715,7 @@ display:
                   container_type: details
                   title: 'Container 12'
                   description: ''
-                  weight: '-17'
+                  weight: '-16'
                   open: 0
                   id: container-12
                   pid: root
@@ -1725,7 +1725,7 @@ display:
                   container_type: details
                   title: 'Container 13'
                   description: ''
-                  weight: '-16'
+                  weight: '-15'
                   open: 0
                   id: container-13
                   pid: root

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -64,3 +64,18 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Remove "operator" on all views exposed forms, as it's confusing terminology.
+ * This is a temporary workaround before we upgrade to Drupal 9.
+ * See https://www.drupal.org/project/drupal/issues/2625136
+ */
+function prisoner_hub_taxonomy_sorting_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  foreach ($form as &$field) {
+    if (isset($field['#title']) && $field['#title'] == 'Operator') {
+      unset($field['#title']);
+    }
+  }
+}

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -3,6 +3,8 @@
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 
+const PRISONER_CONTENT_HUB_PROFILE_BATCH_LIMIT = 20;
+
 /**
  * Remove all moj_hub_item content, so that the content type can be removed.
  */
@@ -62,7 +64,7 @@ function prisoner_content_hub_profile_update_8010(&$sandbox) {
 /**
  * Update terms assigned to youth female.
  */
-function prisoner_content_hub_profile_update_8011(&$sandbox) {
+function prisoner_content_hub_profile_update_8012(&$sandbox) {
 
   if (!isset($sandbox['progress'])) {
     $sandbox['progress'] = 0;
@@ -73,7 +75,7 @@ function prisoner_content_hub_profile_update_8011(&$sandbox) {
     $sandbox['result'] = $query->execute();
   }
 
-  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], 100, TRUE));
+  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], PRISONER_CONTENT_HUB_PROFILE_BATCH_LIMIT, TRUE));
 
   foreach ($terms as $term) {
     /** @var \Drupal\taxonomy\TermInterface $term */

--- a/patches/3173822-views_ef_fieldset-operator_issue-3.patch
+++ b/patches/3173822-views_ef_fieldset-operator_issue-3.patch
@@ -1,0 +1,70 @@
+diff --git a/src/ViewsEFFieldsetData.php b/src/ViewsEFFieldsetData.php
+index 47e73cff0632256e3e24227ade4ce331c55d4724..4b92344de5d9de7d1314090e6f0055529d9604ab 100644
+--- a/src/ViewsEFFieldsetData.php
++++ b/src/ViewsEFFieldsetData.php
+@@ -126,6 +126,36 @@ class ViewsEFFieldsetData {
+     return empty($branch) ? [] : $branch;
+   }
+ 
++  /**
++   * Helper function that moves a form element.
++   *
++   * @param string $field_name
++   *   The field name.
++   * @param array $item
++   *   The item.
++   * @param array $form_info
++   *   The form info.
++   * @param array $form
++   *   The form.
++   * @param bool $operator_element
++   *   Are we moving an operator element?
++   *
++   * @return array
++   *   The converted element.
++   */
++  private function moveFormElement($field_name, array $item, array $form_info, array &$form, $operator_element = FALSE) {
++    $element = $form[$field_name] +
++      [
++        '#weight' => $operator_element ? $item['item']['weight'] - 1 : $item['item']['weight'],
++        '#title' => $form_info['label'] ?? '',
++        '#description' => $form_info['description'] ?? '',
++      ];
++    unset($form['#info']['filter-' . $item['item']['id']]);
++    unset($form[$field_name]);
++
++    return $element;
++  }
++
+   /**
+    * Tree to FAPI recursive.
+    *
+@@ -141,20 +171,16 @@ class ViewsEFFieldsetData {
+ 
+       // If it's a filter field.
+       if ($item['item']['type'] === 'filter') {
+-        $form_info = isset($form['#info']['filter-' . $item['item']['id']])
+-          ? $form['#info']['filter-' . $item['item']['id']]
+-          : NULL;
++        $form_info = $form['#info']['filter-' . $item['item']['id']] ?? [];
+ 
+-        $field_name = $form_info['value'] ?: $item['item']['id'];
++        $field_name = $form_info['value'] ?? $item['item']['id'];
+         if (isset($form[$field_name]) && is_array($form[$field_name])) {
+-          $element[$field_name] = $form[$field_name] +
+-            [
+-              '#weight' => $item['item']['weight'],
+-              '#title' => $form_info['label'] ?: '',
+-              '#description' => $form_info['description'] ?: '',
+-            ];
+-          unset($form['#info']['filter-' . $item['item']['id']]);
+-          unset($form[$field_name]);
++          $element[$field_name] = $this->moveFormElement($field_name, $item, $form_info, $form);
++          // Check if there's an operator exposed and handle it as well.
++          $field_name .= '_op';
++          if (isset($form[$field_name]) && is_array($form[$field_name])) {
++            $element[$field_name] = $this->moveFormElement($field_name, $item, $form_info, $form, TRUE);
++          }
+         }
+       }
+ 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pXhgMj2C/141-assign-content-for-lindholme

### Intent

To update the content for Lindholme and to avoid a timeout on the deployment, it was decided that we would use the bulk content update tool in the CMS.

This card adds a filter for prisons to the content overview page, allowing us to select all content tagged with Berywn *and* Wayland.  To allow the *and*, the "operator" had to be exposed.  As I did this, the layout of the filters broke, so I grouped everything into different sections.

I also added a filter for prison categories, and removed filters for language and "promoted to frontpage" (neither are in use).


https://user-images.githubusercontent.com/436483/119125484-b94a1e80-ba29-11eb-9399-b1764958a032.mov



### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
