### PR TITLE
Adding cronjon to rebuild cache at 3:01AM every day.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-cache-rebuild-cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-cache-rebuild-cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "prisoner-content-hub-backend.fullname" . }}-cache-rebuild-cronjob
+  labels:
+    {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "1 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          containers:
+          - name: drupal-cache-rebuild-cronjob
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["drush", "cache-rebuild"]
+          restartPolicy: OnFailure


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/wSOaJS7g/515-fix-broken-images-with-cron

### Intent

This PR adds a new cronjob, that runs `drush cache-rebuild` everyday at 3:01AM.
Why 3:01AM?  Because s3 signatures are set to expire at 3:00AM every day, so by running this at 3:01 we ensure that any newly generated urls will be for the _next_ day at 3:00AM.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
