### PR TITLE
Add delete file logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,9 @@
             },
             "drupal/views_ef_fieldset": {
                 "Issue #3173822: Exposed operators are not included in fieldsets": "patches/views_ef_fieldset_3173822-operator_issue-9.patch"
+            },
+            "drupal/jsonapi_image_styles": {
+                "Issue #3232157: Image styles are generated for other types of file entites": "patches/jsonapi_image_styles-3232157-image-styles-are-generated-for-other-types-of-file-entities-2.patch"
             }
         },
         "patches-ignore": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "drupal/jsonapi_search_api": "^1.0@RC",
         "drupal/maintenance_exempt": "1.x-dev",
         "drupal/memcache": "^2.0",
-        "drupal/migrate_tools": "^4.1",
+        "drupal/migrate_tools": "^5.0",
         "drupal/monolog": "^2.0",
         "drupal/pathauto": "^1.8",
         "drupal/profile_switcher": "1.0-alpha5",
@@ -164,6 +164,7 @@
         "drupal/console": "^1.9",
         "drupal/core-dev": "^9.0.0",
         "drupal/devel": "^4.0",
+        "phpspec/prophecy-phpunit": "^2",
         "weitzman/drupal-test-traits": "^1.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,8 @@
                 "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-56-private-files-image-styles.patch",
                 "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch",
                 "Issue #3219524 - CORS upload functionality doesn't work with Claro theme.": "patches/flysystem_s3-cors-upload-claro-theme-3219524-2.patch",
-                "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch"
+                "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch",
+                "Debug file deletions for https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue": "patches/flysystem_s3-add-delete-logging-for-debugging.patch"
             },
             "twistor/stream-util": {
                 "PR #3 - More robust version of getSize() ": "patches/stream_util-pr3-more-robust-version-of-getsize.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0d0e4623c7b85ea2003657947716fd5",
+    "content-hash": "5f8d22b4cf1225c6006b02b761a20a21",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2953,6 +2953,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Issue #3232157: Image styles are generated for other types of file entites": "patches/jsonapi_image_styles-3232157-image-styles-are-generated-for-other-types-of-file-entities-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f8d22b4cf1225c6006b02b761a20a21",
+    "content-hash": "66b7557904b9461d108f9b7e61241ff0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2675,7 +2675,8 @@
                     "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-56-private-files-image-styles.patch",
                     "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch",
                     "Issue #3219524 - CORS upload functionality doesn't work with Claro theme.": "patches/flysystem_s3-cors-upload-claro-theme-3219524-2.patch",
-                    "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch"
+                    "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch",
+                    "Debug file deletions for https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue": "patches/flysystem_s3-add-delete-logging-for-debugging.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3ad04e0c2a9eb3a5e40bd2260bad410",
+    "content-hash": "a0d0e4623c7b85ea2003657947716fd5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2926,29 +2926,32 @@
         },
         {
             "name": "drupal/jsonapi_image_styles",
-            "version": "2.0.0-beta1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/jsonapi_image_styles.git",
-                "reference": "2.0.0-beta1"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi_image_styles-2.0.0-beta1.zip",
-                "reference": "2.0.0-beta1",
-                "shasum": "d7a362ade6beeb2cdc378106dfe986f0ab464a0f"
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_image_styles-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "cc7f8172602cf5bd16483806e77cadc7f8543089"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8.8 || ^9"
+            },
+            "require-dev": {
+                "drupal/coder": "^8.3"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta1",
-                    "datestamp": "1603349829",
+                    "version": "2.0.0",
+                    "datestamp": "1629502460",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -2958,18 +2961,31 @@
             ],
             "authors": [
                 {
-                    "name": "jefuri",
-                    "homepage": "https://www.drupal.org/user/2733365"
+                    "name": "Alona O'neill",
+                    "homepage": "https://www.drupal.org/u/alonaoneill"
                 },
                 {
-                    "name": "kirkkala",
-                    "homepage": "https://www.drupal.org/user/390806"
+                    "name": "Timo Kirkkala",
+                    "homepage": "https://www.drupal.org/u/kirkkala"
+                },
+                {
+                    "name": "Jeffrey Bertoen",
+                    "homepage": "https://www.drupal.org/u/jefuri"
+                },
+                {
+                    "name": "Chrsitopher C. Wells (wells)",
+                    "homepage": "https://www.drupal.org/user/2452278",
+                    "email": "drupal.org@chris-wells.net"
                 }
             ],
-            "description": "Expose image styles to JSON:API",
+            "description": "JSON:API Image Styles provides a means to expose image styles to JSON:API.",
             "homepage": "https://www.drupal.org/project/jsonapi_image_styles",
