### PR TITLE
Fix for series not appearing on landing pages

### DIFF
--- a/docroot/modules/custom/moj_resources/src/CategoryFeaturedContentApiClass.php
+++ b/docroot/modules/custom/moj_resources/src/CategoryFeaturedContentApiClass.php
@@ -207,7 +207,8 @@ class CategoryFeaturedContentApiClass
   {
     $loadedTerms = $this->termStorage->loadMultiple($termIds);
     $promotedTerms = array_filter($loadedTerms, function ($term) use ($prisonId) {
-      if ($term->field_moj_category_featured_item->value == true && $prisonId == $term->field_moj_prisons->target_id) {
+      $prisons = array_column($term->field_moj_prisons->getValue(), 'target_id');
+      if ($term->field_moj_category_featured_item->value == true && in_array($prisonId, $prisons)) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
### Context

This fixes issue discussed in Slack https://mojdt.slack.com/archives/CNQK3S7GT/p1634828698048500

### Intent

The previous fix for featured series on landing pages only checked the first value of the `field_moj_prison`.  This PR updates this to check for all prisons.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
