### PR TITLE
233 modify decoupled router path

### DIFF
--- a/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
+++ b/docroot/modules/custom/prisoner_hub_prison_context/prisoner_hub_prison_context.services.yml
@@ -9,3 +9,8 @@ services:
     arguments: ['%jsonapi.base_path%']
     tags:
       - { name: event_subscriber }
+  prisoner_hub_prison_context.outbound_path_processor:
+    class: Drupal\prisoner_hub_prison_context\PathProcessorOutbound
+    arguments: ['@current_route_match', '%jsonapi.base_path%']
+    tags:
+      - { name: path_processor_outbound, priority: 200 }

--- a/docroot/modules/custom/prisoner_hub_prison_context/src/PathProcessorOutbound.php
+++ b/docroot/modules/custom/prisoner_hub_prison_context/src/PathProcessorOutbound.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\prisoner_hub_prison_context;
+
+
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\prisoner_hub_prison_context\Routing\RouteSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Processes the inbound path to use the prison context, passing it forward
+ * from the current request.
+ *
+ * This was primarily required for the decoupled_router module, so that JSON:API
+ * urls would reflect the current prison.  But should work for any url that is
+ * being requested through a prison context.
+ */
+class PathProcessorOutbound implements OutboundPathProcessorInterface {
+
+  /**
+   * The routematch service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The JsonApi base path parameter.  This is normally '/jsonapi'.
+   *
+   * @var string
+   */
+  protected $jsonApiBasePath;
+
+  /**
+   * PathProcessorOutbound constructor.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match service.
+   * @param string $jsonapi_base_path
+   *   The jsonapi base path parameter.
+   */
+  public function __construct(RouteMatchInterface $route_match, string $jsonapi_base_path) {
+    $this->routeMatch = $route_match;
+    $this->jsonApiBasePath = $jsonapi_base_path;
+  }
+
+  /**
+   * Process outbound urls, i.e. paths that are being generated in the current
+   * request.
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $prison = $this->routeMatch->getParameter('prison');
+    if ($prison && isset($options['route']) && RouteSubscriber::isJsonApiRoute($options['route'])) {
+      $prison_machine_name = $prison->get('machine_name')->getString();
+      $path = str_replace($this->jsonApiBasePath, $this->jsonApiBasePath . '/prison/' . $prison_machine_name, $path);
+    }
+    return $path;
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_prison_context/src/PathProcessorOutbound.php
+++ b/docroot/modules/custom/prisoner_hub_prison_context/src/PathProcessorOutbound.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\prisoner_hub_prison_context;
 
-
 use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;

--- a/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
@@ -39,12 +39,12 @@ class RouteSubscriber extends RouteSubscriberBase {
       /* @var \Symfony\Component\Routing\Route $route */
       if (self::isJsonApiRoute($route)) {
         $new_route = clone($route);
-        $this->addPrisonContextToRoute($route, str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
+        $this->addPrisonContextToRoute($new_route, str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
         $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
       }
       elseif ($name == 'decoupled_router.path_translation') {
         $new_route = clone($route);
-        $this->addPrisonContextToRoute($route, 'router/prison/{prison}/translate-path');
+        $this->addPrisonContextToRoute($new_route, 'router/prison/{prison}/translate-path');
         $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
       }
     }

--- a/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_context/src/Routing/RouteSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\prisoner_hub_prison_context\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\jsonapi\Routing\Routes;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -18,6 +19,12 @@ class RouteSubscriber extends RouteSubscriberBase {
    */
   protected $jsonapiBasePath;
 
+  /**
+   * RouteSubscriber constructor.
+   *
+   * @param string $jsonapi_base_path
+   *   The jsonapi base path parameter.
+   */
   public function __construct(string $jsonapi_base_path) {
     $this->jsonapiBasePath = $jsonapi_base_path;
   }
@@ -30,14 +37,48 @@ class RouteSubscriber extends RouteSubscriberBase {
   public function alterRoutes(RouteCollection $collection) {
     foreach ($collection as $name => $route) {
       /* @var \Symfony\Component\Routing\Route $route */
-      if (Routes::isJsonApiRequest($route->getDefaults()) || !empty($route->getDefault('_jsonapi_resource'))) {
+      if (self::isJsonApiRoute($route)) {
         $new_route = clone($route);
-        $new_route->setPath(str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
-        $parameters = $route->getOption('parameters');
-        $parameters['prison'] = ['type' => 'prison_context'];
-        $new_route->setOption('parameters', $parameters);
+        $this->addPrisonContextToRoute($route, str_replace($this->jsonapiBasePath, $this->jsonapiBasePath . '/prison/{prison}', $route->getPath()));
+        $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
+      }
+      elseif ($name == 'decoupled_router.path_translation') {
+        $new_route = clone($route);
+        $this->addPrisonContextToRoute($route, 'router/prison/{prison}/translate-path');
         $collection->add('prisoner_hub_prison_context.' . $name, $new_route);
       }
     }
+  }
+
+  /**
+   * Add prison context to a route.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to be modified.
+   * @param string $new_path
+   *   The new path for the route.
+   *
+   * @return \Symfony\Component\Routing\Route
+   *   The modified route, with prison context.
+   */
+  protected function addPrisonContextToRoute(Route $route, string $new_path) {
+    $route->setPath($new_path);
+    $parameters = $route->getOption('parameters');
+    $parameters['prison'] = ['type' => 'prison_context'];
+    $route->setOption('parameters', $parameters);
+    return $route;
+  }
+
+  /**
+   * Check to see if a route is a JSON:API request, that should be copied.
+   *
+   * @param $route
+   *   The route to check.
+   *
+   * @return bool
+   *   TRUE if the route is for JsonAPI, FALSE if otherwise.
+   */
+  static public function isJsonApiRoute($route) {
+    return Routes::isJsonApiRequest($route->getDefaults()) || !empty($route->getDefault('_jsonapi_resource'));
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/fh1sP4L6/233-switch-to-jsonapi-for-basic-pages

### Intent

This is a follow-on PR from https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/230, implementing option **a** from the **Considerations** section.

This PR modifies the decoupled router path, so that we can use the current prison.  This will also be returned in the jsonapi urls in the response.

Example:
<img width="1214" alt="Screenshot 2021-08-06 at 16 46 32" src="https://user-images.githubusercontent.com/436483/128536992-b89e4f3a-1f50-4f32-8a87-d05b77137744.png">



### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
