### PR TITLE
Feature/exclude from feedback

### DIFF
--- a/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.moj_radio_item.field_exclude_feedback
     - field.field.node.moj_radio_item.field_feature_on_category
     - field.field.node.moj_radio_item.field_moj_audio
     - field.field.node.moj_radio_item.field_moj_category_featured_item
@@ -114,6 +115,13 @@ content:
     weight: 2
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_exclude_feedback:
+    weight: 13
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_feature_on_category:
     type: options_buttons
@@ -231,12 +239,12 @@ content:
     region: content
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -244,7 +252,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 17
     third_party_settings: {  }
     region: content
   title:
@@ -272,7 +280,7 @@ content:
     region: content
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_video_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.moj_video_item.field_exclude_feedback
     - field.field.node.moj_video_item.field_feature_on_category
     - field.field.node.moj_video_item.field_moj_category_featured_item
     - field.field.node.moj_video_item.field_moj_description
@@ -115,6 +116,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_exclude_feedback:
+    weight: 13
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_feature_on_category:
     type: options_buttons
     weight: 11
@@ -152,7 +160,7 @@ content:
     type: number
     region: content
   field_moj_secondary_tags:
-    weight: 11
+    weight: 10
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -230,12 +238,12 @@ content:
     region: content
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -243,7 +251,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 17
     third_party_settings: {  }
     region: content
   title:
@@ -271,7 +279,7 @@ content:
     region: content
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.page.field_exclude_feedback
     - field.field.node.page.field_feature_on_category
     - field.field.node.page.field_moj_category_featured_item
     - field.field.node.page.field_moj_description
@@ -113,6 +114,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_exclude_feedback:
+    weight: 12
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_feature_on_category:
     type: options_buttons
     weight: 10
@@ -222,12 +230,12 @@ content:
     region: content
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -235,7 +243,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 16
     third_party_settings: {  }
     region: content
   title:
@@ -258,7 +266,7 @@ content:
     region: content
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.series.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.series.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.series.field_category
+    - field.field.taxonomy_term.series.field_exclude_feedback
     - field.field.taxonomy_term.series.field_feature_on_category
     - field.field.taxonomy_term.series.field_feature_programme_code
     - field.field.taxonomy_term.series.field_featured_image
@@ -58,6 +59,13 @@ content:
       autocomplete: false
       width: 100%
     third_party_settings: {  }
+  field_exclude_feedback:
+    weight: 8
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_feature_on_category:
     weight: 4
     settings: {  }
@@ -110,7 +118,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
 hidden:

--- a/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.tags.field_exclude_feedback
     - field.field.taxonomy_term.tags.field_featured_image
     - field.field.taxonomy_term.tags.field_moj_category_featured_item
     - field.field.taxonomy_term.tags.field_moj_prisons
@@ -45,6 +46,13 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  field_exclude_feedback:
+    weight: 7
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_featured_image:
     weight: 4
     settings:
@@ -97,7 +105,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.moj_radio_item.field_exclude_feedback
     - field.field.node.moj_radio_item.field_feature_on_category
     - field.field.node.moj_radio_item.field_moj_audio
     - field.field.node.moj_radio_item.field_moj_category_featured_item
@@ -31,6 +32,16 @@ targetEntityType: node
 bundle: moj_radio_item
 mode: default
 content:
+  field_exclude_feedback:
+    weight: 17
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_feature_on_category:
     weight: 16
     label: above

--- a/config/sync/core.entity_view_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_video_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.moj_video_item.field_exclude_feedback
     - field.field.node.moj_video_item.field_feature_on_category
     - field.field.node.moj_video_item.field_moj_category_featured_item
     - field.field.node.moj_video_item.field_moj_description
@@ -32,6 +33,16 @@ targetEntityType: node
 bundle: moj_video_item
 mode: default
 content:
+  field_exclude_feedback:
+    weight: 20
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_feature_on_category:
     weight: 19
     label: above

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.page.field_exclude_feedback
     - field.field.node.page.field_feature_on_category
     - field.field.node.page.field_moj_category_featured_item
     - field.field.node.page.field_moj_description
@@ -30,6 +31,16 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
+  field_exclude_feedback:
+    weight: 18
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_feature_on_category:
     weight: 17
     label: above

--- a/config/sync/core.entity_view_display.node.page.search_index.yml
+++ b/config/sync/core.entity_view_display.node.page.search_index.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_index
+    - field.field.node.page.field_exclude_feedback
     - field.field.node.page.field_feature_on_category
     - field.field.node.page.field_moj_category_featured_item
     - field.field.node.page.field_moj_description
@@ -29,6 +30,7 @@ bundle: page
 mode: search_index
 content: {  }
 hidden:
+  field_exclude_feedback: true
   field_feature_on_category: true
   field_moj_category_featured_item: true
   field_moj_description: true

