### PR TITLE
Update change episode order page 

### DIFF
--- a/config/sync/views.view.series_taxonomy_term_content_sorting.yml
+++ b/config/sync/views.view.series_taxonomy_term_content_sorting.yml
@@ -4,9 +4,9 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.moj_pdf_item.field_moj_episode
-    - field.field.node.moj_pdf_item.field_moj_season
-    - field.field.node.moj_pdf_item.field_release_date
+    - field.field.node.moj_radio_item.field_moj_episode
+    - field.field.node.moj_radio_item.field_moj_season
+    - field.field.node.moj_radio_item.field_release_date
     - field.storage.node.field_moj_category_featured_item
     - field.storage.node.field_moj_secondary_tags
     - field.storage.node.field_moj_top_level_categories
@@ -62,29 +62,19 @@ display:
         options:
           offset: 0
       sorts:
-        field_moj_season_value:
-          id: field_moj_season_value
-          table: node__field_moj_season
-          field: field_moj_season_value
+        series_sort_value:
+          id: series_sort_value
+          table: node_field_data
+          field: series_sort_value
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
+          order: ASC
           exposed: false
           expose:
             label: ''
-          plugin_id: standard
-        field_moj_episode_value:
-          id: field_moj_episode_value
-          table: node__field_moj_episode
-          field: field_moj_episode_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
+          entity_type: node
+          entity_field: series_sort_value
           plugin_id: standard
       arguments:
         tid_1:
@@ -1128,9 +1118,9 @@ display:
         - user.permissions
       max-age: -1
       tags:
-        - 'config:field.field.node.moj_pdf_item.field_moj_episode'
-        - 'config:field.field.node.moj_pdf_item.field_moj_season'
-        - 'config:field.field.node.moj_pdf_item.field_release_date'
+        - 'config:field.field.node.moj_radio_item.field_moj_episode'
+        - 'config:field.field.node.moj_radio_item.field_moj_season'
+        - 'config:field.field.node.moj_radio_item.field_release_date'
         - 'config:field.storage.node.field_moj_category_featured_item'
         - 'config:field.storage.node.field_moj_episode'
         - 'config:field.storage.node.field_moj_season'
@@ -1140,10 +1130,11 @@ display:
   embed_1:
     display_plugin: embed
     id: embed_1
-    display_title: 'Episode number DESC'
+    display_title: 'All sorting options/directions'
     position: 2
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        views_ef_fieldset: {  }
       display_description: ''
     cache_metadata:
       max-age: -1
