### PR TITLE
Adding sentry as an output for monologger.

### DIFF
--- a/docroot/sites/default/services.yml
+++ b/docroot/sites/default/services.yml
@@ -175,7 +175,7 @@ parameters:
     supportsCredentials: false
 
   monolog.channel_handlers:
-    default: ["stream", "errStream"]
+    default: ["stream", "errStream", "drupal.raven"]
 
   jsonapi_page_limit.size_max: []
   jsonapi_page_limit.global_size_max: 100


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/xL7P4r7Z/274-fix-drupal-and-sentry-integration

### Intent

This should hopefully fix the Sentry integration, there appears to be an issue integrating with the monologger module (which was enabled to allow logging in cloud platform).

### Considerations

If this doesn't work, the next step would be to update the sentry module and client.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
