### PR TITLE
Update content overview page with new prison field.

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -4,12 +4,11 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_feature_on_category
-    - field.storage.node.field_moj_prisons
     - field.storage.node.field_moj_secondary_tags
     - field.storage.node.field_moj_series
     - field.storage.node.field_moj_top_level_categories
+    - field.storage.node.field_prisons
     - taxonomy.vocabulary.moj_categories
-    - taxonomy.vocabulary.prison_category
     - taxonomy.vocabulary.prisons
     - taxonomy.vocabulary.series
     - taxonomy.vocabulary.tags
@@ -611,10 +610,10 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        field_moj_prisons:
-          id: field_moj_prisons
-          table: node__field_moj_prisons
-          field: field_moj_prisons
+        field_prisons:
+          id: field_prisons
+          table: node__field_prisons
+          field: field_prisons
           relationship: none
           group_type: group
           admin_label: ''
@@ -662,7 +661,7 @@ display:
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: true
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1331,110 +1330,6 @@ display:
           entity_type: node
           entity_field: uid
           plugin_id: user_name
-        field_moj_prisons_target_id:
-          id: field_moj_prisons_target_id
-          table: node__field_moj_prisons
-          field: field_moj_prisons_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_moj_prisons_target_id_op
-            label: Prisons
-            description: ''
-            use_operator: true
-            operator: field_moj_prisons_target_id_op
-            operator_limit_selection: false
-            operator_list:
-              and: and
-            identifier: field_moj_prisons_target_id
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              moj_local_content_manager: '0'
-              local_administrator: '0'
-              administrator: '0'
-              gds_theme_user: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: 'Prisons (field_moj_prisons)'
-            description: null
-            identifier: field_moj_prisons_target_id
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1: {  }
-              2: {  }
-              3: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: prisons
-          hierarchy: true
-          error_message: true
-          plugin_id: taxonomy_index_tid
-        field_prison_categories_target_id:
-          id: field_prison_categories_target_id
-          table: node__field_prison_categories
-          field: field_prison_categories_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_prison_categories_target_id_op
-            label: 'Prison categories'
-            description: ''
-            use_operator: true
-            operator: field_prison_categories_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: field_prison_categories_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              moj_local_content_manager: '0'
-              local_administrator: '0'
-              administrator: '0'
-              gds_theme_user: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: prison_category
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
         field_moj_description_value:
           id: field_moj_description_value
           table: node__field_moj_description
@@ -1487,6 +1382,58 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: string
+        field_prisons_target_id:
+          id: field_prisons_target_id
+          table: node__field_prisons
+          field: field_prisons_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_prisons_target_id_op
+            label: 'Prisons (field_prisons)'
+            description: ''
+            use_operator: true
+            operator: field_prisons_target_id_op
+            operator_limit_selection: true
+            operator_list:
+              or: or
+              and: and
+              not: not
+            identifier: field_prisons_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: prisons
+          hierarchy: true
+          error_message: true
+          plugin_id: taxonomy_index_tid
       sorts: {  }
       title: Content
       empty:
@@ -1528,10 +1475,10 @@ display:
       max-age: 0
       tags:
         - 'config:field.storage.node.field_feature_on_category'
-        - 'config:field.storage.node.field_moj_prisons'
         - 'config:field.storage.node.field_moj_secondary_tags'
         - 'config:field.storage.node.field_moj_series'
         - 'config:field.storage.node.field_moj_top_level_categories'
+        - 'config:field.storage.node.field_prisons'
   page_1:
     display_options:
       path: admin/content/node
@@ -1569,7 +1516,7 @@ display:
                   title: General
                   description: ''
                   open: '1'
-                  weight: '-35'
+                  weight: '-30'
                   id: container-2
                   pid: root
                   depth: '1'
@@ -1609,7 +1556,7 @@ display:
                   title: Description
                   description: ''
                   open: '1'
-                  weight: '-34'
+                  weight: '-29'
                   id: container-6
                   pid: root
                   depth: '1'
@@ -1626,12 +1573,18 @@ display:
                   pid: container-6
                   depth: '2'
                   type: filter
+                reset:
+                  weight: '-28'
+                  id: reset
+                  pid: root
+                  depth: '1'
+                  type: buttons
                 container-1:
                   container_type: details
                   title: Taxonomy
                   description: ''
                   open: '1'
-                  weight: '-31'
+                  weight: '-27'
                   id: container-1
                   pid: root
                   depth: '1'
@@ -1665,43 +1618,21 @@ display:
                   title: Prisons
                   description: ''
                   open: '1'
-                  weight: '-30'
+                  weight: '-26'
                   id: container-0
                   pid: root
                   depth: '1'
                   type: container
-                field_moj_prisons_target_id_op:
-                  weight: '-29'
-                  id: field_moj_prisons_target_id_op
+                field_prisons_target_id:
+                  weight: '-31'
+                  id: field_prisons_target_id
                   pid: container-0
                   depth: '2'
                   type: filter
