### PR TITLE
165 set originating IP address for betting logging

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -120,14 +120,16 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
  *
  * For more information, see default.settings.php
  */
-// Tell Drupal we are running behind a reverse proxy.
-// This allows the real client IP to be used for logging.
-$settings['reverse_proxy'] = TRUE;
+if (PHP_SAPI !== 'cli') {
+  // Tell Drupal we are running behind a reverse proxy.
+  // This allows the real client IP to be used for logging.
+  $settings['reverse_proxy'] = TRUE;
 
-// Drupal asks for the IP addresses that the proxy requests will come in from,
-// for additional security, to prevent IP spoofing.
-// As these addresses can change, we will just dynamically set the value.
-$settings['reverse_proxy_addresses'] = [$_SERVER['REMOTE_ADDR']];
+  // Drupal asks for the IP addresses that the proxy requests will come in from,
+  // for additional security, to prevent IP spoofing.
+  // As these addresses can change, we will just dynamically set the value.
+  $settings['reverse_proxy_addresses'] = [$_SERVER['REMOTE_ADDR']];
 
-// Setting the trusted reverse proxy header, to further prevent IP spoofing.
-$settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;
+  // Setting the trusted reverse proxy header, to further prevent IP spoofing.
+  $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;
+}

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -114,3 +114,20 @@ $settings['config_sync_directory'] = '../config/sync';
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings.local.php';
 }
+
+/**
+ * Reverse proxy settings.
+ *
+ * For more information, see default.settings.php
+ */
+// Tell Drupal we are running behind a reverse proxy.
+// This allows the real client IP to be used for logging.
+$settings['reverse_proxy'] = TRUE;
+
+// Drupal asks for the IP addresses that the proxy requests will come in from,
+// for additional security, to prevent IP spoofing.
+// As these addresses can change, we will just dynamically set the value.
+$settings['reverse_proxy_addresses'] = [$_SERVER['REMOTE_ADDR']];
+
+// Setting the trusted reverse proxy header, to further prevent IP spoofing.
+$settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/aGdfaKK5/165-do-we-have-an-login-change-audit-log

### Intent

Failed login attempts are already logged (e.g. see https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/doc/89ddb820-d648-11ea-a3d9-7f47a73dbcba/kubernetes_cluster-2021.07.14?id=4UgGpHoBFuiXLfuCgzEZ&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))

However, the IP address recorded is that from the load balancer, and not the original users IP.

This PR adds Drupal's reverse proxy support, to determine the original IP.

### Considerations

na

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
