### PR TITLE
Make category fields optional

### DIFF
--- a/config/sync/field.field.node.moj_pdf_item.field_moj_top_level_categories.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_moj_top_level_categories.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: moj_pdf_item
 label: Category
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.moj_video_item.field_moj_top_level_categories.yml
+++ b/config/sync/field.field.node.moj_video_item.field_moj_top_level_categories.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: moj_video_item
 label: Category
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

This is related to https://trello.com/c/hCm7yE4Q/209-switch-to-jsonapi-for-in-this-section-sidebar-component

### Intent

Discovered during testing the release that the category field was still required on two content types, this would have prevented content from being saved/updated that was part of a series (as the category field would be hidden).

The fields have already been updated on live, this PR adds this into config so it doesn't get reverted on the next release.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
