### PR TITLE
Fix issue where image urls inside the text editor were expiring.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,8 @@
             },
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
-                "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch"
+                "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch",
+                "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch"
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d78d43e17ebef7ad100c40b8c868104f",
+    "content-hash": "8378dc8ab31f845b96c46ea954455517",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1833,7 +1833,8 @@
                 },
                 "patches_applied": {
                     "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
-                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch"
+                    "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch",
+                    "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch"
                 }
             },
             "autoload": {

--- a/patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch
+++ b/patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch
@@ -1,0 +1,13 @@
+diff --git a/core/modules/editor/src/Plugin/Filter/EditorFileReference.php b/core/modules/editor/src/Plugin/Filter/EditorFileReference.php
+index 8cb9aad2d6..17d451753b 100644
+--- a/core/modules/editor/src/Plugin/Filter/EditorFileReference.php
++++ b/core/modules/editor/src/Plugin/Filter/EditorFileReference.php
+@@ -123,7 +123,7 @@ public function process($text, $langcode) {
+ 
+           $file = $this->entityRepository->loadEntityByUuid('file', $uuid);
+           if ($file instanceof FileInterface) {
+-            $result->addCacheTags($file->getCacheTags());
++            $result->addCacheableDependency($file);
+           }
+         }
+       }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

This fix is related to https://trello.com/c/fh1sP4L6/233-switch-to-jsonapi-for-basic-pages

### Intent

This fixes the issue of files uploaded through the text editor getting expired urls.
The cache metadata of the file was not being properly passed onto the containing content.  So whilst we are setting a max-age for the file based on the url signature expiration, this was not being used when the file was uploaded inside a text editor field.

This is a bug in Drupal, I opened an issue for this: https://www.drupal.org/project/drupal/issues/3228329

### Considerations

As this is a patch to Drupal core, we should monitor the above issue to see whether this is an acceptable solution or not.
It may also be worth writing tests for this, to ensure that the fix gets committed back in.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
