### PR TITLE
Disable all outgoing emails, to keep the logs a little bit tidier.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
@@ -22,3 +22,14 @@ function prisoner_content_hub_profile_toolbar_alter(&$items) {
   // users to prisons).
   unset($items['home']);
 }
+
+
+/**
+ * Implements hook_mail_alter().
+ *
+ * Disable all email messages from being sent, as they just result in an error
+ * in the logs.
+ */
+function prisoner_content_hub_profile_mail_alter(&$message) {
+  $message['send'] = FALSE;
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/VWPKV7Rs/212-stop-email-error-messages-appearing-in-the-logs

### Intent

This PR essentially disables all emails Drupal tries to send, from being sent.

As we do not have a mailing service, all outgoing emails result in an error in the logs.  As this happens fairly frequently (e.g. on every cron run), it causes a large amount of unnecessary log entries.

Emails are typically sent out on cron runs (to notify the "site owner" or updates) and when a user tries to reset their password.

### Considerations

Whilst this PR disables the email from being sent, a user can still access the "Reset my password" page, fill out their email, and submit the form.  Nothing is shown to the user to let them know this process doesn't work.
We did discuss removing this in https://trello.com/c/szjwBSkb/85-remove-reset-password-functionality-as-it-doesnt-work but decided we would instead wait to implement HMPPS auth (which will then replace the reset password functionality).
However, as it's unlikely we will implement HMPPS auth in the near future, we may want to do something about the reset password page (such as disabling it, or providing alternative info on how to reset the password such as who to contact).

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
