### PR TITLE
Fix deployment health check issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "drupal/jsonapi_image_styles": "^2.0@beta",
         "drupal/jsonapi_page_limit": "^1.0@beta",
         "drupal/jsonapi_search_api": "^1.0@RC",
+        "drupal/maintenance_exempt": "1.x-dev",
         "drupal/memcache": "^2.0",
         "drupal/migrate_tools": "^4.1",
         "drupal/monolog": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8378dc8ab31f845b96c46ea954455517",
+    "content-hash": "e3ad04e0c2a9eb3a5e40bd2260bad410",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3131,6 +3131,56 @@
                 "source": "https://git.drupalcode.org/project/jsonapi_search_api",
                 "issues": "https://www.drupal.org/project/issues/jsonapi_search_api"
             }
+        },
+        {
+            "name": "drupal/maintenance_exempt",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/maintenance_exempt.git",
+                "reference": "600d77d213d58c1c2c2e01d4a577b4640f00472e"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.2+2-dev",
+                    "datestamp": "1593615521",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "RandallKent",
+                    "homepage": "https://www.drupal.org/user/164904"
+                },
+                {
+                    "name": "malcomio",
+                    "homepage": "https://www.drupal.org/user/418511"
+                },
+                {
+                    "name": "webchick",
+                    "homepage": "https://www.drupal.org/user/24967"
+                }
+            ],
+            "description": "Allow exemption of maintenance mode based on either certain set IP addresses or matching a set query string value.",
+            "homepage": "https://www.drupal.org/project/maintenance_exempt",
+            "support": {
+                "source": "https://git.drupalcode.org/project/maintenance_exempt"
+            },
+            "time": "2020-07-01T14:58:15+00:00"
         },
         {
             "name": "drupal/memcache",
@@ -13598,6 +13648,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
@@ -14621,6 +14672,7 @@
         "drupal/jsonapi_image_styles": 10,
         "drupal/jsonapi_page_limit": 10,
         "drupal/jsonapi_search_api": 5,
+        "drupal/maintenance_exempt": 20,
         "drupal/taxonomy_machine_name": 20,
         "drupal/theme_switcher": 20,
         "drupal/views_entity_form_field": 10

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -38,6 +38,7 @@ module:
   layout_builder: 0
   layout_discovery: 0
   link: 0
+  maintenance_exempt: 0
   menu_ui: 0
   moj: 0
   moj_healthcheck: 0

--- a/config/sync/maintenance_exempt.settings.yml
+++ b/config/sync/maintenance_exempt.settings.yml
@@ -1,0 +1,3 @@
+exempt_ips: ''
+exempt_urls: "/health\r\n/jsonapi/*\r\n/api/*\r\n/v2/api/*"
+query_key: ''

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.deploy.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.deploy.php
@@ -47,7 +47,6 @@ function prisoner_hub_taxonomy_sorting_deploy_set_series_value_field(&$sandbox) 
     $query = \Drupal::entityQuery('node');
     // Get all nodes tagged with "Youth female".
     $query->exists('field_moj_series');
-    $query->accessCheck(FALSE);
     $sandbox['result'] = $query->execute();
   }
 

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
@@ -15,28 +15,3 @@ function prisoner_hub_taxonomy_sorting_update_9001(&$sandbox) {
   \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
 
 }
-
-/**
- * Bulk populate values for series_sort_value field.
- */
-function prisoner_hub_taxonomy_sorting_update_9002(&$sandbox) {
-  if (!isset($sandbox['progress'])) {
-    $sandbox['progress'] = 0;
-    $query = \Drupal::entityQuery('node');
-    // Get all nodes tagged with "Youth female".
-    $query->exists('field_moj_series');
-    $query->accessCheck(FALSE);
-    $sandbox['result'] = $query->execute();
-  }
-
-  $nodes = Node::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], 100, TRUE));
-
-  foreach ($nodes as $node) {
-    /** @var \Drupal\node\NodeInterface $node */
-    // Resave the node to invoke hook_entity_presave().
-    $node->save();
-    $sandbox['progress']++;
-  }
-  $sandbox['#finished'] = $sandbox['progress'] >= count($sandbox['result']);
-  return 'Processed nodes: ' . $sandbox['progress'];
-}


### PR DESCRIPTION
### Context

The deployments on main branch are currently failing, the k8ns fails and the pods are restarted.
Because the Drupal site gets put into maintenance mode during the deployment, and this disables the health check.

### Intent
This PR does two things:
1) Installs the maintenance_exempt module, and configures it to allow the health check, JSONAPI, and REST api urls to still be accessible when the site is in maintenance mode.
2) Moves the problematic update hook to a deploy hook, which does not operate in maintenance mode.


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
