### PR TITLE
254 switch to jsonapi for series pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             helm upgrade ${HELM_BACKEND_RELEASE_NAME} ~/git/helm_deploy/prisoner-content-hub-backend \
-              --install --wait --force --reset-values --timeout 360s \
+              --install --wait --force --reset-values --timeout 1200s \
               --namespace=${KUBE_NAMESPACE} \
               --values ~/git/helm_deploy/prisoner-content-hub-backend/values.<< parameters.environment >>.yaml \
               --set image.tag=${VERSION_TO_DEPLOY} \

--- a/config/sync/field.field.node.moj_pdf_item.field_moj_episode.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_moj_episode.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.moj_pdf_item.field_moj_season.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_moj_season.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.moj_radio_item.field_moj_episode.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_moj_episode.yml
@@ -16,8 +16,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.moj_radio_item.field_moj_season.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_moj_season.yml
@@ -16,8 +16,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.moj_video_item.field_moj_episode.yml
+++ b/config/sync/field.field.node.moj_video_item.field_moj_episode.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.moj_video_item.field_moj_season.yml
+++ b/config/sync/field.field.node.moj_video_item.field_moj_season.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.page.field_moj_episode.yml
+++ b/config/sync/field.field.node.page.field_moj_episode.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/sync/field.field.node.page.field_moj_season.yml
+++ b/config/sync/field.field.node.page.field_moj_season.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/README.md
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/README.md
@@ -1,9 +1,15 @@
 # Prisoner Hub Taxonomy Sorting
 
 This module provides functionality related to sorting content on Taxonomy pages.
-Currently this includes the following features:
-* Adds a tab to Series and Secondary tags taxonomy pages that displays a list
-  of content in the same order as it would on the frontend.
-* Shows/hides season/episode number and release date fields depending on what
-  sorting has been selected for the associated Series.
+Currently, this includes the following features:
+* Creates a new `series_sort_value` read-only field (i.e not editable via the CMS).
+  This stores a calculated value for sorting based on the series that the content is associated with.
+  Either season + episode number, or release date.  This allows for easy sorting via JSON:API by re-using of the same
+  field.  Also, for DESC direction, all the values of the field are inverted, so you should always use ASC direction
+  when running queries.
+  e.g. /jsonapi/node/moj_video_item?filter[field_moj_series.meta.drupal_internal__tid]=123&sort=series_sort_value
+* Adds a tab to Series and Secondary tags taxonomy pages that displays a list of content in the same order as it would
+  on the frontend.
+* Shows/hides season/episode number and release date fields depending on what sorting has been selected for the
+  associated Series.
 

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Install and update hooks for the prisoner_hub_taxonomy_sorting module.
+ */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Add the series_sort_value field to the node entity type.
+ */
+function prisoner_hub_taxonomy_sorting_update_9001(&$sandbox) {
+  $definition = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node')['series_sort_value'];
+  \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
+
+}
+
+/**
+ * Bulk populate values for series_sort_value field.
+ */
+function prisoner_hub_taxonomy_sorting_update_9002(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $query = \Drupal::entityQuery('node');
+    // Get all nodes tagged with "Youth female".
+    $query->exists('field_moj_series');
+    $query->accessCheck(FALSE);
+    $sandbox['result'] = $query->execute();
+  }
+
+  $nodes = Node::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], 100, TRUE));
+
+  foreach ($nodes as $node) {
+    /** @var \Drupal\node\NodeInterface $node */
+    // Resave the node to invoke hook_entity_presave().
+    $node->save();
+    $sandbox['progress']++;
+  }
+  $sandbox['#finished'] = $sandbox['progress'] >= count($sandbox['result']);
+  return 'Processed nodes: ' . $sandbox['progress'];
+}

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -5,7 +5,11 @@
  * Primary hook implementations for Prisoner hub taxonomy sorting module.
  */
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -45,7 +49,7 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
             [
               $terms_with_episode_sorting,
             ],
-        ]
+        ],
       ];
     }
 
@@ -59,8 +63,112 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
             [
               $terms_with_release_date_sorting,
             ],
