### PR TITLE
Fix issue with missing sort values

### DIFF
--- a/config/sync/field.field.node.moj_pdf_item.field_release_date.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_release_date.yml
@@ -15,7 +15,10 @@ label: Date
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/config/sync/field.field.node.moj_radio_item.field_release_date.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_release_date.yml
@@ -15,7 +15,10 @@ label: Date
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/config/sync/field.field.node.moj_video_item.field_release_date.yml
+++ b/config/sync/field.field.node.moj_video_item.field_release_date.yml
@@ -15,7 +15,10 @@ label: Date
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/config/sync/field.field.node.page.field_release_date.yml
+++ b/config/sync/field.field.node.page.field_release_date.yml
@@ -15,7 +15,10 @@ label: Date
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -43,22 +43,20 @@ function prisoner_hub_taxonomy_sorting_field_group_form_process_build_alter(arra
       hide($element['group_season_and_episode_number']);
     }
     else {
-      $element['group_season_and_episode_number']['#states'] = [
-        'visible' => [
-          ':input[name="field_moj_series"]' => $terms_with_episode_sorting
-        ]
-      ];
+      $element['group_season_and_episode_number']['#states']['visible'][':input[name="field_moj_series"]'] = $terms_with_episode_sorting;
+      $element['field_moj_season']['widget'][0]['value']['#states']['required'][':input[name="field_moj_series"]'] = $terms_with_episode_sorting;
+      $element['field_moj_episode']['widget'][0]['value']['#states']['required'][':input[name="field_moj_series"]'] = $terms_with_episode_sorting;
     }
 
     if (empty($terms_with_release_date_sorting)) {
       hide($element['group_release_date']);
     }
     else {
-      $element['group_release_date']['#states'] = [
-        'visible' => [
-          ':input[name="field_moj_series"]' => $terms_with_release_date_sorting
-        ]
-      ];
+      $element['group_release_date']['#states']['visible'][':input[name="field_moj_series"]'] = $terms_with_release_date_sorting;
+      // Currently we cannot set a required state for field_release_date.
+      // See https://www.drupal.org/project/drupal/issues/2419131
+      // However, this field has a default value (of the current date),
+      // so it's less likely to not be set.
     }
   }
 }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -112,8 +112,7 @@ function prisoner_hub_taxonomy_sorting_entity_presave(Drupal\Core\Entity\EntityI
           // to 0 and warn the user.  This should only ever happen if content is
           // being bulk updated. (As when editing the content directly, the
           // fields are made mandatory and dont allow numbers outside the range).
-          $link = Link::fromTextAndUrl($entity->label(), $entity->toUrl());
-          \Drupal::messenger()->addWarning(t('Missing season or episode number for :link. This could effect how the content is sorted within a series.', [':link' => $link->toString()]));
+          \Drupal::messenger()->addWarning(t('Missing season or episode number for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
           $calculated_sort_value = 0;
         }
         break;
@@ -127,8 +126,7 @@ function prisoner_hub_taxonomy_sorting_entity_presave(Drupal\Core\Entity\EntityI
           // warn the user.  This should only ever happen if content is being
           // bulk updated. (As when editing the content directly, the field is
           // made mandatory).
-          $link = Link::fromTextAndUrl($entity->label(), $entity->toUrl());
-          \Drupal::messenger()->addWarning(t('Missing release date for :link. This could effect how the content is sorted within a series.', [':link' => $link->toString()]));
+          \Drupal::messenger()->addWarning(t('Missing release date for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
           $calculated_sort_value = 0;
         }
         break;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No, this is an issue reported on Slack:

https://mojdt.slack.com/archives/C9EKLJ1QE/p1631176829002200

### Intent

The last deployment introduced a change where when content is saved, a sort value is calculated.  This value is based on the season+episode number fields *or* the release date field (depending on what series had been selected).

The error was caused when the value was empty, and the content was first being added.
This is because of a warning message printed out, which included a link to the content.  At this point, there was no url for the content, so there was a PHP error.

Also, to avoid user submitting empty values, I've made the season+episode number fields required.
The release date field I couldn't make required (due to an issue in drupal core, which is detailed in the code comments).  But instead the release date field is given a default value of today's date.  So a user would need to unset this, in order to submit an empty value.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
