### PR TITLE
Add delete file logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,8 @@
                 "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-56-private-files-image-styles.patch",
                 "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch",
                 "Issue #3219524 - CORS upload functionality doesn't work with Claro theme.": "patches/flysystem_s3-cors-upload-claro-theme-3219524-2.patch",
-                "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch"
+                "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch",
+                "Debug file deletions for https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue": "patches/flysystem_s3-add-delete-logging-for-debugging.patch"
             },
             "twistor/stream-util": {
                 "PR #3 - More robust version of getSize() ": "patches/stream_util-pr3-more-robust-version-of-getsize.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f8d22b4cf1225c6006b02b761a20a21",
+    "content-hash": "66b7557904b9461d108f9b7e61241ff0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2675,7 +2675,8 @@
                     "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-56-private-files-image-styles.patch",
                     "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch",
                     "Issue #3219524 - CORS upload functionality doesn't work with Claro theme.": "patches/flysystem_s3-cors-upload-claro-theme-3219524-2.patch",
-                    "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch"
+                    "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch",
+                    "Debug file deletions for https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue": "patches/flysystem_s3-add-delete-logging-for-debugging.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/patches/flysystem_s3-add-delete-logging-for-debugging.patch
+++ b/patches/flysystem_s3-add-delete-logging-for-debugging.patch
@@ -1,0 +1,12 @@
+diff --git a/src/File/FlysystemS3FileSystem.php b/src/File/FlysystemS3FileSystem.php
+index 3cc4087..9f84db9 100644
+--- a/src/File/FlysystemS3FileSystem.php
++++ b/src/File/FlysystemS3FileSystem.php
+@@ -238,6 +238,7 @@ class FlysystemS3FileSystem extends FileSystem {
+    * @codeCoverageIgnore
+    */
+   public function delete($path) {
++    $this->logger->warning('File deleted: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
+     if (method_exists($this->fileSystem, 'delete')) {
+       return $this->fileSystem->delete($path);
+     }

--- a/patches/flysystem_s3-add-delete-logging-for-debugging.patch
+++ b/patches/flysystem_s3-add-delete-logging-for-debugging.patch
@@ -6,7 +6,7 @@ index 3cc4087..9f84db9 100644
     * @codeCoverageIgnore
     */
    public function delete($path) {
-+    $this->logger->warning('File deleted: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
++    $this->logger->warning('File deleted from S3: !path \n !debug', ['!path' => $path, '!debug' => print_r($_SERVER, TRUE)]);
      if (method_exists($this->fileSystem, 'delete')) {
        return $this->fileSystem->delete($path);
      }


### PR DESCRIPTION
Context
Does this issue have a Trello card?

https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue

Intent
This PR adds logging to when files are deleted from S3. This logging will only apply to files that are deleted through Drupal.

Previously it was thought that files were never deleted in Drupal. But since enabling S3 file logging ministryofjustice/cloud-platform-environments#5497, we have discovered that Drupal is sometimes deletes files. We disabled logging ministryofjustice/cloud-platform-environments#5551 as it was no longer required, and will use the logging provided by this PR to further investigate the issue.

Considerations
Is there any additional information that would help when reviewing this PR?

Are there any steps required when merging/deploying this PR?

Checklist
 This PR contains only changes related to the above card
 Tests have been added/updated to cover the change
 Documentation has been updated where appropriate
 Tested in Development