### PR TITLE
152 plug in for video and audio percentage upload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,8 @@
         "installer-types": ["bower-asset", "npm-asset"],
         "patches": {
             "drupal/flysystem_s3": {
-                "[FEATURE] Enable pre-signed links": "patches/flysystem_s3_2.0.0-rc1_enable_pre-signed_downloads.patch"
+                "[FEATURE] Enable pre-signed links": "patches/flysystem_s3_2.0.0-rc1_enable_pre-signed_downloads.patch",
+                "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch"
             },
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal-1149078-drupal-states_multiselect-104-drupal86.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "836b8b4f5016ca4219c387eabe87ccbe",
+    "content-hash": "8641b4a20faf7fea6bc20ce89231cfbb",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2240,7 +2240,8 @@
                 },
                 "patches_applied": {
                     "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal-1149078-drupal-states_multiselect-104-drupal86.patch",
-                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-118.patch"
+                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-118.patch",
+                    "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch"
                 }
             },
             "autoload": {
@@ -2984,7 +2985,8 @@
                     }
                 },
                 "patches_applied": {
-                    "[FEATURE] Enable pre-signed links": "patches/flysystem_s3_2.0.0-rc1_enable_pre-signed_downloads.patch"
+                    "[FEATURE] Enable pre-signed links": "patches/flysystem_s3_2.0.0-rc1_enable_pre-signed_downloads.patch",
+                    "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -66,7 +66,7 @@ $flysystem_schemes = [
       'public' => TRUE,
 
       // Set to TRUE if CORS upload support is enabled for the bucket
-      // 'cors' => TRUE,
+       'cors' => TRUE,
     ],
 
     'cache' => TRUE, // Creates a metadata cache to speed up lookups

--- a/patches/flysystem_s3_cors_upload-2770263-60.patch
+++ b/patches/flysystem_s3_cors_upload-2770263-60.patch
@@ -1,0 +1,43 @@
+diff --git a/src/Controller/S3CorsUploadAjaxController.php b/src/Controller/S3CorsUploadAjaxController.php
+index cd838be..b01010e 100644
+--- a/src/Controller/S3CorsUploadAjaxController.php
++++ b/src/Controller/S3CorsUploadAjaxController.php
+@@ -74,12 +74,6 @@ class S3CorsUploadAjaxController extends ControllerBase {
+     $bucket = $adapter->getBucket();
+     $destination = $adapter->applyPathPrefix(StreamWrapperManager::getTarget($post['destination']));
+ 
+-    $options = [
+-      ['acl' => $post['acl']],
+-      ['bucket' => $bucket],
+-      ['starts-with', '$key', $destination . '/'],
+-    ];
+-
+     // Retrieve the file name and build the URI.
+     // Destination does not contain a prefix as it is applied by the fly system.
+     $uri = \Drupal::service('file_system')->createFilename($post['filename'], $post['destination']);
+@@ -88,7 +82,7 @@ class S3CorsUploadAjaxController extends ControllerBase {
+ 
+     // Create a temporary file to return with a file ID in the response.
+     $file = File::create([
+-      'uri' => $post['key'],
++      'uri' => $uri,
+       'filesize' => $post['filesize'],
+       'filename' => $post['filename'],
+       'filemime' => $post['filemime'],
+@@ -96,6 +90,16 @@ class S3CorsUploadAjaxController extends ControllerBase {
+     ]);
+     $file->save();
+ 
++    // Match Drupal DB mimetype with aws Content-Type Metadata. 
++    $post['Content-Type'] = $file->getMimeType();
++
++    $options = [
++      ['acl' => $post['acl']],
++      ['bucket' => $bucket],
++      ['starts-with', '$key', $destination . '/'],
++      ['starts-with', '$Content-Type', $post['Content-Type']],
++    ];
++
+     // Remove values not necessary for the request to Amazon.
+     unset($post['destination']);
+     unset($post['filename']);


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/lT8SSUoL/152-spike-plug-in-for-video-and-audio-percentage-upload

### Intent

File upload progress is apparently already a feature of the `flysystem_s3` module, but CORS has to be enabled on the S3 bucket.  Once it has been enabled, and the `CORS` setting set to `TRUE`, it should all magically work.

CORS has been added to the dev s3 bucket in https://github.com/ministryofjustice/cloud-platform-environments/pull/4854

<img width="1176" alt="Screenshot 2021-05-28 at 09 31 14" src="https://user-images.githubusercontent.com/436483/120311794-d3a8b580-c2cf-11eb-8d91-eb023048a63c.png">


### Considerations

CORS config needs to be added to MoJ hosting platform. These are done in three separate PRs:
- Dev (merged): https://github.com/ministryofjustice/cloud-platform-environments/pull/4854
- Staging (merged): https://github.com/ministryofjustice/cloud-platform-environments/pull/4863
- Production (reviewed but not yet merged): https://github.com/ministryofjustice/cloud-platform-environments/pull/4867

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
