### PR TITLE
Fix missing series field issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/flood_unblock": "^2.0",
         "drupal/flysystem": "^2.0",
         "drupal/flysystem_s3": "^2.0-rc1",
+        "drupal/form_state_empty": "^1.0@alpha",
         "drupal/govuk_design_system": "^2.0",
         "drupal/govuk_inline_form_errors": "2.0.0-beta2",
         "drupal/health_check": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4dfb7c05a5a161219de4c9c4ac122d4a",
+    "content-hash": "b433d65c9dd27a471083916f52b4e473",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2923,6 +2923,50 @@
             "homepage": "https://www.drupal.org/project/flysystem_s3",
             "support": {
                 "source": "https://git.drupalcode.org/project/flysystem_s3"
+            }
+        },
+        {
+            "name": "drupal/form_state_empty",
+            "version": "1.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/form_state_empty.git",
+                "reference": "1.0.0-alpha2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/form_state_empty-1.0.0-alpha2.zip",
+                "reference": "1.0.0-alpha2",
+                "shasum": "2e7fe4ce5c5e668af1315ed3b30ff5abd7ec01df"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha2",
+                    "datestamp": "1634571058",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Donnyboypony",
+                    "homepage": "https://www.drupal.org/user/523868"
+                }
+            ],
+            "description": "Extends core's Form API States to allow the emptying of fields with javascript.",
+            "homepage": "https://www.drupal.org/project/form_state_empty",
+            "support": {
+                "source": "https://git.drupalcode.org/project/form_state_empty"
             }
         },
         {
@@ -16539,6 +16583,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/cer": 20,
+        "drupal/form_state_empty": 15,
         "drupal/jsonapi_image_styles": 10,
         "drupal/jsonapi_page_limit": 10,
         "drupal/jsonapi_search_api": 5,

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -34,7 +34,7 @@ third_party_settings:
         - field_prison_categories
         - field_moj_prisons
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       region: content
       format_settings:
@@ -115,7 +115,7 @@ content:
     region: content
   field_feature_on_category:
     type: options_buttons
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -27,6 +27,7 @@ module:
   flood_unblock: 0
   flysystem: 0
   flysystem_s3: 0
+  form_state_empty: 0
   image: 0
   image_style_warmer: 0
   inline_form_errors: 0

--- a/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
+++ b/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
@@ -14,7 +14,9 @@
       $categoryField
         .once()
         .on('change', (e) => {
-          filterCheckboxes($(e.currentTarget).val());
+          if ($(e.currentTarget).is(":visible")) {
+            filterCheckboxes($(e.currentTarget).val());
+          }
         });
       // Trigger change event if value is not empty.
       if ($categoryField.length && $categoryField.val().length) {
@@ -24,10 +26,12 @@
       $seriesField
         .once()
         .on('change', (e) => {
-          // Retrieve the categories for the series via drupalSettings.
-          const seriesVal = $(e.currentTarget).val();
-          const selectedCategories = drupalSettings.prisonerHubFeaturedContent.seriesByCategory.hasOwnProperty(seriesVal) ? drupalSettings.prisonerHubFeaturedContent.seriesByCategory[seriesVal] : [];
-          filterCheckboxes(selectedCategories);
+          if ($(e.currentTarget).is(":visible")) {
+            // Retrieve the categories for the series via drupalSettings.
+            const seriesVal = $(e.currentTarget).val();
+            const selectedCategories = drupalSettings.prisonerHubFeaturedContent.seriesByCategory.hasOwnProperty(seriesVal) ? drupalSettings.prisonerHubFeaturedContent.seriesByCategory[seriesVal] : [];
+            filterCheckboxes(selectedCategories);
+          }
         });
       // Trigger change event if value is not empty.
       if ($seriesField.length && $seriesField.val().length) {

--- a/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
+++ b/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
@@ -189,9 +189,6 @@ class FeaturedContentFieldsFormTest extends ExistingSiteWebDriverTestBase {
         else {
           $feature_on_category_field = $feature_on_category_field_wrapper->findField($this->categoryTermForSeries->label());
         }
-        if (!$feature_on_category_field->isVisible()) {
-          print $node->id(); exit;
-        }
         self::assertTrue($feature_on_category_field->isVisible());
       }
     }

--- a/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
+++ b/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
@@ -163,6 +163,8 @@ class FeaturedContentFieldsFormTest extends ExistingSiteWebDriverTestBase {
     $series_field->setValue($this->seriesWithoutCategoryTerm->id());
     self::assertFalse($feature_on_category_field->isVisible());
 
+    $not_in_series_field = $page->findField('This content is not part of any series');
+    $not_in_series_field->check();
     $category_field = $page->findField('Category');
     $category_field->setValue($this->categoryTerm->id());
     $feature_on_category_field = $page->findById('edit-field-feature-on-category-wrapper')->findField($this->categoryTerm->label());
@@ -186,6 +188,9 @@ class FeaturedContentFieldsFormTest extends ExistingSiteWebDriverTestBase {
         }
         else {
           $feature_on_category_field = $feature_on_category_field_wrapper->findField($this->categoryTermForSeries->label());
+        }
+        if (!$feature_on_category_field->isVisible()) {
+          print $node->id(); exit;
         }
         self::assertTrue($feature_on_category_field->isVisible());
       }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/prisoner_hub_taxonomy_field_ux.info.yml
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/prisoner_hub_taxonomy_field_ux.info.yml
@@ -1,7 +1,8 @@
 name: 'Prisoner Hub Taxonomy Field UX'
 type: module
-description: 'Provides CMS UX enhacements for Taxonomy (and related) fields.'
+description: 'Provides CMS UX enhancements for Taxonomy (and related) fields.'
 core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - field_group:field_group
+  - form_state_empty:form_state_empty

--- a/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/src/EntityFormStates.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/src/EntityFormStates.php
@@ -79,7 +79,9 @@ class EntityFormStates {
       hide($form['group_season_and_episode_number']);
     }
     else {
-      $form['group_season_and_episode_number']['#states']['visible'][':input[name="field_moj_series"]'] = $this->episodeSortingStates;
+      $form['group_season_and_episode_number']['#states']['visible'] = [
+        ':input[name="field_moj_series"]' => $this->episodeSortingStates,
+      ];
       $form['field_moj_season']['widget'][0]['value']['#states']['required'] = [
         ':input[name="field_moj_series"]' => $this->episodeSortingStates,
         'and',
@@ -96,19 +98,24 @@ class EntityFormStates {
       hide($form['group_release_date']);
     }
     else {
-      $form['group_release_date']['#states']['visible'][':input[name="field_moj_series"]'] = $this->releaseDateSortingStates;
+      $form['group_release_date']['#states']['visible'] = [
+        ':input[name="field_moj_series"]' => $this->releaseDateSortingStates,
+      ];
       // Currently we cannot set a required state for field_release_date.
       // See https://www.drupal.org/project/drupal/issues/2419131
       // However, this field has a default value (of the current date),
       // so it's less likely to not be set.
     }
 
+    // Apply states to the category field and group, based on field_not_in_series.
     $form['group_category']['#states']['visible'][':input[name="field_not_in_series[value]"]']['checked'] = TRUE;
     $form['field_moj_top_level_categories']['widget']['#states']['required'][':input[name="field_not_in_series[value]"]']['checked'] = TRUE;
+    $form['field_moj_top_level_categories']['widget']['#states']['empty'][':input[name="field_not_in_series[value]"]']['checked'] = FALSE;
+
+    // Apply states to the series field and group, based on field_not_in_series.
     $form['field_moj_series']['#states']['visible'][':input[name="field_not_in_series[value]"]']['checked'] = FALSE;
     $form['field_moj_series']['widget']['#states']['required'][':input[name="field_not_in_series[value]"]']['checked'] = FALSE;
-    $form['group_season_and_episode_number']['#states']['visible'][':input[name="field_not_in_series[value]"]']['checked'] = FALSE;
-    $form['group_release_date']['#states']['visible'][':input[name="field_not_in_series[value]"]']['checked'] = FALSE;
+    $form['field_moj_series']['#states']['empty'][':input[name="field_not_in_series[value]"]']['checked'] = TRUE;
   }
 
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No, this was an issue reported by Jo today on Slack.

### Intent

A bug was discovered where the series sorting fields (i.e. the season+episode number or release date fields) were not shown when selecting a series.  This only occurred if an image had been uploaded first onto the form (for some reason this messed up the visible/invisible states).

This PR fixes the issue by setting the correct form states, that work after an image has been uploaded.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
