### PR TITLE
Hide the featured category when field_not_in_series is switched

### DIFF
--- a/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
+++ b/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
@@ -7,6 +7,7 @@
       const $checkboxes = $('[name^="field_feature_on_category"]'); // Use name^ to account for multiple checkbox fields.
       const $categoryField = $('[name="field_moj_top_level_categories[]"], [name="field_category[]"]');
       const $seriesField = $('[name="field_moj_series"]');
+      const $notInSeries = $('[name="field_not_in_series[value]"]');
 
       // Hide the entire fieldset upon page load.
       $checkboxes.closest('fieldset').once().hide();
@@ -60,6 +61,16 @@
           return selectedCategories.includes(checkbox.value);
         }
       }
+
+      // Hide checkboxes when field_not_in_series is switched.
+      $notInSeries
+        .once()
+        .on('change', (e) => {
+          $checkboxes
+            .prop('checked', false)
+            .closest('div.form-item')
+            .hide();
+        });
     }
   };
 })(Drupal, drupalSettings, jQuery);


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/kkzyF5JE/102-allow-greater-control-of-featured-content-on-category-pages

### Intent

This is a small optimisation, that fixes a bug where the category is still shown after `field_not_in_series` is switched.

https://user-images.githubusercontent.com/436483/140506778-c95095c6-afb3-4532-b9e5-32cad93017d8.mov


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
