### PR TITLE
Simplify the trusted host setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             sed -i "s/appVersion:.*/appVersion: \"${VERSION_TO_DEPLOY}\"/g" ~/git/helm_deploy/prisoner-content-hub-backend/Chart.yaml
-            kubectl -n ${KUBE_NAMESPACE} get secret ip-allowlist -o json | jq '{ ingress: { allowed: .data |  map_values(@base64d) } } ' | \
+            kubectl -n ${KUBE_NAMESPACE} get secret ip-allowlist -o json | jq '{ ingress: { jsonapi: { allowed: .data |  map_values(@base64d) } } } ' | \
             helm upgrade ${HELM_BACKEND_RELEASE_NAME} ~/git/helm_deploy/prisoner-content-hub-backend \
               --install --wait --reset-values --timeout 1500s \
               --namespace=${KUBE_NAMESPACE} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ commands:
               --install --wait --reset-values --timeout 1500s \
               --namespace=${KUBE_NAMESPACE} \
               --values ~/git/helm_deploy/prisoner-content-hub-backend/values.<< parameters.environment >>.yaml \
+              --values - \
               --set image.tag=${VERSION_TO_DEPLOY} \
               --set cronToken=${HELM_BACKEND_CRON_TOKEN} \
               --set application.sentry_dsn="${DRUPAL_SENTRY_DSN}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             sed -i "s/appVersion:.*/appVersion: \"${VERSION_TO_DEPLOY}\"/g" ~/git/helm_deploy/prisoner-content-hub-backend/Chart.yaml
+            kubectl -n ${KUBE_NAMESPACE} get secret ip-allowlist -o json | jq '{ ingress: { allowed: .data |  map_values(@base64d) } } ' | \
             helm upgrade ${HELM_BACKEND_RELEASE_NAME} ~/git/helm_deploy/prisoner-content-hub-backend \
               --install --wait --reset-values --timeout 1500s \
               --namespace=${KUBE_NAMESPACE} \

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -14,10 +14,9 @@ $databases['default']['default'] = array(
   'driver' => 'mysql',
 );
 
