### PR TITLE
Feature/block external jsonapi access config snippet

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -17,7 +17,8 @@ $databases['default']['default'] = array(
 $trusted_hosts = getenv('TRUSTED_HOSTS', true);
 
 $settings['trusted_host_patterns'] = [
-  $trusted_hosts
+  $trusted_hosts,
+  '^localhost$', // For debugging purposes, see https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3790667855/Drupal+and+JSON+API#Viewing-JSON%3AAPI-on-Cloud-platform-(debugging)
 ];
 
 /**

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -78,6 +78,12 @@ ingress:
        add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      server_tokens off;
+      location /jsonapi {
+        deny all;
+        return 401;
+      }
 
 cron:
   schedule: "*/5 * * * *"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/6vgxPaTU/492-only-allow-access-to-content-from-within-cloud-platform-network

### Intent

This PR adds a nginx configuration snippet that denies external access to `/jsonapi` routes.
After this update, only requests within cloud platform will be accepted through to any path starting with `/jsonapi`.

To allow developers to view JSON:API responses, for debugging purposes, port-forwarding will be used.  The instructions for doing so will be in: https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3790667855/Drupal+and+JSON+API#Viewing-JSON%3AAPI-on-Cloud-platform-(debugging)

### Considerations

> Is there any additional information that would help when reviewing this PR?

We did look into allow-listing access to jsonapi routes (to avoid having to use port-forwarding).  But couldnt get this to work with nginx config.  See relevant slack convo: https://mojdt.slack.com/archives/C57UPMZLY/p1638888435313400


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
