### PR TITLE
Limiting series field to one item.

### DIFF
--- a/config/sync/field.storage.node.field_moj_series.yml
+++ b/config/sync/field.storage.node.field_moj_series.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -28,10 +28,10 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
       /* @var \Drupal\taxonomy\TermInterface $term */
       $sort_by_value = $term->get('field_sort_by')->getValue();
       if (in_array($sort_by_value[0]['value'], ['season_and_episode_desc', 'season_and_episode_asc'])) {
-        $terms_with_episode_sorting[] = ['value' => [$term->id()]];
+        $terms_with_episode_sorting[] = ['value' => $term->id()];
       }
       elseif (in_array($sort_by_value[0]['value'], ['release_date_desc', 'release_date_asc'])) {
-        $terms_with_release_date_sorting[] = ['value' => [$term->id()]];
+        $terms_with_release_date_sorting[] = ['value' => $term->id()];
       }
     }
 
@@ -41,10 +41,7 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
     else {
       $element['group_season_and_episode_number']['#states'] = [
         'visible' => [
-          ':input[name="field_moj_series[]"]' =>
-            [
-              $terms_with_episode_sorting,
-            ],
+          ':input[name="field_moj_series"]' => $terms_with_episode_sorting
         ]
       ];
     }
@@ -55,10 +52,7 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
     else {
       $element['group_release_date']['#states'] = [
         'visible' => [
-          ':input[name="field_moj_series[]"]' =>
-            [
-              $terms_with_release_date_sorting,
-            ],
+          ':input[name="field_moj_series"]' => $terms_with_release_date_sorting
         ]
       ];
     }

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -127,3 +127,19 @@ function prisoner_content_hub_profile_update_8013() {
     $file_usage->add($file, 'file', 'node', $row->entity_id);
   }
 }
+
+/**
+ * Update content assigned with more than one series, to be part of just one
+ * series.
+ */
+function prisoner_content_hub_profile_update_8014() {
+  $query = \Drupal::entityQuery('node')->condition('field_moj_series.%delta', 0, '>')->accessCheck(FALSE);
+  $results = $query->execute();
+  $nodes = Node::loadMultiple($results);
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($nodes as $node) {
+    $field_value = $node->get('field_moj_series')->get(0)->getValue();
+    $node->set('field_moj_series', $field_value);
+    $node->save();
+  }
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/I3GkyBuT/113-only-allow-content-to-be-linked-to-one-series

### Intent

Updates the `field_moj_series` to accept just one item.
Includes an update hook to set all existing content with more than one series to just have the first series they were associated with.

### Considerations


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
