### PR TITLE
Updating to drupal core 9.1.11 to include security fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/cer": "^4.0@alpha",
         "drupal/core-composer-scaffold": "^9.0.0",
         "drupal/core-project-message": "^9.0.0",
-        "drupal/core-recommended": "^9.0.0",
+        "drupal/core-recommended": "~9.1.11",
         "drupal/core-vendor-hardening": "^9.0.0",
         "drupal/diff": "^1.0",
         "drupal/elasticsearch_connector": "^7.0-alpha2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4538b07cf60956824e417e249adc8cca",
+    "content-hash": "ca611ae00f95fa876ec5920425249d45",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1629,16 +1629,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.1.10",
+            "version": "9.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "7fa70eb78addcef8ad704edad9fa73337b8cdab5"
+                "reference": "34249d59f0846760ecf361ae3ae2b29eaf758f19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/7fa70eb78addcef8ad704edad9fa73337b8cdab5",
-                "reference": "7fa70eb78addcef8ad704edad9fa73337b8cdab5",
+                "url": "https://api.github.com/repos/drupal/core/zipball/34249d59f0846760ecf361ae3ae2b29eaf758f19",
+                "reference": "34249d59f0846760ecf361ae3ae2b29eaf758f19",
                 "shasum": ""
             },
             "require": {
@@ -1664,7 +1664,7 @@
                 "laminas/laminas-diactoros": "^2.1",
                 "laminas/laminas-feed": "^2.12",
                 "masterminds/html5": "^2.1",
-                "pear/archive_tar": "^1.4.12",
+                "pear/archive_tar": "^1.4.14",
                 "php": ">=7.3.0",
                 "psr/log": "^1.0",
                 "stack/builder": "^1.0",
@@ -1878,7 +1878,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2021-06-04T17:28:30+00:00"
+            "time": "2021-07-20T21:42:58+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
@@ -1967,16 +1967,16 @@
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.1.10",
+            "version": "9.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "cf3bc76f7f15a77b6655d74a535ed6e704da9490"
+                "reference": "cc3445dd2d711cc5061615a82476e489f976665d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/cf3bc76f7f15a77b6655d74a535ed6e704da9490",
-                "reference": "cf3bc76f7f15a77b6655d74a535ed6e704da9490",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/cc3445dd2d711cc5061615a82476e489f976665d",
+                "reference": "cc3445dd2d711cc5061615a82476e489f976665d",
                 "shasum": ""
             },
             "require": {
@@ -1985,7 +1985,7 @@
                 "doctrine/annotations": "1.11.1",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.2",
-                "drupal/core": "9.1.10",
+                "drupal/core": "9.1.11",
                 "egulias/email-validator": "2.1.22",
                 "guzzlehttp/guzzle": "6.5.5",
                 "guzzlehttp/promises": "1.4.0",
@@ -1996,7 +1996,7 @@
                 "laminas/laminas-stdlib": "3.3.0",
                 "laminas/laminas-zendframework-bridge": "1.1.1",
                 "masterminds/html5": "2.7.4",
-                "pear/archive_tar": "1.4.13",
+                "pear/archive_tar": "1.4.14",
                 "pear/console_getopt": "v1.4.3",
                 "pear/pear-core-minimal": "v1.10.10",
                 "pear/pear_exception": "v1.0.1",
@@ -2045,7 +2045,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
-            "time": "2021-06-04T17:28:30+00:00"
+            "time": "2021-07-20T21:42:58+00:00"
         },
         {
             "name": "drupal/core-vendor-hardening",
@@ -6035,16 +6035,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.13",
+            "version": "1.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011"
+                "reference": "4d761c5334c790e45ef3245f0864b8955c562caa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/2b87b41178cc6d4ad3cba678a46a1cae49786011",
-                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/4d761c5334c790e45ef3245f0864b8955c562caa",
+                "reference": "4d761c5334c790e45ef3245f0864b8955c562caa",
                 "shasum": ""
             },
             "require": {
@@ -6107,7 +6107,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-16T10:50:50+00:00"
+            "time": "2021-07-20T13:53:39+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -13271,6 +13271,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't need a card.

### Intent

Bumps Drupal core version to 9.1.11 to include security fix https://www.drupal.org/sa-core-2021-004

We are unlikely to be vulnerable to the security issue, as we do not have any custom or contributed code using the Archive_Tar library.  But we should update anyway to be sure.

### Considerations

na

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
