### PR TITLE
Enabling CORS upload progress for all logged in Drupal roles

### DIFF
--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -16,5 +16,6 @@ permissions:
   - 'post comments'
   - 'search content'
   - 'skip comment approval'
+  - 'use S3 CORS upload'
   - 'use text format basic_html'
   - 'view entity autocomplete id results'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

There was a previous card https://trello.com/c/lT8SSUoL/966-enable-video-and-audio-upload-progress which was deployed to prod.  Unfortunately a setting was missed so that it wasn't actually enabled for studio admins or local comms manager accounts.  This PR adds in the setting.


### Intent

Update permissions so that all authenticated users can use the CORS upload functionality. 

This should also hopefully fix Paul's issue uploading videos in Cookhamwood:
https://mojdt.slack.com/archives/C02097M28D9/p1623403471004900

### Considerations
none 

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