+            "keywords": [
+                "Drupal"
+            ],
             "support": {
-                "source": "https://git.drupalcode.org/project/jsonapi_image_styles"
+                "source": "https://git.drupalcode.org/project/jsonapi_image_styles",
+                "issues": "https://www.drupal.org/project/issues/jsonapi_image_styles"
             }
         },
         {
@@ -3321,32 +3337,36 @@
         },
         {
             "name": "drupal/migrate_tools",
-            "version": "4.5.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/migrate_tools.git",
-                "reference": "8.x-4.5"
+                "reference": "8.x-5.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/migrate_tools-8.x-4.5.zip",
-                "reference": "8.x-4.5",
-                "shasum": "06390b359bf53c50a30f2d6dc4c7542bfb1fe7ca"
+                "url": "https://ftp.drupal.org/files/projects/migrate_tools-8.x-5.0.zip",
+                "reference": "8.x-5.0",
+                "shasum": "b7c91aa6f7de9d6d548f65f83c8736e47e5926a1"
             },
             "require": {
-                "drupal/core": "^8 || ^9",
-                "drupal/migrate_plus": "^4 || ^5"
+                "drupal/core": "^8.8 | ^9",
+                "drupal/migrate_plus": "^5",
+                "php": ">=7.1"
             },
             "require-dev": {
-                "drupal/migrate_plus": "4.x-dev",
-                "drupal/migrate_source_csv": "^2.2",
+                "drupal/migrate_plus": "^5",
+                "drupal/migrate_source_csv": "^3",
                 "drush/drush": "^10"
+            },
+            "suggest": {
+                "drush/drush": "^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.5",
-                    "datestamp": "1574693285",
+                    "version": "8.x-5.0",
+                    "datestamp": "1588260531",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3364,8 +3384,14 @@
             ],
             "authors": [
                 {
-                    "name": "drupalspoons",
-                    "homepage": "https://www.drupal.org/user/3647684"
+                    "name": "Mike Ryan",
+                    "homepage": "https://www.drupal.org/u/mikeryan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Lucas Hedding",
+                    "homepage": "https://www.drupal.org/u/heddn",
+                    "role": "Maintainer"
                 },
                 {
                     "name": "mikeryan",
@@ -3375,9 +3401,9 @@
             "description": "Tools to assist in developing and running migrations.",
             "homepage": "http://drupal.org/project/migrate_tools",
             "support": {
-                "source": "http://cgit.drupalcode.org/migrate_tools",
-                "issues": "http://drupal.org/project/migrate_tools",
-                "irc": "irc://irc.freenode.org/drupal-migrate"
+                "source": "https://git.drupalcode.org/project/migrate_tools",
+                "issues": "https://www.drupal.org/project/issues/migrate_tools",
+                "slack": "#migrate"
             }
         },
         {
@@ -12453,6 +12479,54 @@
                 "stub"
             ],
             "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/patches/flysystem_s3-add-delete-logging-for-debugging.patch
+++ b/patches/flysystem_s3-add-delete-logging-for-debugging.patch
@@ -1,0 +1,12 @@
+diff --git a/src/File/FlysystemS3FileSystem.php b/src/File/FlysystemS3FileSystem.php
+index 3cc4087..9f84db9 100644
+--- a/src/File/FlysystemS3FileSystem.php
++++ b/src/File/FlysystemS3FileSystem.php
+@@ -238,6 +238,7 @@ class FlysystemS3FileSystem extends FileSystem {
+    * @codeCoverageIgnore
+    */
+   public function delete($path) {
++    $this->logger->warning('File deleted: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
+     if (method_exists($this->fileSystem, 'delete')) {
+       return $this->fileSystem->delete($path);
+     }

--- a/patches/flysystem_s3-add-delete-logging-for-debugging.patch
+++ b/patches/flysystem_s3-add-delete-logging-for-debugging.patch
@@ -6,7 +6,7 @@ index 3cc4087..9f84db9 100644
     * @codeCoverageIgnore
     */
    public function delete($path) {
-+    $this->logger->warning('File deleted: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
++    $this->logger->warning('File deleted from S3: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
      if (method_exists($this->fileSystem, 'delete')) {
        return $this->fileSystem->delete($path);
      }

--- a/patches/jsonapi_image_styles-3232157-image-styles-are-generated-for-other-types-of-file-entities-2.patch
+++ b/patches/jsonapi_image_styles-3232157-image-styles-are-generated-for-other-types-of-file-entities-2.patch
@@ -1,0 +1,46 @@
+diff --git a/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php b/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php
+index caa1b70..63edfe3 100644
+--- a/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php
++++ b/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php
+@@ -21,24 +21,26 @@ protected function computeValue() {
+     $config = \Drupal::config('jsonapi_image_styles.settings');
+     $styles = [];
+     $entity = $this->getEntity();
+-    $uri = ($entity instanceof File) ? $entity->getFileUri() : FALSE;
+-
+-    $defined_styles = ($config->get('image_styles')) ? $config->get('image_styles') : [];
+-    if (!empty(array_filter($defined_styles))) {
+-      foreach ($defined_styles as $key) {
+-        $styles[$key] = ImageStyle::load($key);
++    $uri = ($entity instanceof File && substr($entity->getMimeType(), 0, 5) === 'image') ? $entity->getFileUri() : FALSE;
++
++    if ($uri) {
++      $defined_styles = ($config->get('image_styles')) ? $config->get('image_styles') : [];
++      if (!empty(array_filter($defined_styles))) {
++        foreach ($defined_styles as $key) {
++          $styles[$key] = ImageStyle::load($key);
++        }
++      }
++      else {
++        $styles = ImageStyle::loadMultiple();
+       }
+-    }
+-    else {
+-      $styles = ImageStyle::loadMultiple();
+-    }
+ 
+-    $offset = 0;
+-    foreach ($styles as $name => $style) {
+-      if ($style instanceof ImageStyle) {
+-        $this->list[] = $this->createItem($offset, ['url' => [$name => $style->buildUrl($uri)]]);
++      $offset = 0;
++      foreach ($styles as $name => $style) {
++        if ($style instanceof ImageStyle) {
++          $this->list[] = $this->createItem($offset, ['url' => [$name => $style->buildUrl($uri)]]);
++        }
++        $offset++;
+       }
+-      $offset++;
+     }
+   }
+ 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue

### Intent

This PR adds logging to when files are deleted from S3. This logging will only apply to files that are deleted through Drupal.  

Previously it was thought that files were never deleted in Drupal.  But since enabling S3 file logging https://github.com/ministryofjustice/cloud-platform-environments/pull/5497, we have discovered that Drupal is _sometimes_ deletes files.  We disabled logging https://github.com/ministryofjustice/cloud-platform-environments/pull/5551 as it was no longer required, and will use the logging provided by this PR to further investigate the issue.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