--- a/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.page.field_exclude_feedback
     - field.field.node.page.field_feature_on_category
     - field.field.node.page.field_moj_category_featured_item
     - field.field.node.page.field_moj_description
@@ -34,6 +35,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_exclude_feedback: true
   field_feature_on_category: true
   field_moj_category_featured_item: true
   field_moj_description: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.page.field_exclude_feedback
     - field.field.node.page.field_feature_on_category
     - field.field.node.page.field_moj_category_featured_item
     - field.field.node.page.field_moj_description
@@ -34,6 +35,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_exclude_feedback: true
   field_feature_on_category: true
   field_moj_category_featured_item: true
   field_moj_description: true

--- a/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.series.field_category
+    - field.field.taxonomy_term.series.field_exclude_feedback
     - field.field.taxonomy_term.series.field_feature_on_category
     - field.field.taxonomy_term.series.field_feature_programme_code
     - field.field.taxonomy_term.series.field_featured_image
@@ -28,6 +29,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_exclude_feedback:
+    weight: 16
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_feature_on_category:
     weight: 15
     label: above

--- a/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.tags.field_exclude_feedback
     - field.field.taxonomy_term.tags.field_featured_image
     - field.field.taxonomy_term.tags.field_moj_category_featured_item
     - field.field.taxonomy_term.tags.field_moj_prisons
@@ -24,6 +25,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_exclude_feedback:
+    weight: 6
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_featured_image:
     weight: 2
     label: above

--- a/config/sync/field.field.node.moj_radio_item.field_exclude_feedback.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_exclude_feedback.yml
@@ -1,0 +1,23 @@
+uuid: 1c43f236-8f8e-4a73-9e8e-59fd611dbdeb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_feedback
+    - node.type.moj_radio_item
+id: node.moj_radio_item.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: node
+bundle: moj_radio_item
+label: 'Exclude feedback'
+description: 'Select to hide the feedback form when viewing this content.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.moj_video_item.field_exclude_feedback.yml
+++ b/config/sync/field.field.node.moj_video_item.field_exclude_feedback.yml
@@ -1,0 +1,23 @@
+uuid: 301a981e-ca1b-4044-b485-f62d834df7c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_feedback
+    - node.type.moj_video_item
+id: node.moj_video_item.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: node
+bundle: moj_video_item
+label: 'Exclude feedback'
+description: 'Select to hide the feedback form when viewing this content.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.page.field_exclude_feedback.yml
+++ b/config/sync/field.field.node.page.field_exclude_feedback.yml
@@ -1,0 +1,23 @@
+uuid: 307f38a5-ad8a-40fb-965b-736ecea525bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_feedback
+    - node.type.page
+id: node.page.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: node
+bundle: page
+label: 'Exclude feedback'
+description: 'Select to hide the feedback form when viewing this content.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.series.field_exclude_feedback.yml
+++ b/config/sync/field.field.taxonomy_term.series.field_exclude_feedback.yml
@@ -1,0 +1,23 @@
+uuid: 780c0915-3533-4185-988c-193e77427443
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_exclude_feedback
+    - taxonomy.vocabulary.series
+id: taxonomy_term.series.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: taxonomy_term
+bundle: series
+label: 'Exclude feedback'
+description: 'Select to hide the feedback form when viewing this series.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.tags.field_exclude_feedback.yml
+++ b/config/sync/field.field.taxonomy_term.tags.field_exclude_feedback.yml
@@ -1,0 +1,23 @@
+uuid: f3c4299e-2479-4c70-a1e1-c2126eb6366b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_exclude_feedback
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: taxonomy_term
+bundle: tags
+label: 'Exclude feedback'
+description: 'Select to hide the feedback form when viewing this secondary tag.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_exclude_feedback.yml
+++ b/config/sync/field.storage.node.field_exclude_feedback.yml
@@ -1,0 +1,18 @@
+uuid: b685c5ed-c9e9-4112-8b90-9083cb8f447f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_exclude_feedback.yml
+++ b/config/sync/field.storage.taxonomy_term.field_exclude_feedback.yml
@@ -1,0 +1,18 @@
+uuid: cd6f82bd-f8ae-46f3-a54d-8a75a3451b3d
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_exclude_feedback
+field_name: field_exclude_feedback
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/OnD5Jbau/400-remove-the-ability-to-leave-feedback-on-education-pages

### Intent

This PR adds a new `exclude_feedback` field to Drupal.  This field is available on the following content types/taxonomy terms:
- Basic pages
- Audio items
- Video items
- Series
- Secondary tags
<img width="432" alt="Screenshot 2021-11-12 at 12 59 00" src="https://user-images.githubusercontent.com/436483/141776234-eb643e4b-2ae5-4bff-a157-f37f01baa12a.png">


### Considerations

Note this PR just adds the field to Drupal, this will need to be implemented in the frontend.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
