### PR TITLE
Prison categories should be shown before the prison field.

### DIFF
--- a/config/sync/core.entity_form_display.node.featured_articles.default.yml
+++ b/config/sync/core.entity_form_display.node.featured_articles.default.yml
@@ -16,8 +16,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 6
       format_type: fieldset
@@ -61,7 +61,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_moj_prisons:
-    weight: 13
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: options_buttons

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -22,8 +22,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 8
       format_type: fieldset
@@ -85,7 +85,7 @@ content:
     type: select2_entity_reference
     region: content
   field_moj_prisons:
-    weight: 15
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: options_buttons

--- a/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
@@ -30,8 +30,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 11
       format_type: fieldset
@@ -130,7 +130,7 @@ content:
     type: file_generic
     region: content
   field_moj_prisons:
-    weight: 15
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: options_buttons

--- a/config/sync/core.entity_form_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_video_item.default.yml
@@ -31,8 +31,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 12
       format_type: fieldset
@@ -125,7 +125,7 @@ content:
     type: number
     region: content
   field_moj_prisons:
-    weight: 16
+    weight: 18
     settings: {  }
     third_party_settings: {  }
     type: options_buttons

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -29,8 +29,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 11
       format_type: fieldset
@@ -122,7 +122,7 @@ content:
     type: number
     region: content
   field_moj_prisons:
-    weight: 18
+    weight: 20
     settings: {  }
     third_party_settings: {  }
     type: options_buttons

--- a/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -19,8 +19,8 @@ third_party_settings:
   field_group:
     group_prison_categories:
       children:
-        - field_moj_prisons
         - field_prison_categories
+        - field_moj_prisons
       parent_name: ''
       weight: 6
       format_type: fieldset
@@ -61,7 +61,7 @@ content:
     type: boolean_checkbox
     region: content
   field_moj_prisons:
-    weight: 6
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_buttons


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Previous (deployed) card https://trello.com/c/IpnUaB9o/950-improve-field-description-for-prison-and-prison-category-fields


### Intent

The prison category field should be before the prison field, but was the wrong way round for several content types, this PR fixes that.

### Considerations

n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
