### PR TITLE
Set the Docker build stage to optimised-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build-deps:
 	composer install --no-dev --no-ansi --no-scripts --prefer-dist --ignore-platform-reqs --no-interaction --no-autoloader
 
 build:
-	docker build -t prisoner-content-hub-backend .
+	docker build -t prisoner-content-hub-backend:optimised-build .
 
 clean:
 	rm -rf modules/contrib


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't warrant a card.

### Intent

Docker multistage builds were introduced on this repo several months ago, however it appears that the build in circleCI for dev/staging/prod doesn't use the `optimised-build` stage, and instead runs through all stages (which includes steps for local and test environments).

This PR sets the correct build stage.

### Considerations

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