-                field_moj_prisons_target_id:
-                  weight: '-28'
-                  id: field_moj_prisons_target_id
+                field_prisons_target_id_op:
+                  weight: '-30'
+                  id: field_prisons_target_id_op
                   pid: container-0
-                  depth: '2'
-                  type: filter
-                container-5:
-                  container_type: details
-                  title: 'Prison categories'
-                  description: ''
-                  open: '1'
-                  weight: '-29'
-                  id: container-5
-                  pid: root
-                  depth: '1'
-                  type: container
-                field_prison_categories_target_id_op:
-                  weight: '-29'
-                  id: field_prison_categories_target_id_op
-                  pid: container-5
-                  depth: '2'
-                  type: filter
-                field_prison_categories_target_id:
-                  weight: '-28'
-                  id: field_prison_categories_target_id
-                  pid: container-5
                   depth: '2'
                   type: filter
                 container-3:
@@ -1709,7 +1640,7 @@ display:
                   title: ''
                   description: ''
                   open: '1'
-                  weight: '-28'
+                  weight: '-24'
                   id: container-3
                   pid: root
                   depth: '1'
@@ -1720,11 +1651,21 @@ display:
                   pid: container-3
                   depth: '2'
                   type: buttons
+                container-5:
+                  container_type: details
+                  title: 'Prison categories'
+                  description: ''
+                  weight: '-23'
+                  open: 0
+                  id: container-5
+                  pid: root
+                  depth: '1'
+                  type: container
                 container-4:
                   container_type: details
                   title: 'Container 6'
                   description: ''
-                  weight: '-27'
+                  weight: '-22'
                   open: 0
                   id: container-4
                   pid: root
@@ -1734,7 +1675,7 @@ display:
                   container_type: details
                   title: 'Container 7'
                   description: ''
-                  weight: '-26'
+                  weight: '-21'
                   open: 0
                   id: container-7
                   pid: root
@@ -1744,7 +1685,7 @@ display:
                   container_type: details
                   title: 'Container 8'
                   description: ''
-                  weight: '-25'
+                  weight: '-20'
                   open: 0
                   id: container-8
                   pid: root
@@ -1754,7 +1695,7 @@ display:
                   container_type: details
                   title: 'Container 9'
                   description: ''
-                  weight: '-24'
+                  weight: '-19'
                   open: 0
                   id: container-9
                   pid: root
@@ -1764,7 +1705,7 @@ display:
                   container_type: details
                   title: 'Container 10'
                   description: ''
-                  weight: '-23'
+                  weight: '-18'
                   open: 0
                   id: container-10
                   pid: root
@@ -1774,7 +1715,7 @@ display:
                   container_type: details
                   title: 'Container 11'
                   description: ''
-                  weight: '-22'
+                  weight: '-17'
                   open: 0
                   id: container-11
                   pid: root
@@ -1784,7 +1725,7 @@ display:
                   container_type: details
                   title: 'Container 12'
                   description: ''
-                  weight: '-21'
+                  weight: '-16'
                   open: 0
                   id: container-12
                   pid: root
@@ -1794,7 +1735,7 @@ display:
                   container_type: details
                   title: 'Container 13'
                   description: ''
-                  weight: '-20'
+                  weight: '-15'
                   open: 0
                   id: container-13
                   pid: root
@@ -1804,19 +1745,9 @@ display:
                   container_type: details
                   title: 'Container 14'
                   description: ''
-                  weight: '-19'
+                  weight: '-14'
                   open: 0
                   id: container-14
-                  pid: root
-                  depth: '1'
-                  type: container
-                container-15:
-                  container_type: details
-                  title: 'Container 15'
-                  description: ''
-                  weight: '-18'
-                  open: 0
-                  id: container-15
                   pid: root
                   depth: '1'
                   type: container
@@ -1836,7 +1767,7 @@ display:
       max-age: 0
       tags:
         - 'config:field.storage.node.field_feature_on_category'
-        - 'config:field.storage.node.field_moj_prisons'
         - 'config:field.storage.node.field_moj_secondary_tags'
         - 'config:field.storage.node.field_moj_series'
         - 'config:field.storage.node.field_moj_top_level_categories'
+        - 'config:field.storage.node.field_prisons'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

This PR is based on https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/300

### Intent
This updates the content overview page /admin/content with the new prison field.

As prisons and prison categories are now combined, they can be filtered and shown in just one field.
> Would this PR benefit from screenshots?

New filter, with hierarchy 
<img width="1024" alt="Screenshot 2021-11-25 at 10 25 55" src="https://user-images.githubusercontent.com/436483/143424923-22946739-1929-4203-b600-805b0e9e8595.png">

New field in table, showing both prison categories and prisons.

<img width="1613" alt="Screenshot 2021-11-25 at 10 26 03" src="https://user-images.githubusercontent.com/436483/143424989-92214cb2-9ae9-4c6e-94e3-0eb97748a2ac.png">
### Considerations

There are further improvements to this page planned in https://trello.com/c/cG3gVH3O/305-improvements-to-the-content-overview-page
Which will include updating the field to use checkboxes, instead of a dropdown.  For now we are just using what functionality comes with Drupal as standard to do this filter.


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
