### PR TITLE
Adding description field as an exposed filter. …

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -1430,6 +1430,50 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
+        field_moj_description_value:
+          id: field_moj_description_value
+          table: node__field_moj_description
+          field: field_moj_description_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_moj_description_value_op
+            label: Description
+            description: ''
+            use_operator: true
+            operator: field_moj_description_value_op
+            operator_limit_selection: false
+            operator_list:
+              contains: contains
+            identifier: field_moj_description_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts: {  }
       title: Content
       empty:
@@ -1512,45 +1556,67 @@ display:
                   title: General
                   description: ''
                   open: '1'
-                  weight: '-31'
+                  weight: '-35'
                   id: container-2
                   pid: root
                   depth: '1'
                   type: container
                 title:
-                  weight: '-27'
+                  weight: '-33'
                   id: title
                   pid: container-2
                   depth: '2'
                   type: filter
                 nid:
-                  weight: '-26'
+                  weight: '-32'
                   id: nid
                   pid: container-2
                   depth: '2'
                   type: filter
                 type:
-                  weight: '-25'
+                  weight: '-31'
                   id: type
                   pid: container-2
                   depth: '2'
                   type: filter
                 status:
-                  weight: '-24'
+                  weight: '-30'
                   id: status
                   pid: container-2
                   depth: '2'
                   type: filter
                 field_moj_category_featured_item_value:
-                  weight: '-23'
+                  weight: '-29'
                   id: field_moj_category_featured_item_value
                   pid: container-2
                   depth: '2'
                   type: filter
                 uid:
-                  weight: '-22'
+                  weight: '-28'
                   id: uid
                   pid: container-2
+                  depth: '2'
+                  type: filter
+                container-6:
+                  container_type: details
+                  title: Description
+                  description: ''
+                  open: '1'
+                  weight: '-34'
+                  id: container-6
+                  pid: root
+                  depth: '1'
+                  type: container
+                field_moj_description_value_op:
+                  weight: '-35'
+                  id: field_moj_description_value_op
+                  pid: container-6
+                  depth: '2'
+                  type: filter
+                field_moj_description_value:
+                  weight: '-34'
+                  id: field_moj_description_value
+                  pid: container-6
                   depth: '2'
                   type: filter
                 container-1:
@@ -1558,7 +1624,7 @@ display:
                   title: Taxonomy
                   description: ''
                   open: '1'
-                  weight: '-30'
+                  weight: '-31'
                   id: container-1
                   pid: root
                   depth: '1'
@@ -1586,7 +1652,7 @@ display:
                   title: Prisons
                   description: ''
                   open: '1'
-                  weight: '-29'
+                  weight: '-30'
                   id: container-0
                   pid: root
                   depth: '1'
@@ -1608,7 +1674,7 @@ display:
                   title: 'Prison categories'
                   description: ''
                   open: '1'
-                  weight: '-28'
+                  weight: '-29'
                   id: container-5
                   pid: root
                   depth: '1'
@@ -1630,38 +1696,28 @@ display:
                   title: ''
                   description: ''
                   open: '1'
-                  weight: '-27'
+                  weight: '-28'
                   id: container-3
                   pid: root
                   depth: '1'
                   type: container
                 submit:
-                  weight: '-31'
+                  weight: '-35'
                   id: submit
                   pid: container-3
                   depth: '2'
                   type: buttons
                 reset:
-                  weight: '-30'
+                  weight: '-34'
                   id: reset
                   pid: container-3
                   depth: '2'
                   type: buttons
-                container-6:
-                  container_type: details
-                  title: 'Container 5'
-                  description: ''
-                  weight: '-25'
-                  open: 0
-                  id: container-6
-                  pid: root
-                  depth: '1'
-                  type: container
                 container-4:
                   container_type: details
                   title: 'Container 6'
                   description: ''
-                  weight: '-24'
+                  weight: '-27'
                   open: 0
                   id: container-4
                   pid: root
@@ -1671,7 +1727,7 @@ display:
                   container_type: details
                   title: 'Container 7'
                   description: ''
-                  weight: '-23'
+                  weight: '-26'
                   open: 0
                   id: container-7
                   pid: root
@@ -1681,7 +1737,7 @@ display:
                   container_type: details
                   title: 'Container 8'
                   description: ''
-                  weight: '-22'
+                  weight: '-25'
                   open: 0
                   id: container-8
                   pid: root
@@ -1691,7 +1747,7 @@ display:
                   container_type: details
                   title: 'Container 9'
                   description: ''
-                  weight: '-21'
+                  weight: '-24'
                   open: 0
                   id: container-9
                   pid: root
@@ -1701,7 +1757,7 @@ display:
                   container_type: details
                   title: 'Container 10'
                   description: ''
-                  weight: '-20'
+                  weight: '-23'
                   open: 0
                   id: container-10
                   pid: root
@@ -1711,7 +1767,7 @@ display:
                   container_type: details
                   title: 'Container 11'
                   description: ''
-                  weight: '-19'
+                  weight: '-22'
                   open: 0
                   id: container-11
                   pid: root
@@ -1721,7 +1777,7 @@ display:
                   container_type: details
                   title: 'Container 12'
                   description: ''
-                  weight: '-18'
+                  weight: '-21'
                   open: 0
                   id: container-12
                   pid: root
@@ -1731,7 +1787,7 @@ display:
                   container_type: details
                   title: 'Container 13'
                   description: ''
-                  weight: '-17'
+                  weight: '-20'
                   open: 0
                   id: container-13
                   pid: root
@@ -1741,9 +1797,29 @@ display:
                   container_type: details
                   title: 'Container 14'
                   description: ''
-                  weight: '-16'
+                  weight: '-19'
                   open: 0
                   id: container-14
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-15:
+                  container_type: details
+                  title: 'Container 15'
+                  description: ''
+                  weight: '-18'
+                  open: 0
+                  id: container-15
+                  pid: root
+                  depth: '1'
+                  type: container
+                container-16:
+                  container_type: details
+                  title: 'Container 16'
+                  description: ''
+                  weight: '-17'
+                  open: 0
+                  id: container-16
                   pid: root
                   depth: '1'
                   type: container

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -1437,7 +1437,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
+          operator: contains
           value: ''
           group: 1
           exposed: true
@@ -1447,9 +1447,17 @@ display:
             description: ''
             use_operator: true
             operator: field_moj_description_value_op
-            operator_limit_selection: false
+            operator_limit_selection: true
             operator_list:
               contains: contains
+              word: word
+              allwords: allwords
+              not: not
+              shorterthan: shorterthan
+              longerthan: longerthan
+              regular_expression: regular_expression
+              empty: empty
+              'not empty': 'not empty'
             identifier: field_moj_description_value
             required: false
             remember: false


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't warrant a card.

### Intent

This PR adds the description field as a filter to the /admin/content page, which can be used to search for embedded urls.

We've been seeing lots of 404s appearing in the logs recently.  Some of which are from embedded links inside pages.  Adding this filter will allow the content team to search through the site for places where they should be updated.

<img width="1225" alt="Screenshot 2021-09-01 at 16 06 43" src="https://user-images.githubusercontent.com/436483/131698648-f60d67de-e4ed-4391-9723-fe59a0648a88.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
