### PR TITLE
Revert "Set the Docker build stage to optimised-build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build-deps:
 	composer install --no-dev --no-ansi --no-scripts --prefer-dist --ignore-platform-reqs --no-interaction --no-autoloader
 
 build:
-	docker build -t prisoner-content-hub-backend:optimised-build .
+	docker build -t prisoner-content-hub-backend .
 
 clean:
 	rm -rf modules/contrib


### PR DESCRIPTION
Reverts ministryofjustice/prisoner-content-hub-backend#263

This appears to be causing issues with the deployment.

We have seen the wrong branch deployed to staging on two occasions.