### PR TITLE
Revert "Enabling CORS upload progress for all logged in Drupal roles"

### DIFF
--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -16,6 +16,5 @@ permissions:
   - 'post comments'
   - 'search content'
   - 'skip comment approval'
-  - 'use S3 CORS upload'
   - 'use text format basic_html'
   - 'view entity autocomplete id results'


### PR DESCRIPTION
Reverts ministryofjustice/prisoner-content-hub-backend#213
There's an issue with the CORS upload functionality, preventing files from being uploaded.
The change in this PR already been made on production (via the UI), this PR means the change does not get reverted on the next deployment.
