### PR TITLE
Fix issue with cache clearing breaking jsonapi_cross_bundle routes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,8 @@
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
                 "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch",
-                "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch"
+                "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
+                "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache.": "https://www.drupal.org/files/issues/2021-04-19/2352009-max-age-bubbling-9.1.x.patch"
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch"
@@ -136,6 +137,9 @@
             },
             "drupal/jsonapi_image_styles": {
                 "Issue #3232157: Image styles are generated for other types of file entites": "patches/jsonapi_image_styles-3232157-image-styles-are-generated-for-other-types-of-file-entities-2.patch"
+            },
+            "drupal/jsonapi_cross_bundles": {
+                "Issue #3241626: 404 on cross bundle routes when uninstalling another module": "patches/jsonapi_cross_bundles-3241626-fix-404-on-cross-bundle-routes-when-uninstalling-another-module-2.patch"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7b6301d8c7bc85bc35042a8cc167f62",
+    "content-hash": "fbbdd4956c757be8a610b5a72cef0cc1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1834,7 +1834,8 @@
                 "patches_applied": {
                     "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
                     "Issue #3036593 - Allow jsonapi filters to work with bundle types (see #3085486).": "patches/drupal-3036593-123.patch",
-                    "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch"
+                    "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
+                    "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache.": "https://www.drupal.org/files/issues/2021-04-19/2352009-max-age-bubbling-9.1.x.patch"
                 }
             },
             "autoload": {
@@ -2914,6 +2915,11 @@
                 "reference": "c0c90e6ecdd894732a0ca58f6d6c314e9dc29f28"
             },
             "type": "drupal-module",
+            "extra": {
+                "patches_applied": {
+                    "Issue #3241626: 404 on cross bundle routes when uninstalling another module": "patches/jsonapi_cross_bundles-3241626-fix-404-on-cross-bundle-routes-when-uninstalling-another-module-2.patch"
+                }
+            },
             "license": [
                 "GPL-2.0+"
             ],

--- a/patches/jsonapi_cross_bundles-3241626-fix-404-on-cross-bundle-routes-when-uninstalling-another-module-2.patch
+++ b/patches/jsonapi_cross_bundles-3241626-fix-404-on-cross-bundle-routes-when-uninstalling-another-module-2.patch
@@ -1,0 +1,21 @@
+diff --git a/src/ResourceType/CrossBundleResourceTypeRepository.php b/src/ResourceType/CrossBundleResourceTypeRepository.php
+index db72946..40b9410 100644
+--- a/src/ResourceType/CrossBundleResourceTypeRepository.php
++++ b/src/ResourceType/CrossBundleResourceTypeRepository.php
+@@ -66,6 +66,8 @@ class CrossBundleResourceTypeRepository implements ResourceTypeRepositoryInterfa
+    * {@inheritdoc}
+    */
+   public function getByTypeName($type_name) {
++    // Ensure jsonapi.resource_types cache is generated from this class.
++    $this->all();
+     return $this->inner->getByTypeName($type_name);
+   }
+ 
+@@ -73,6 +75,7 @@ class CrossBundleResourceTypeRepository implements ResourceTypeRepositoryInterfa
+    * {@inheritdoc}
+    */
+   public function get($entity_type_id, $bundle) {
++    $this->all();
+     return $this->inner->get($entity_type_id, $bundle);
+   }
+ 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't warrant a card.

### Intent

Adding patch for jsonapi_cross_bundles to fix issue when caches are cleared. See https://www.drupal.org/project/jsonapi_cross_bundles/issues/3241626.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
