### PR TITLE
Adding patches to drupal core to fix broken file viewing issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,7 @@
                 "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
                 "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-34.patch",
                 "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch",
-                "Issue #3254553 - FileUrlGenerator::generate() does not work with externally hosted files using stream wrappers": "patches/drupal-3254553-fileurlgenerator-external-files-7.patch",
+                "Issue #3254553 - FileUrlGenerator::generate() does not work with externally hosted files using stream wrappers": "patches/drupal-3254553-fileurlgenerator-external-files-20.patch",
                 "Issue #3254727 - File links with query parameters no longer work": "patches/drupal-3254727-file-links-with-query-parameters-2.patch"
             },
             "drupal/jsonapi_page_limit": {

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,9 @@
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
                 "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
                 "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-34.patch",
-                "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch"
+                "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch",
+                "Issue #3254553 - FileUrlGenerator::generate() does not work with externally hosted files using stream wrappers": "patches/drupal-3254553-fileurlgenerator-external-files-7.patch",
+                "Issue #3254727 - File links with query parameters no longer work": "patches/drupal-3254727-file-links-with-query-parameters-2.patch"
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch"

--- a/patches/drupal-3254553-fileurlgenerator-external-files-20.patch
+++ b/patches/drupal-3254553-fileurlgenerator-external-files-20.patch
@@ -1,75 +1,23 @@
-diff --git a/core/core.services.yml b/core/core.services.yml
-index 0fa5ab98a3..215e2404f8 100644
---- a/core/core.services.yml
-+++ b/core/core.services.yml
-@@ -394,7 +394,7 @@ services:
-     arguments: ['@stream_wrapper_manager', '@settings', '@logger.channel.file']
-   file_url_generator:
-     class: Drupal\Core\File\FileUrlGenerator
--    arguments: ['@stream_wrapper_manager', '@request_stack', '@module_handler']
-+    arguments: ['@stream_wrapper_manager', '@request_stack', '@module_handler', '@router.request_context']
-   form_builder:
-     class: Drupal\Core\Form\FormBuilder
-     arguments: ['@form_validator', '@form_submitter', '@form_cache', '@module_handler', '@event_dispatcher', '@request_stack', '@class_resolver', '@element_info', '@theme.manager', '@?csrf_token']
 diff --git a/core/lib/Drupal/Core/File/FileUrlGenerator.php b/core/lib/Drupal/Core/File/FileUrlGenerator.php
-index dbfdb0d33b..71e330e624 100644
+index dbfdb0d33b..b3fdefea70 100644
 --- a/core/lib/Drupal/Core/File/FileUrlGenerator.php
 +++ b/core/lib/Drupal/Core/File/FileUrlGenerator.php
-@@ -5,6 +5,7 @@
- use Drupal\Component\Utility\UrlHelper;
- use Drupal\Core\Extension\ModuleHandlerInterface;
- use Drupal\Core\File\Exception\InvalidStreamWrapperException;
-+use Drupal\Core\Routing\RequestContext;
- use Drupal\Core\StreamWrapper\StreamWrapperManager;
- use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
- use Drupal\Core\Url;
-@@ -36,6 +37,13 @@ class FileUrlGenerator implements FileUrlGeneratorInterface {
-    */
-   protected $moduleHandler;
-
-+  /**
-+   * The request context service.
-+   *
-+   * @var \Drupal\Core\Routing\RequestContext
-+   */
-+  protected $requestContext;
-+
-   /**
-    * Constructs a new file URL generator object.
-    *
-@@ -45,11 +53,18 @@ class FileUrlGenerator implements FileUrlGeneratorInterface {
-    *   The request stack.
-    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-    *   The module handler.
-+   * @param \Drupal\Core\Routing\RequestContext $request_context
-+   *   The request context service.
-    */
--  public function __construct(StreamWrapperManagerInterface $stream_wrapper_manager, RequestStack $request_stack, ModuleHandlerInterface $module_handler) {
-+  public function __construct(StreamWrapperManagerInterface $stream_wrapper_manager, RequestStack $request_stack, ModuleHandlerInterface $module_handler, RequestContext $request_context = NULL) {
-     $this->streamWrapperManager = $stream_wrapper_manager;
-     $this->requestStack = $request_stack;
-     $this->moduleHandler = $module_handler;
-+    if (!$request_context) {
-+      @trigger_error('Invoking the FileUrlGenerator constructor without the request_context service parameter is deprecated in drupal:9.4.0 and will no longer be supported in drupal:10.0.0. The request_context service parameter is now required in the FileUrlGenerator constructor. See https://www.drupal.org/node/3254553', E_USER_DEPRECATED);
-+      $request_context = \Drupal::service('router.request_context');
-+    }
-+    $this->requestContext = $request_context;
-   }
-
-   /**
-@@ -186,8 +201,15 @@ public function generate(string $uri): Url {
+@@ -186,8 +186,18 @@ public function generate(string $uri): Url {
        return Url::fromUri(urldecode($options['path']), $options);
      }
      elseif ($wrapper = $this->streamWrapperManager->getViaUri($uri)) {
 -      // Attempt to return an external URL using the appropriate wrapper.
 -      return Url::fromUri('base:' . $this->transformRelative(urldecode($wrapper->getExternalUrl()), FALSE));
 +      $external_url = $wrapper->getExternalUrl();
-+      if (UrlHelper::externalIsLocal($external_url, $this->requestContext->getCompleteBaseUrl())) {
++      $options = UrlHelper::parse($external_url);
++
++      // @todo Switch to dependency injected request_context service after
++      // https://www.drupal.org/project/drupal/issues/3256884 is fixed.
++      if (UrlHelper::externalIsLocal($external_url, \Drupal::service('router.request_context')->getCompleteBaseUrl())) {
 +        // Attempt to return an external URL using the appropriate wrapper.
-+        return Url::fromUri('base:' . $this->transformRelative(urldecode($external_url), FALSE));
++        return Url::fromUri('base:' . $this->transformRelative(urldecode($options['path']), FALSE), $options);
 +      }
 +      else {
-+        $options = UrlHelper::parse($external_url);
 +        return Url::fromUri(urldecode($options['path']), $options);
 +      }
      }
@@ -247,13 +195,13 @@ index af8e25e9b5..a4a004c825 100644
 --- a/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php
 +++ b/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php
 @@ -188,7 +188,7 @@ public function testGenerateURI($filepath, $expected) {
-
+ 
      // No schema file.
      $url = $this->fileUrlGenerator->generate($filepath);
 -    $this->assertEquals($expected, $url->getUri());
 +    $this->assertEquals($expected, $url->toUriString());
    }
-
+ 
    /**
 @@ -251,6 +251,26 @@ public function providerGenerateURI() {
            'https://www.example.com/core/assets/vendor/jquery/jquery.min.js',
@@ -281,4 +229,4 @@ index af8e25e9b5..a4a004c825 100644
 +        ],
      ];
    }
-
+ 

--- a/patches/drupal-3254553-fileurlgenerator-external-files-7.patch
+++ b/patches/drupal-3254553-fileurlgenerator-external-files-7.patch
@@ -1,0 +1,284 @@
+diff --git a/core/core.services.yml b/core/core.services.yml
+index 0fa5ab98a3..215e2404f8 100644
+--- a/core/core.services.yml
++++ b/core/core.services.yml
+@@ -394,7 +394,7 @@ services:
+     arguments: ['@stream_wrapper_manager', '@settings', '@logger.channel.file']
+   file_url_generator:
+     class: Drupal\Core\File\FileUrlGenerator
+-    arguments: ['@stream_wrapper_manager', '@request_stack', '@module_handler']
++    arguments: ['@stream_wrapper_manager', '@request_stack', '@module_handler', '@router.request_context']
+   form_builder:
+     class: Drupal\Core\Form\FormBuilder
+     arguments: ['@form_validator', '@form_submitter', '@form_cache', '@module_handler', '@event_dispatcher', '@request_stack', '@class_resolver', '@element_info', '@theme.manager', '@?csrf_token']
+diff --git a/core/lib/Drupal/Core/File/FileUrlGenerator.php b/core/lib/Drupal/Core/File/FileUrlGenerator.php
+index dbfdb0d33b..71e330e624 100644
+--- a/core/lib/Drupal/Core/File/FileUrlGenerator.php
++++ b/core/lib/Drupal/Core/File/FileUrlGenerator.php
+@@ -5,6 +5,7 @@
+ use Drupal\Component\Utility\UrlHelper;
+ use Drupal\Core\Extension\ModuleHandlerInterface;
+ use Drupal\Core\File\Exception\InvalidStreamWrapperException;
++use Drupal\Core\Routing\RequestContext;
+ use Drupal\Core\StreamWrapper\StreamWrapperManager;
+ use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+ use Drupal\Core\Url;
+@@ -36,6 +37,13 @@ class FileUrlGenerator implements FileUrlGeneratorInterface {
+    */
+   protected $moduleHandler;
+
++  /**
++   * The request context service.
++   *
++   * @var \Drupal\Core\Routing\RequestContext
++   */
++  protected $requestContext;
++
+   /**
+    * Constructs a new file URL generator object.
+    *
+@@ -45,11 +53,18 @@ class FileUrlGenerator implements FileUrlGeneratorInterface {
+    *   The request stack.
+    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+    *   The module handler.
++   * @param \Drupal\Core\Routing\RequestContext $request_context
++   *   The request context service.
+    */
+-  public function __construct(StreamWrapperManagerInterface $stream_wrapper_manager, RequestStack $request_stack, ModuleHandlerInterface $module_handler) {
++  public function __construct(StreamWrapperManagerInterface $stream_wrapper_manager, RequestStack $request_stack, ModuleHandlerInterface $module_handler, RequestContext $request_context = NULL) {
+     $this->streamWrapperManager = $stream_wrapper_manager;
+     $this->requestStack = $request_stack;
+     $this->moduleHandler = $module_handler;
++    if (!$request_context) {
++      @trigger_error('Invoking the FileUrlGenerator constructor without the request_context service parameter is deprecated in drupal:9.4.0 and will no longer be supported in drupal:10.0.0. The request_context service parameter is now required in the FileUrlGenerator constructor. See https://www.drupal.org/node/3254553', E_USER_DEPRECATED);
++      $request_context = \Drupal::service('router.request_context');
++    }
++    $this->requestContext = $request_context;
+   }
+
+   /**
+@@ -186,8 +201,15 @@ public function generate(string $uri): Url {
+       return Url::fromUri(urldecode($options['path']), $options);
+     }
+     elseif ($wrapper = $this->streamWrapperManager->getViaUri($uri)) {
+-      // Attempt to return an external URL using the appropriate wrapper.
+-      return Url::fromUri('base:' . $this->transformRelative(urldecode($wrapper->getExternalUrl()), FALSE));
++      $external_url = $wrapper->getExternalUrl();
++      if (UrlHelper::externalIsLocal($external_url, $this->requestContext->getCompleteBaseUrl())) {
++        // Attempt to return an external URL using the appropriate wrapper.
++        return Url::fromUri('base:' . $this->transformRelative(urldecode($external_url), FALSE));
++      }
++      else {
++        $options = UrlHelper::parse($external_url);
++        return Url::fromUri(urldecode($options['path']), $options);
++      }
+     }
+     throw new InvalidStreamWrapperException();
+   }
+diff --git a/core/modules/file/tests/file_test/file_test.services.yml b/core/modules/file/tests/file_test/file_test.services.yml
+index 1e05c26bff..51b048997a 100644
+--- a/core/modules/file/tests/file_test/file_test.services.yml
++++ b/core/modules/file/tests/file_test/file_test.services.yml
+@@ -11,3 +11,7 @@ services:
+     class: Drupal\file_test\StreamWrapper\DummyStreamWrapper
+     tags:
+       - { name: stream_wrapper, scheme: dummy }
++  stream_wrapper.dummy_external_readonly:
++    class: Drupal\file_test\StreamWrapper\DummyExternalReadOnlyWrapper
++    tags:
++      - { name: stream_wrapper, scheme: dummy-external-readonly }
+diff --git a/core/modules/file/tests/file_test/src/StreamWrapper/DummyExternalReadOnlyWrapper.php b/core/modules/file/tests/file_test/src/StreamWrapper/DummyExternalReadOnlyWrapper.php
+new file mode 100644
+index 0000000000..1727b7950a
+--- /dev/null
++++ b/core/modules/file/tests/file_test/src/StreamWrapper/DummyExternalReadOnlyWrapper.php
+@@ -0,0 +1,149 @@
++<?php
++
++namespace Drupal\file_test\StreamWrapper;
++
++use Drupal\Core\StreamWrapper\ReadOnlyStream;
++use Drupal\Core\StreamWrapper\StreamWrapperInterface;
++
++/**
++ * Helper class for testing the stream wrapper registry.
++ *
++ * Dummy external stream wrapper implementation (dummy-external-readonly://).
++ */
++class DummyExternalReadOnlyWrapper extends ReadOnlyStream {
++
++  /**
++   * @inheritDoc
++   */
++  public static function getType() {
++    return StreamWrapperInterface::READ_VISIBLE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function getName() {
++    return t('Dummy external stream wrapper (readonly)');
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function getDescription() {
++    return t('Dummy external read-only stream wrapper for testing.');
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function getExternalUrl() {
++    [, $target] = explode('://', $this->uri, 2);
++    return 'https://www.dummy-external-readonly.com/' . $target;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function realpath() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function dirname($uri = NULL) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function dir_closedir() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function dir_opendir($path, $options) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function dir_readdir() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function dir_rewinddir() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_cast($cast_as) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_close() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_eof() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_read($count) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_seek($offset, $whence = SEEK_SET) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_set_option($option, $arg1, $arg2) {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_stat() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function stream_tell() {
++    return FALSE;
++  }
++
++  /**
++   * @inheritDoc
++   */
++  public function url_stat($path, $flags) {
++    return FALSE;
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php b/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php
+index af8e25e9b5..a4a004c825 100644
+--- a/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php
++++ b/core/tests/Drupal/KernelTests/Core/File/FileUrlGeneratorTest.php
+@@ -188,7 +188,7 @@ public function testGenerateURI($filepath, $expected) {
+
+     // No schema file.
+     $url = $this->fileUrlGenerator->generate($filepath);
+-    $this->assertEquals($expected, $url->getUri());
++    $this->assertEquals($expected, $url->toUriString());
+   }
+
+   /**
+@@ -251,6 +251,26 @@ public function providerGenerateURI() {
+           'https://www.example.com/core/assets/vendor/jquery/jquery.min.js',
+           'https://www.example.com/core/assets/vendor/jquery/jquery.min.js',
+         ],
++      'external stream wrapper' =>
++        [
++          'dummy-external-readonly://core/assets/vendor/jquery/jquery.min.js',
++          'https://www.dummy-external-readonly.com/core/assets/vendor/jquery/jquery.min.js',
++        ],
++      'external stream wrapper with query string' =>
++        [
++          'dummy-external-readonly://core/assets/vendor/jquery/jquery.min.js?foo=bar',
++          'https://www.dummy-external-readonly.com/core/assets/vendor/jquery/jquery.min.js?foo=bar',
++        ],
++      'external stream wrapper with hashes' =>
++        [
++          'dummy-external-readonly://core/assets/vendor/jquery/jquery.min.js#whizz',
++          'https://www.dummy-external-readonly.com/core/assets/vendor/jquery/jquery.min.js#whizz',
++        ],
++      'external stream wrapper with query string and hashes' =>
++        [
++          'dummy-external-readonly://core/assets/vendor/jquery/jquery.min.js?foo=bar#whizz',
++          'https://www.dummy-external-readonly.com/core/assets/vendor/jquery/jquery.min.js?foo=bar#whizz',
++        ],
+     ];
+   }
+

--- a/patches/drupal-3254727-file-links-with-query-parameters-2.patch
+++ b/patches/drupal-3254727-file-links-with-query-parameters-2.patch
@@ -1,0 +1,13 @@
+diff --git a/core/modules/file/file.module b/core/modules/file/file.module
+index 7300dd9c67..04e849466b 100644
+--- a/core/modules/file/file.module
++++ b/core/modules/file/file.module
+@@ -1527,7 +1527,7 @@ function template_preprocess_file_link(&$variables) {
+   $variables['attributes']->addClass($classes);
+   $variables['file_size'] = format_size($file->getSize() ?? 0);
+
+-  $variables['link'] = Link::fromTextAndUrl($link_text, $url->setOptions($options))->toRenderable();
++  $variables['link'] = Link::fromTextAndUrl($link_text, $url->mergeOptions($options))->toRenderable();
+ }
+
+ /**


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pQ2b2byz/538-unable-to-view-audio-video-files-in-drupal

### Intent

This PR adds two new patches to Drupal core to fix the issues introduced by the 9.3.0 update.  These fix the broken file urls inside Drupal.
For more info on the patches, see:
- https://www.drupal.org/project/drupal/issues/3254553
- https://www.drupal.org/project/drupal/issues/3254727

Documentation about this has been added to https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3760291937/Drupal+and+S3#Drupal-core-update-9.3.0

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
