### PR TITLE
Fix for Lindholme not receiving the correct content

### DIFF
--- a/docroot/modules/custom/moj_resources/src/Utils.php
+++ b/docroot/modules/custom/moj_resources/src/Utils.php
@@ -1,19 +1,12 @@
 <?php
 function getPrisonResults($prison_id, $results) {
-  $prison_ids = [
-    792, // berwyn
-    793, // wayland
-    959  // cookham wood
-  ];
 
-  if (in_array($prison_id, $prison_ids)) {
-    $prison_results = $results
-      ->orConditionGroup()
-      ->condition('field_moj_prisons', $prison_id, '=')
-      ->condition('field_moj_prisons', '', '=')
-      ->notExists('field_moj_prisons');
-    $results->condition($prison_results);
-  }
+  $prison_results = $results
+    ->orConditionGroup()
+    ->condition('field_moj_prisons', $prison_id, '=')
+    ->condition('field_moj_prisons', '', '=')
+    ->notExists('field_moj_prisons');
+  $results->condition($prison_results);
 
   return $results;
 }


### PR DESCRIPTION
### Context

This is a fix for the issue reported in https://trello.com/c/KZOMMSmY/226-check-content-is-appropriate-for-hmp-lindholme-launch-friday-20-august

### Intent

Found there is a hard-coded list of prison ID's in the Drupal code.  If an ID is not part of the list (which Lindholme isn't), then it skips the check for the prison, and returns all results (for all prisons).

This PR removes this check, so that any prison ID is passed onto the query.  The difference means that
a) We don't need to manage this list of prison IDs (which we will be removing anyway once we switch to JSON:API)
b) If an invalid prison id is used, you get back no content.

### Considerations

We don't have to worry about malicious use of the prison id query parameter, as this will be sanitised by Drupal's entity query system.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
