### PR TITLE
Update landing page urls embedded in description fields.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -197,3 +197,39 @@ function prisoner_content_hub_profile_deploy_category_tiles() {
 function prisoner_content_hub_profile_deploy_category_tiles_redeploy() {
   prisoner_content_hub_profile_deploy_category_tiles();
 }
+
+/**
+ * Update any embedded links inside description fields, so that they point to
+ * the category and not the landing page.
+ */
+function prisoner_content_hub_profile_deploy_update_embedded_links_to_landing_pages() {
+  $landing_pages = [];
+  $result = \Drupal::entityQuery('taxonomy_term')->condition('vid', 'moj_categories')->execute();
+  $terms = Term::loadMultiple($result);
+  /** @var \Drupal\taxonomy\TermInterface $term */
+  foreach ($terms as $term) {
+    $referenced_entities = $term->get('field_legacy_landing_page')->referencedEntities();
+    if (!empty($referenced_entities)) {
+      /** @var \Drupal\node\NodeInterface $referenced_entity */
+      $referenced_entity = array_shift($referenced_entities);
+      $landing_pages['/tags/' . $term->id()] = '/content/' . $referenced_entity->id();
+    }
+  }
+
+  $result = \Drupal::entityQuery('node')
+    ->condition('field_moj_description', '/content/', 'CONTAINS')
+    ->accessCheck(FALSE)
+    ->execute();
+  $nodes = Node::loadMultiple($result);
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($nodes as $node) {
+    $count = 0;
+    $description = $node->get('field_moj_description')->getValue();
+    $description[0]['value'] = str_replace(array_values($landing_pages), array_keys($landing_pages), $description[0]['value'], $count);
+    if ($count) {
+      $node->set('field_moj_description', $description);
+      $node->save();
+      print 'Updated description on node: ' . $node->id() . PHP_EOL;
+    }
+  }
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Ar7YBRus/208-switch-to-jsonapi-for-category-landing-pages

### Intent
Cherry picking c089de8eea178c68cd274e9080f845b4ddac0ed5 from https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/266 (as we don't want to remove landing pages just yet, can do that as part of a "cleanup" release).

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
