### PR TITLE
Fix unable to edit certain videos.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -102,3 +102,28 @@ function prisoner_content_hub_profile_update_8012(&$sandbox) {
   $sandbox['#finished'] = $sandbox['progress'] >= count($sandbox['result']);
   return 'Processed terms: ' . $sandbox['progress'];
 }
+
+/**
+ * Update missing file usage db records.
+ *
+ * See https://trello.com/c/TQHhdb4i/151-unable-to-edit-certain-videos-in-drupal
+ */
+function prisoner_content_hub_profile_update_8013() {
+  /** @var \Drupal\file\FileUsage\FileUsageInterface $file_usage */
+  $file_usage = Drupal::service('file.usage');
+
+  // Find all field_video entries that do not have an entry in the file_usage table.
+  //
+  // We can't use an entity query here, as we need to a specific join to bring
+  // in the missing entries.
+  $query = Drupal::database()->select('node__field_video', 'nfu');
+  $query->addField('nfu', 'entity_id');
+  $query->addField('nfu', 'field_video_target_id');
+  $query->addJoin('LEFT OUTER', 'file_usage', 'fu', 'nfu.field_video_target_id = fu.fid');
+  $query->where('fu.fid IS NULL');
+  $result = $query->execute()->fetchAll();
+  foreach ($result as $row) {
+    $file = \Drupal\file\Entity\File::load($row->field_video_target_id);
+    $file_usage->add($file, 'file', 'node', $row->entity_id);
+  }
+}

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -114,8 +114,8 @@ function prisoner_content_hub_profile_update_8013() {
 
   // Find all field_video entries that do not have an entry in the file_usage table.
   //
-  // We can't use an entity query here, as we need to a specific join to bring
-  // in the missing entries.
+  // We can't use an entity query here, as we need to use a specific
+  // LEFT join to bring in the missing entries.
   $query = Drupal::database()->select('node__field_video', 'nfu');
   $query->addField('nfu', 'entity_id');
   $query->addField('nfu', 'field_video_target_id');


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/TQHhdb4i/151-unable-to-edit-certain-videos-in-drupal

### Intent

This PR adds an update hook to re-instate the missing entries to the `file_usage` table.

### Considerations

We need to keep monitoring the database to see whether these entries come back, as it's not clear how they went missing in the first place.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
