### PR TITLE
Moving standfirst field to top of content edit form.

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -109,7 +109,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -120,7 +120,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_moj_description:
-    weight: 1
+    weight: 2
     settings:
       rows: 9
       summary_rows: 3
@@ -170,7 +170,7 @@ content:
     type: select2_entity_reference
     region: content
   field_moj_stand_first:
-    weight: 6
+    weight: 1
     settings:
       rows: 5
       placeholder: ''
@@ -178,7 +178,7 @@ content:
     type: string_textarea
     region: content
   field_moj_thumbnail_image:
-    weight: 2
+    weight: 3
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -216,7 +216,7 @@ content:
     region: content
   path:
     type: path
-    weight: 5
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -248,7 +248,7 @@ content:
     region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/oo5RlgEP/417-move-standfirst-in-drupal-to-top-of-page

### Intent

This update has already been made on production, this PR adds the config into code, so that we don't revert the change on the next deployment.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
