### PR TITLE
Fix help pages not being viewable in Drupal.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
+++ b/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
@@ -13,6 +13,8 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_local_tasks_alter().
  *
  * Replace the "View" with the "Edit" tab.
+ * TODO: Re-instate the view tab, and point the url to frontend prison sites.
+ * Ensure that EntityViewOverride::$excludedContentTypes are excluded.
  */
 function prisoner_hub_edit_only_local_tasks_alter(&$local_tasks) {
   foreach (['node', 'taxonomy_term'] as $entity_type) {
@@ -20,7 +22,6 @@ function prisoner_hub_edit_only_local_tasks_alter(&$local_tasks) {
     $local_tasks['entity.' . $entity_type . '.canonical']['route_name'] = 'entity.' . $entity_type . '.edit_form';
     unset($local_tasks['entity.' . $entity_type . '.edit_form']);
   }
-
 }
 
 /**


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/atLA4c1V/539-help-pages-can-no-longer-be-viewed-in-drupal

### Intent

This fixes a bug introduced by https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/312
The changes from this PR redirected all "View" pages in Drupal to the "Edit" page.  This included help pages, which we _do_ want to view in Drupal.

This PR adds support for excluding help pages (and other content types in the future) from the redirect.  New content types will automatically be redirected, so much be specifically added to the EntityViewOverride::$excludedContentTypes array.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
