### PR TITLE
Disable other file fields and submit buttons when uploading.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,8 @@
                 "Issue #2770263 - Amazon S3 CORS Upload like functionality.": "patches/flysystem_s3_cors_upload-2770263-60.patch",
                 "Issue #3219524 - CORS upload functionality doesn't work with Claro theme.": "patches/flysystem_s3-cors-upload-claro-theme-3219524-2.patch",
                 "Issue #3159928 - uriScheme() method missing after update to Drupal 9.": "patches/flysystem_replace-urischeme-method-3159928-with-2772847.patch",
-                "Issue #3248466 - Duplicate file entities when uploaded through CORS [DATA LOSS]": "patches/flysystem_3248466-fix-data-loss.patch"
+                "Issue #3248466 - Duplicate file entities when uploaded through CORS [DATA LOSS]": "patches/flysystem_3248466-fix-data-loss.patch",
+                "Issue #3248956 - Disable other fields when uploading files": "patches/flysystem_s3-3248956-disable-other-fields-when-uploading.patch"
             },
             "twistor/stream-util": {
                 "PR #3 - More robust version of getSize() ": "patches/stream_util-pr3-more-robust-version-of-getsize.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1af22649f8fffe44957ec39a0845379d",
+    "content-hash": "988bba351bbccadde2bc1cea415e1fa5",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/flysystem_s3-3248956-disable-other-fields-when-uploading.patch
+++ b/patches/flysystem_s3-3248956-disable-other-fields-when-uploading.patch
@@ -1,0 +1,50 @@
+diff --git a/flysystem_s3.js b/flysystem_s3.js
+index dfebbae..2e29c3e 100644
+--- a/flysystem_s3.js
++++ b/flysystem_s3.js
+@@ -44,6 +44,21 @@
+       // Store uploaded files fid values.
+       var uploadedFileFid = [];
+ 
++      // Disable "other" file fields, and also submit buttons.
++      // @See Drupal.file.disableFields().
++      var $enabledFields = [];
++      if ($fileElement.closest('div.js-form-managed-file').length > 0) {
++        $enabledFields = $fileElement
++            .closest('div.js-form-managed-file')
++            .find('input.js-form-file');
++      }
++      const $fieldsToTemporarilyDisable = $(
++          'div.js-form-managed-file input.js-form-file, input[type="submit"]',
++      )
++          .not($enabledFields)
++          .not(':disabled');
++      $fieldsToTemporarilyDisable.prop('disabled', true);
++
+       Object.keys(filelist).forEach(function (file) {
+ 
+         var file_obj = filelist[file];
+@@ -55,6 +70,7 @@
+           Drupal.flysystemS3.setCorsUploadProgress($progressBar, 1, Drupal.t('Signing request failed. Trying secondary upload method...'));
+           // Trigger the submit button to let normal AJAX process the upload.
+           Drupal.file.triggerUploadButton(event);
++          $fieldsToTemporarilyDisable.prop('disabled', false);
+         })
+         .done(function (signedFormData) {
+           Drupal.flysystemS3.setCorsUploadProgress($progressBar, 1, Drupal.t('Uploading @file', {'@file': file_obj.name}));
+@@ -64,6 +80,7 @@
+               Drupal.flysystemS3.setCorsUploadProgress($progressBar, 1, Drupal.t('Upload failed. Trying secondary upload method...'));
+               // Trigger the submit button to let normal AJAX process the upload.
+               Drupal.file.triggerUploadButton(event);
++              $fieldsToTemporarilyDisable.prop('disabled', false);
+             })
+             .done(function () {
+               // Set progress bar to 100% in case the upload was so fast.
+@@ -88,6 +105,7 @@
+                 // Trigger the submit button to let normal AJAX process the upload.
+                 Drupal.file.triggerUploadButton(event);
+               }
++              $fieldsToTemporarilyDisable.prop('disabled', false);
+             });
+         });
+       });


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue
and
https://trello.com/c/ididuzch/227-prevent-user-from-saving-content-before-a-file-has-finished-uploading

### Intent

Currently multiple files can be uploaded simultaneously, i.e. a video and a thumbnail can be uploaded at the same time.

When this happens, the first file that finishes uploading to S3, has to actually wait for the second file to upload, and this file ends up getting sent directly to Drupal (in addition to S3), which is totally unnecessary.   This issue is described here: https://www.drupal.org/project/flysystem_s3/issues/3248956
Whilst this doesn't actually cause any errors, if both files are uploaded successfully, it does slow things down.  It also means that if one file fails, then it can impact the other.

During investigating the missing file issue, we found that often video files would fail to upload, and get re-uploaded.  (This caused the error where the first failed attempt ended up causing the successful attempt to be deleted, see https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/295 for more details).  This issue has now been fixed, so it's OK for files to fail to upload, but this PR is to stop failed uploads from happening as often.

To fix the issue, we disable all _other_ file fields, as well as submit buttons (as pressing submit during an upload will break the upload). 

Before (notice how the second file gets stuck on 100%)


https://user-images.githubusercontent.com/436483/141340744-dec7b960-5fa1-4458-89de-a885b6ddc22d.mov



After, with this PR


https://user-images.githubusercontent.com/436483/141340804-721e77b0-d5b0-4fe5-a500-5466e46af324.mov


### Considerations

This is yet another patch on the flysytem_s3 module, so this will make updates even more difficult to manage.

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
