### PR TITLE
Re-enabling module which got removed by Drupal core config update merge.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -55,6 +55,7 @@ module:
   path_alias: 0
   prisoner_hub_cms_help: 0
   prisoner_hub_content_suggestions: 0
+  prisoner_hub_edit_only: 0
   prisoner_hub_featured_content: 0
   prisoner_hub_prison_access: 0
   prisoner_hub_prison_context: 0


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Wa7f4PAU/495-update-drupal-to-latest-version

### Intent

In https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/316 a bunch of config was updated (via the Drupal core update process), and this accidentally wiped a recent change brought in https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/312

This PR adds back in the change.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
