### PR TITLE
Revert "Fix unpublished content being shown"

### DIFF
--- a/docroot/modules/custom/prisoner_hub_entity_access/src/EntityAccessCheck.php
+++ b/docroot/modules/custom/prisoner_hub_entity_access/src/EntityAccessCheck.php
@@ -65,10 +65,10 @@ class EntityAccessCheck {
       $prison_category_field_name = $this->prisonCategoryLoader->getPrisonCategoryFieldName();
       if ($entity->hasField($prison_field_name) && $entity->hasField($prison_category_field_name)) {
         if ($this->fieldValueExists($entity->get($prison_field_name), $current_prison_id)) {
-          return AccessResult::neutral();
+          return AccessResult::allowed();
         }
         if ($this->fieldValueExists($entity->get($prison_category_field_name), $this->prisonCategoryLoader->getPrisonCategoryIdFromCurrentRoute())) {
-          return AccessResult::neutral();
+          return AccessResult::allowed();
         }
         return AccessResult::forbidden();
       }

--- a/docroot/modules/custom/prisoner_hub_entity_access/tests/src/ExistingSite/PrisonerHubEntityAccessJsonApiTest.php
+++ b/docroot/modules/custom/prisoner_hub_entity_access/tests/src/ExistingSite/PrisonerHubEntityAccessJsonApiTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\prisoner_hub_entity_access\ExistingSite;
 
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 
 /**
  * Test that the correct access is applied when accessing entities directly
@@ -122,20 +121,6 @@ class PrisonerHubEntityAccessJsonApiTest extends PrisonerHubQueryAccessTestBase 
     }
   }
 
-
-  /**
-   * Test that we can access the correct entities, when tagged with both a
-   * prison and a category.
-   */
-  public function testContentTaggedWithPrisonAndCategoryUnpublished() {
-    foreach ($this->bundlesByEntityType as $entity_type_id => $bundles) {
-      foreach ($bundles as $bundle) {
-        $uuid_to_check_is_403 = $this->createEntityTaggedWithPrisonAndCategory($entity_type_id, $bundle, $this->prisonTerm->id(), $this->prisonCategoryTerm->id(), NodeInterface::NOT_PUBLISHED);
-        $url = $this->getJsonApiUri($this->prisonTermMachineName, $entity_type_id, $bundle, $uuid_to_check_is_403);
-        $this->assertJsonApiResponseByStatusCode($url, 403);
-      }
-    }
-  }
 
   /**
    * @param \Drupal\Core\Url $url

--- a/docroot/modules/custom/prisoner_hub_entity_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
+++ b/docroot/modules/custom/prisoner_hub_entity_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\prisoner_hub_entity_access\ExistingSite;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
@@ -174,11 +173,6 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
       $this->createEntityTaggedWithPrisonButNoCategory($entity_type_id, $bundle, $this->anotherPrisonTerm->id());
     }
 
-    // Also create some unpublished entities.
-    for ($i = 0; $i < $amount; $i++) {
-      $this->createEntityTaggedWithPrisonButNoCategory($entity_type_id, $bundle, $this->prisonTerm->id(), FALSE);
-    }
-
    return $entities_to_check;
   }
 
@@ -188,12 +182,11 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
    * @return int
    *   The uuid of the created entity.
    */
-  public function createEntityTaggedWithPrisonButNoCategory(string $entity_type_id, string $bundle, int $prison_id, $status = NodeInterface::PUBLISHED) {
+  public function createEntityTaggedWithPrisonButNoCategory(string $entity_type_id, string $bundle, int $prison_id) {
     $values = [
       $this->prisonFieldName => [
         ['target_id' => $prison_id]
       ],
-      'status' => $status,
     ];
     return $this->createEntity($entity_type_id, $bundle, $values);
   }
@@ -224,12 +217,11 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
    * @return int
    *   The uuid of the created entity.
    */
-  public function createEntityTaggedWithCategoryButNoPrison(string $entity_type_id, string $bundle, int $prison_category_id, $status = NodeInterface::PUBLISHED) {
+  public function createEntityTaggedWithCategoryButNoPrison(string $entity_type_id, string $bundle, int $prison_category_id) {
     $values = [
       $this->prisonCategoryFieldName => [
         ['target_id' => $prison_category_id],
       ],
-      'status' => $status,
     ];
     return $this->createEntity($entity_type_id, $bundle, $values);
   }
@@ -260,7 +252,7 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
    * @return int
    *   The uuid of the created entity.
    */
-  public function createEntityTaggedWithPrisonAndCategory(string $entity_type_id, string $bundle, string $prison_id, int $prison_category_id, $status = NodeInterface::PUBLISHED) {
+  public function createEntityTaggedWithPrisonAndCategory(string $entity_type_id, string $bundle, string $prison_id, int $prison_category_id) {
     $values = [
       $this->prisonFieldName => [
         ['target_id' => $prison_id],
@@ -268,7 +260,6 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
       $this->prisonCategoryFieldName => [
         ['target_id' => $prison_category_id],
       ],
-      'status' => $status,
     ];
     return $this->createEntity($entity_type_id, $bundle, $values);
   }


### PR DESCRIPTION
Reverts ministryofjustice/prisoner-content-hub-backend#277

This needs more work, we still need to return a `AccessResult::allowed();`, as otherwise content can be hidden.  But need to work out why unpublished content is still appearing.