@@ -1155,149 +1146,9 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.field.node.moj_pdf_item.field_moj_episode'
-        - 'config:field.field.node.moj_pdf_item.field_moj_season'
-        - 'config:field.field.node.moj_pdf_item.field_release_date'
-        - 'config:field.storage.node.field_moj_category_featured_item'
-        - 'config:field.storage.node.field_moj_episode'
-        - 'config:field.storage.node.field_moj_season'
-        - 'config:field.storage.node.field_moj_secondary_tags'
-        - 'config:field.storage.node.field_moj_top_level_categories'
-        - 'config:field.storage.node.field_release_date'
-  embed_2:
-    display_plugin: embed
-    id: embed_2
-    display_title: 'Episode. number ASC'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      display_description: ''
-      sorts:
-        field_moj_season_value:
-          id: field_moj_season_value
-          table: node__field_moj_season
-          field: field_moj_season_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-        field_moj_episode_value:
-          id: field_moj_episode_value
-          table: node__field_moj_episode
-          field: field_moj_episode_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-      defaults:
-        sorts: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - user
-        - 'user.node_grants:view'
-        - user.permissions
-      tags:
-        - 'config:field.field.node.moj_pdf_item.field_moj_episode'
-        - 'config:field.field.node.moj_pdf_item.field_moj_season'
-        - 'config:field.field.node.moj_pdf_item.field_release_date'
-        - 'config:field.storage.node.field_moj_category_featured_item'
-        - 'config:field.storage.node.field_moj_episode'
-        - 'config:field.storage.node.field_moj_season'
-        - 'config:field.storage.node.field_moj_secondary_tags'
-        - 'config:field.storage.node.field_moj_top_level_categories'
-        - 'config:field.storage.node.field_release_date'
-  embed_3:
-    display_plugin: embed
-    id: embed_3
-    display_title: 'Release date DESC'
-    position: 4
-    display_options:
-      display_extenders: {  }
-      display_description: ''
-      sorts:
-        field_release_date_value:
-          id: field_release_date_value
-          table: node__field_release_date
-          field: field_release_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
-      defaults:
-        sorts: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - user
-        - 'user.node_grants:view'
-        - user.permissions
-      tags:
-        - 'config:field.field.node.moj_pdf_item.field_moj_episode'
-        - 'config:field.field.node.moj_pdf_item.field_moj_season'
-        - 'config:field.field.node.moj_pdf_item.field_release_date'
-        - 'config:field.storage.node.field_moj_category_featured_item'
-        - 'config:field.storage.node.field_moj_episode'
-        - 'config:field.storage.node.field_moj_season'
-        - 'config:field.storage.node.field_moj_secondary_tags'
-        - 'config:field.storage.node.field_moj_top_level_categories'
-        - 'config:field.storage.node.field_release_date'
-  embed_4:
-    display_plugin: embed
-    id: embed_4
-    display_title: 'Release date ASC'
-    position: 5
-    display_options:
-      display_extenders: {  }
-      display_description: ''
-      sorts:
-        field_release_date_value:
-          id: field_release_date_value
-          table: node__field_release_date
-          field: field_release_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
-      defaults:
-        sorts: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - user
-        - 'user.node_grants:view'
-        - user.permissions
-      tags:
-        - 'config:field.field.node.moj_pdf_item.field_moj_episode'
-        - 'config:field.field.node.moj_pdf_item.field_moj_season'
-        - 'config:field.field.node.moj_pdf_item.field_release_date'
+        - 'config:field.field.node.moj_radio_item.field_moj_episode'
+        - 'config:field.field.node.moj_radio_item.field_moj_season'
+        - 'config:field.field.node.moj_radio_item.field_release_date'
         - 'config:field.storage.node.field_moj_category_featured_item'
         - 'config:field.storage.node.field_moj_episode'
         - 'config:field.storage.node.field_moj_season'

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/Controller/SeriesPageController.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/Controller/SeriesPageController.php
@@ -23,30 +23,6 @@ class SeriesPageController extends ControllerBase {
    */
   public function renderPage(TermInterface $taxonomy_term) {
     $view_name = 'series_taxonomy_term_content_sorting';
-    $sort_by_field_value = $taxonomy_term->get('field_sort_by')->getValue();
-    switch ($sort_by_field_value[0]['value']) {
-      case 'season_and_episode_asc':
-        $view_display_id = 'embed_2';
-        break;
-
-      case 'release_date_desc':
-        $view_display_id = 'embed_3';
-        break;
-
-      case 'release_date_asc':
-        $view_display_id = 'embed_4';
-        break;
-
-      case 'season_and_episode_desc':
-      default:
-        $view_display_id = 'embed_1';
-    }
-    $view = Views::getView($view_name);
-    return $view->buildRenderable($view_display_id, [$taxonomy_term->id()]);
-  }
-
-  public function renderChangeContentOrderPage(TermInterface $taxonomy_term) {
-    $view_name = 'seconday_tag_term_content_sorting';
     $view_display_id = 'embed_1';
     $view = Views::getView($view_name);
     return $view->buildRenderable($view_display_id, [$taxonomy_term->id()]);


### PR DESCRIPTION
### Context

Related to https://trello.com/c/EyX2RFzY/254-switch-to-jsonapi-for-series-pages

### Intent

Now that https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/238 has been merged in, this PR updates the "Change episode order" page to use the new field for sorting.  

The "Change episode order" page appears as a tab when editing a series or secondary tag. 
<img width="1229" alt="Screenshot 2021-09-03 at 11 32 08" src="https://user-images.githubusercontent.com/436483/131991866-e726f161-cf10-4fc8-b684-49581787c30f.png">

Note that there should be no visual change to the page, it should behave in exactly the same way as before.  We are just simplifying how the sorting is done, and aligning it with how sorting will be achieved through JSON:API.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