-$trusted_hosts = getenv('TRUSTED_HOSTS', true);
-
 $settings['trusted_host_patterns'] = [
-  $trusted_hosts
+  getenv('TRUSTED_HOSTS', true),
+  getenv('TRUSTED_HOSTS_JSONAPI', true),
 ];
 
 /**

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -15,8 +15,8 @@ $databases['default']['default'] = array(
 );
 
 $settings['trusted_host_patterns'] = [
-  getenv('TRUSTED_HOSTS', true),
-  getenv('TRUSTED_HOSTS_JSONAPI', true),
+  '^' . getenv('TRUSTED_HOST') . '$',
+  '^' . getenv('TRUSTED_HOST_JSONAPI') . '$',
 ];
 
 /**

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -73,6 +73,8 @@ env:
     value: {{ quote .Values.application.sentry_release }}
   - name: TRUSTED_HOSTS
     value: {{ include "prisoner-content-hub-backend.trustedHosts" . }}
+  - name: TRUSTED_HOSTS_JSONAPI
+    value: {{ include "prisoner-content-hub-backend.trustedHostsJsonApi" . }}
   - name: REDIS_HOST
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -71,10 +71,10 @@ env:
     value: {{ .Values.application.sentry_environment }}
   - name: SENTRY_RELEASE
     value: {{ quote .Values.application.sentry_release }}
-  - name: TRUSTED_HOSTS
-    value: {{ include "prisoner-content-hub-backend.trustedHosts" . }}
-  - name: TRUSTED_HOSTS_JSONAPI
-    value: {{ include "prisoner-content-hub-backend.trustedHostsJsonApi" . }}
+  - name: TRUSTED_HOST
+    value: {{ quote .Values.ingress.host }}
+  - name: TRUSTED_HOST_JSONAPI
+    value: {{ quote .Values.ingress.jsonapi.host }}
   - name: REDIS_HOST
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -83,6 +83,19 @@ Create trusted host pattern
 {{- end }}
 
 {{/*
+Create trusted jsonapi host pattern
+*/}}
+{{- define "prisoner-content-hub-backend.trustedHostsJsonApi" -}}
+{{- with (first .Values.ingress.hosts_jsonapi) -}}
+^{{ (.host | replace "." "\\.") }}$
+{{- end }}
+{{- range (slice .Values.ingress.hosts_jsonapi 1) -}}
+|^{{ (.host | replace "." "\\.")}}$
+{{- end }}
+{{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}
+{{- end }}
+
+{{/*
 Create a string from a list of values joined by a comma
 */}}
 {{- define "app.joinListWithComma" -}}

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -81,3 +81,11 @@ Create trusted host pattern
 {{- end }}
 {{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}
 {{- end }}
+
+{{/*
+Create a string from a list of values joined by a comma
+*/}}
+{{- define "app.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -66,33 +66,7 @@ Create external Kubernetes hostname
 {{- if .Values.ingress.tlsEnabled }}
 {{- $protocol = "https" }}
 {{- end }}
-{{- printf "%s://%s" $protocol (index .Values.ingress.hosts 0).host }}
-{{- end }}
-
-{{/*
-Create trusted host pattern
-*/}}
-{{- define "prisoner-content-hub-backend.trustedHosts" -}}
-{{- with (first .Values.ingress.hosts) -}}
-^{{ (.host | replace "." "\\.") }}$
-{{- end }}
-{{- range (slice .Values.ingress.hosts 1) -}}
-|^{{ (.host | replace "." "\\.")}}$
-{{- end }}
-{{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}
-{{- end }}
-
-{{/*
-Create trusted jsonapi host pattern
-*/}}
-{{- define "prisoner-content-hub-backend.trustedHostsJsonApi" -}}
-{{- with (first .Values.ingress.jsonapi.hosts) -}}
-^{{ (.host | replace "." "\\.") }}$
-{{- end }}
-{{- range (slice .Values.ingress.jsonapi.hosts 1) -}}
-|^{{ (.host | replace "." "\\.")}}$
-{{- end }}
-{{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}
+{{- printf "%s://%s" $protocol .Values.ingress.host }}
 {{- end }}
 
 {{/*

--- a/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_helpers.tpl
@@ -86,10 +86,10 @@ Create trusted host pattern
 Create trusted jsonapi host pattern
 */}}
 {{- define "prisoner-content-hub-backend.trustedHostsJsonApi" -}}
-{{- with (first .Values.ingress.hosts_jsonapi) -}}
+{{- with (first .Values.ingress.jsonapi.hosts) -}}
 ^{{ (.host | replace "." "\\.") }}$
 {{- end }}
-{{- range (slice .Values.ingress.hosts_jsonapi 1) -}}
+{{- range (slice .Values.ingress.jsonapi.hosts 1) -}}
 |^{{ (.host | replace "." "\\.")}}$
 {{- end }}
 {{- printf "|^%s\\.%s\\.svc\\.cluster\\.local$" (include "prisoner-content-hub-backend.fullname" .) .Release.Namespace }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               port: http
               httpHeaders:
                 - name: Host
-                  value: {{ (index .Values.ingress.hosts 0).host }}
+                  value: {{ .Values.ingress.host }}
             initialDelaySeconds: {{ .Values.application.liveness.delaySeconds }}
             timeoutSeconds: {{ .Values.application.liveness.timeoutSeconds }}
           readinessProbe:
@@ -58,7 +58,7 @@ spec:
               port: http
               httpHeaders:
                 - name: Host
-                  value: {{ (index .Values.ingress.hosts 0).host }}
+                  value: {{ .Values.ingress.host }}
             initialDelaySeconds: {{ .Values.application.readiness.delaySeconds }}
             timeoutSeconds: {{ .Values.application.readiness.timeoutSeconds }}
           resources:

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "prisoner-content-hub-backend.fullname" . -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-jsonapi
+  labels:
+    {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
+spec:
+  tls:
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ .host }}
+    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: "/jsonapi"
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -14,13 +14,13 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
 spec:
   tls:
-  {{- range .Values.ingress.hosts-jsonapi }}
+  {{- range .Values.ingress.hosts_jsonapi }}
   - hosts:
     - {{ .host }}
     {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts-jsonapi }}
+  {{- range .Values.ingress.hosts_jsonapi }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -13,19 +13,15 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.jsonapi.allowed | quote }}
 spec:
   tls:
-  {{- range .Values.ingress.jsonapi.hosts }}
-  - hosts:
-    - {{ .host }}
-    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
-  {{- end }}
+    - hosts:
+        - {{ .Values.ingress.jsonapi.host }}
+      {{ if .Values.ingress.jsonapi.cert_secret }}secretName: {{ .Values.ingress.jsonapi.cert_secret }}{{ end }}
   rules:
-  {{- range .Values.ingress.jsonapi.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.ingress.jsonapi.host | quote }}
       http:
         paths:
           - path: "/"
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-  {{- end }}
-{{- end -}}
+  {{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -24,7 +24,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: "/jsonapi"
+          - path: "/"
             backend:
               serviceName: {{ $fullName }}
               servicePort: http

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -6,21 +6,20 @@ metadata:
   name: {{ $fullName }}-jsonapi
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.jsonapi.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
-    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.jsonapi.allowed | quote }}
 spec:
   tls:
-  {{- range .Values.ingress.hosts_jsonapi }}
+  {{- range .Values.ingress.jsonapi.hosts }}
   - hosts:
     - {{ .host }}
     {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts_jsonapi }}
+  {{- range .Values.ingress.jsonapi.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -14,13 +14,13 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
 spec:
   tls:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts-jsonapi }}
   - hosts:
     - {{ .host }}
     {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts-jsonapi }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress-jsonapi.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
 spec:
   tls:
   {{- range .Values.ingress.hosts }}

--- a/helm_deploy/prisoner-content-hub-backend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/ingress.yaml
@@ -12,19 +12,15 @@ metadata:
   {{- end }}
 spec:
   tls:
-  {{- range .Values.ingress.hosts }}
   - hosts:
-    - {{ .host }}
-    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
-  {{- end }}
+    - {{ .Values.ingress.host }}
+    {{ if .Values.ingress.cert_secret }}secretName: {{ .Values.ingress.cert_secret }}{{ end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
           - path: "/"
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-  {{- end }}
 {{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -4,10 +4,8 @@ image:
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-development-green
-  hosts:
-    - host: cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
+  host: cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
   jsonapi:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
-    hosts:
-      - host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
+    host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -4,6 +4,8 @@ image:
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-development-green
-    
+
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
+  hosts-jsonapi:
+    - host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -7,5 +7,5 @@ ingress:
 
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
-  hosts-jsonapi:
+  hosts_jsonapi:
     - host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -4,8 +4,10 @@ image:
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-development-green
-
   hosts:
     - host: cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
-  hosts_jsonapi:
-    - host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk
+  jsonapi:
+    annotations:
+      external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-development-green
+    hosts:
+      - host: jsonapi-cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -1,15 +1,12 @@
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-production-blue
-  hosts:
-    - host: manage.content-hub.prisoner.service.justice.gov.uk
-      cert_secret: prisoner-content-hub-cms-certificate
-    - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  host: manage.content-hub.prisoner.service.justice.gov.uk
+  cert_secret: prisoner-content-hub-cms-certificate
   jsonapi:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-production-blue
-    hosts:
-      - host: jsonapi-cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    host: jsonapi-cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
 
 application:
   # The S3 bucket for production exists in Ireland,

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -5,8 +5,11 @@ ingress:
     - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate
     - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
-  hosts_jsonapi:
-    - host: jsonapi-cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  jsonapi:
+    annotations:
+      external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-production-blue
+    hosts:
+      - host: jsonapi-cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
 
 application:
   # The S3 bucket for production exists in Ireland,

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -5,6 +5,8 @@ ingress:
     - host: manage.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-cms-certificate
     - host: cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  hosts_jsonapi:
+    - host: jsonapi-cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
 
 application:
   # The S3 bucket for production exists in Ireland,

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -3,5 +3,8 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-staging-blue
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-  hosts_jsonapi:
-    - host: jsonapi-cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  jsonapi:
+    annotations:
+      external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-staging-blue
+    hosts:
+      - host: jsonapi-cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -1,10 +1,8 @@
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-staging-blue
-  hosts:
-    - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
   jsonapi:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-jsonapi-prisoner-content-hub-staging-blue
-    hosts:
-      - host: jsonapi-cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    host: jsonapi-cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.staging.yaml
@@ -3,3 +3,5 @@ ingress:
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-backend-prisoner-content-hub-staging-blue
   hosts:
     - host: cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  hosts_jsonapi:
+    - host: jsonapi-cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -84,13 +84,13 @@ ingress:
         deny all;
         return 401;
       }
-    jsonapi:
-      annotations:
-        kubernetes.io/ingress.class: "nginx"
-        nginx.ingress.kubernetes.io/server-snippet: |
-          add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
-        nginx.ingress.kubernetes.io/proxy-body-size: 500m
-        external-dns.alpha.kubernetes.io/aws-weight: "100"
+  jsonapi:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/server-snippet: |
+        add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
+      nginx.ingress.kubernetes.io/proxy-body-size: 500m
+      external-dns.alpha.kubernetes.io/aws-weight: "100"
 
 cron:
   schedule: "*/5 * * * *"

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -84,6 +84,13 @@ ingress:
         deny all;
         return 401;
       }
+    jsonapi:
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        nginx.ingress.kubernetes.io/server-snippet: |
+          add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
+        nginx.ingress.kubernetes.io/proxy-body-size: 500m
+        external-dns.alpha.kubernetes.io/aws-weight: "100"
 
 cron:
   schedule: "*/5 * * * *"

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -78,6 +78,12 @@ ingress:
        add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      server_tokens off;
+      location /jsonapi {
+        deny all;
+        return 401;
+      }
 
 cron:
   schedule: "*/5 * * * *"


### PR DESCRIPTION
### Context

This PR is based on https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/315

### Intent

This PR removes helper functions `prisoner-content-hub-backend.trustedHosts` and prisoner-content-hub-backend.trustedHostsJsonApi` which were difficult to read and created unnecessary configuration.

In order to remove this helper functions, we remove support for multiple hosts.  This allows us to pass through the single value directly into the env variable.

### Considerations

Removing support for multiple hosts should have no effect, as we are not using them anywhere.
Except for on production, where multiple hosts were defined: 
- manage.content-hub.prisoner.service.justice.gov.uk 
- cms-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk

Only the first is being used, so the second one was removed.  

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