-        ]
+        ],
       ];
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Create the series_sort_value base field.
+ * Note that a one-off call to actually create the field is required.
+ * See prisoner_hub_taxonomy_sorting_update_9001().
+ */
+function prisoner_hub_taxonomy_sorting_entity_base_field_info(\Drupal\Core\Entity\EntityTypeInterface $entity_type) {
+  $fields = [];
+  if ($entity_type->id() === 'node') {
+    $fields['series_sort_value'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Series sort value'))
+      ->setDescription(t('A calculated sorting value for a content within a series.'))
+      ->setReadOnly(TRUE);
+  }
+  return $fields;
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Copy sorting value from either season+episode OR release date fields to the
+ * series_sort_value field.
+ */
+function prisoner_hub_taxonomy_sorting_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity instanceof ContentEntityInterface && $entity->hasField('field_moj_series')) {
+    $series_result = $entity->get('field_moj_series')->referencedEntities();
+    if (empty($series_result)) {
+      // No series attached to content, do nothing.
+      return;
+    }
+    $series_entity = current($series_result);
+    $sort_by_value = $series_entity->get('field_sort_by')->getString();
+    switch ($sort_by_value) {
+      case 'season_and_episode_asc':
+      case 'season_and_episode_desc':
+        $season_number = $entity->get('field_moj_season')->getString();
+        $episode_number = $entity->get('field_moj_episode')->getString();
+
+        // If either season or episode number is empty, set the value to 0 and
+        // warn the user.  This should only ever happen if content is being
+        // bulk updated. (As when editing the content directly, the fields are
+        // made mandatory).
+        if (empty($season_number) || empty($episode_number)) {
+          $link = Link::fromTextAndUrl($entity->label(), $entity->toUrl());
+          \Drupal::messenger()->addWarning(t('Missing season or episode number for :link. This could effect how the content is sorted within a series.', [':link' => $link->toString()]));
+          $calculated_sort_value = 0;
+        }
+        else {
+          // Episode number must be padded to account for the different lengths
+          // upto 999.  E.g. season 1 episode 15 could be mixed up
+          // with season 11 episode 5.
+          $episode_number_padded = str_pad($episode_number, 3, '0', STR_PAD_LEFT);
+          $calculated_sort_value = (int)$season_number . $episode_number_padded;
+        }
+        break;
+      case 'release_date_asc':
+      case 'release_date_desc':
+        if ($entity->field_release_date->date) {
+          $calculated_sort_value = $entity->field_release_date->date->getTimestamp();
+        }
+        else {
+          // If release date field is empty, set the value to 0 and
+          // warn the user.  This should only ever happen if content is being
+          // bulk updated. (As when editing the content directly, the field is
+          // made mandatory).
+          $link = Link::fromTextAndUrl($entity->label(), $entity->toUrl());
+          \Drupal::messenger()->addWarning(t('Missing release date for :link. This could effect how the content is sorted within a series.', [':link' => $link->toString()]));
+          $calculated_sort_value = 0;
+        }
+        break;
+    }
+
+    // If the sorting is descending, cast this as a negative number to invert
+    // the direction.  This allows us to always use ASC direction when running
+    // queries, e.g. through JSON:API.
+    if (substr($sort_by_value, -4) == 'desc') {
+      $calculated_sort_value = -$calculated_sort_value;
+    }
+    $entity->set('series_sort_value', $calculated_sort_value);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ *
+ * Check to see whether the sort_by value has changed on a series.
+ * If so, update all the content associated with that series.
+ */
+function prisoner_hub_taxonomy_sorting_entity_update(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity instanceof ContentEntityInterface && $entity->hasField('field_sort_by')) {
+    /** @var ContentEntityInterface $original_entity */
+    if ($entity->original->get('field_sort_by')->getString() != $entity->get('field_sort_by')->getString()) {
+      $results = \Drupal::entityQuery('node')->condition('field_moj_series', $entity->id())->execute();
+      $nodes = Node::loadMultiple($results);
+      /** @var \Drupal\node\NodeInterface $node */
+      foreach ($nodes as $node) {
+        // Resave the node to invoke hook_entity_presave().
+        $node->save();
+      }
     }
   }
 }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -64,18 +64,3 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
     }
   }
 }
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * Remove "operator" on all views exposed forms, as it's confusing terminology.
- * This is a temporary workaround before we upgrade to Drupal 9.
- * See https://www.drupal.org/project/drupal/issues/2625136
- */
-function prisoner_hub_taxonomy_sorting_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  foreach ($form as &$field) {
-    if (isset($field['#title']) && $field['#title'] == 'Operator') {
-      unset($field['#title']);
-    }
-  }
-}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/EyX2RFzY/254-switch-to-jsonapi-for-series-pages

### Intent

This PR adds a new `series_sort_value` field, which stores the calculated value for sorting of an episode within a series.  It is based on what type of sorting has been selected for the series. 

If sorting by season+episode number is selected, the field will be a concatenation of season and episode (with episode number padded to three digits).  E.g. season 1, episode 13 will be 1013.  Season 15 episode 2 will be 15002.

If sorting by release date is selected, then the field will be the timestamp of the `field_release_date`.  E.g. 1629388758

If sorting by DESC is selected (i.e. Newest first), then the values are inverted to negative values.  
E.g. -1013, or -1629388758 (from the examples above).

The goal is to have one method for sorting via JSON:API.  So you would always use the same field and direction.  With this PR, you can use something like:
`/jsonapi/node?filter[field_moj_series.meta.drupal_internal__tid]=123&sort=series_sort_value`
And this will work for all types of sorting selected on the series.


> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
