### PR TITLE
Copy series summary to description

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -128,5 +128,12 @@ function prisoner_content_hub_profile_deploy_copy_summary(&$sandbox) {
   foreach ($terms as $term) {
     $term->set('description', $term->get('field_content_summary')->getValue());
     $term->save();
+    $sandbox['progress']++;
   }
+  
+  $sandbox['#finished'] = $sandbox['progress'] >= count($sandbox['result']);
+  if ($sandbox['#finished'] ) {
+    return 'Completed updated, processed total of: ' . $sandbox['progress'];
+  }
+  return 'Processed terms: ' . $sandbox['progress'];
 }

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -116,9 +116,14 @@ function prisoner_content_hub_profile_deploy_update_paths(&$sandbox) {
 /**
  * Update description field on series to have the content from summary field.
  */
-function prisoner_content_hub_profile_deploy_copy_summary() {
-  $result = \Drupal::entityQuery('taxonomy_term')->condition('vid', 'series')->execute();
-  $terms = Term::loadMultiple($result);
+function prisoner_content_hub_profile_deploy_copy_summary(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['result'] = $result = \Drupal::entityQuery('taxonomy_term')->condition('vid', 'series')->execute();
+  }
+
+  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], PRISONER_CONTENT_HUB_PROFILE_BATCH_LIMIT, TRUE));
+
   /** @var \Drupal\taxonomy\TermInterface $term */
   foreach ($terms as $term) {
     $term->set('description', $term->get('field_content_summary')->getValue());

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -122,7 +122,7 @@ function prisoner_content_hub_profile_deploy_copy_summary(&$sandbox) {
     $sandbox['result'] = $result = \Drupal::entityQuery('taxonomy_term')->condition('vid', 'series')->execute();
   }
 
-  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], PRISONER_CONTENT_HUB_PROFILE_BATCH_LIMIT, TRUE));
+  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], 100, TRUE));
 
   /** @var \Drupal\taxonomy\TermInterface $term */
   foreach ($terms as $term) {

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -112,3 +112,16 @@ function prisoner_content_hub_profile_deploy_update_paths(&$sandbox) {
   }
 
 }
+
+/**
+ * Update description field on series to have the content from summary field.
+ */
+function prisoner_content_hub_profile_deploy_copy_summary() {
+  $result = \Drupal::entityQuery('taxonomy_term')->condition('vid', 'series')->execute();
+  $terms = Term::loadMultiple($result);
+  /** @var \Drupal\taxonomy\TermInterface $term */
+  foreach ($terms as $term) {
+    $term->set('description', $term->get('field_content_summary')->getValue());
+    $term->save();
+  }
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/EyX2RFzY/112-switch-to-jsonapi-for-series-pages

### Intent

This PR is needed before we switch over JSON:API for series https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/361.  As part of the change, we will switch to using the description field for the intro text at the top of the page.  This will keep it inline with how all other content/taxonomy works on the Hub.

Currently there is a summary field, which is being used.  This PR copies over all the values from summary to description.

After both this PR and https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/361 have been deployed, we should then remove the previous field. This is in a separate PR https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/251

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
