### PR TITLE
Allow homepage tiles to link to series

### DIFF
--- a/config/sync/core.entity_form_display.node.featured_articles.default.yml
+++ b/config/sync/core.entity_form_display.node.featured_articles.default.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.node.featured_articles.field_exclude_from_prison
+    - field.field.node.featured_articles.field_featured_tile_large
+    - field.field.node.featured_articles.field_featured_tile_small
     - field.field.node.featured_articles.field_moj_featured_tile_large
     - field.field.node.featured_articles.field_moj_featured_tile_small
     - field.field.node.featured_articles.field_prisons
     - node.type.featured_articles
   module:
+    - dynamic_entity_reference
     - field_group
     - path
     - scheduler
@@ -65,24 +68,24 @@ content:
       cascading_selection_enforce: false
       max_depth: 0
     third_party_settings: {  }
-  field_moj_featured_tile_large:
-    type: entity_reference_autocomplete
+  field_featured_tile_large:
+    type: dynamic_entity_reference_default
     weight: 4
     region: content
     settings:
       match_operator: CONTAINS
-      match_limit: 20
-      size: 60
+      match_limit: 10
+      size: 40
       placeholder: ''
     third_party_settings: {  }
-  field_moj_featured_tile_small:
-    type: entity_reference_autocomplete
+  field_featured_tile_small:
+    type: dynamic_entity_reference_default
     weight: 5
     region: content
     settings:
       match_operator: CONTAINS
-      match_limit: 20
-      size: 60
+      match_limit: 10
+      size: 40
       placeholder: ''
     third_party_settings: {  }
   field_prisons:
@@ -146,5 +149,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_moj_featured_tile_large: true
+  field_moj_featured_tile_small: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_view_display.node.featured_articles.default.yml
+++ b/config/sync/core.entity_view_display.node.featured_articles.default.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.node.featured_articles.field_exclude_from_prison
+    - field.field.node.featured_articles.field_featured_tile_large
+    - field.field.node.featured_articles.field_featured_tile_small
     - field.field.node.featured_articles.field_moj_featured_tile_large
     - field.field.node.featured_articles.field_moj_featured_tile_small
     - field.field.node.featured_articles.field_prisons
     - node.type.featured_articles
   module:
+    - dynamic_entity_reference
     - user
 id: node.featured_articles.default
 targetEntityType: node
@@ -22,6 +25,22 @@ content:
       link: true
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_featured_tile_large:
+    type: dynamic_entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_featured_tile_small:
+    type: dynamic_entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_moj_featured_tile_large:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.featured_articles.teaser.yml
+++ b/config/sync/core.entity_view_display.node.featured_articles.teaser.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.featured_articles.field_exclude_from_prison
+    - field.field.node.featured_articles.field_featured_tile_large
+    - field.field.node.featured_articles.field_featured_tile_small
     - field.field.node.featured_articles.field_moj_featured_tile_large
     - field.field.node.featured_articles.field_moj_featured_tile_small
     - field.field.node.featured_articles.field_prisons
@@ -23,6 +25,8 @@ content:
     region: content
 hidden:
   field_exclude_from_prison: true
+  field_featured_tile_large: true
+  field_featured_tile_small: true
   field_moj_featured_tile_large: true
   field_moj_featured_tile_small: true
   field_prisons: true

--- a/config/sync/field.field.node.featured_articles.field_featured_tile_large.yml
+++ b/config/sync/field.field.node.featured_articles.field_featured_tile_large.yml
@@ -1,0 +1,69 @@
+uuid: d863deb0-a919-4abc-b557-fdb8fd8ee44c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_featured_tile_large
+    - node.type.external_link
+    - node.type.featured_articles
+    - node.type.moj_pdf_item
+    - node.type.moj_radio_item
+    - node.type.moj_video_item
+    - node.type.page
+    - taxonomy.vocabulary.series
+  module:
+    - dynamic_entity_reference
+id: node.featured_articles.field_featured_tile_large
+field_name: field_featured_tile_large
+entity_type: node
+bundle: featured_articles
+label: 'Large featured content'
+description: 'Featured content for the large tiles.  <em>Search by content title or ID.</em>'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  node:
+    handler: 'default:node'
+    handler_settings:
+      target_bundles:
+        moj_radio_item: moj_radio_item
+        page: page
+        external_link: external_link
+        moj_pdf_item: moj_pdf_item
+        moj_video_item: moj_video_item
+      sort:
+        field: _none
+        direction: ASC
+      auto_create: false
+      auto_create_bundle: moj_radio_item
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        series: series
+      sort:
+        field: name
+        direction: asc
+      auto_create: false
+      auto_create_bundle: ''
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  shortcut:
+    handler: 'default:shortcut'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/config/sync/field.field.node.featured_articles.field_featured_tile_small.yml
+++ b/config/sync/field.field.node.featured_articles.field_featured_tile_small.yml
@@ -1,0 +1,69 @@
+uuid: 30d1b966-6366-4f33-9210-7c88b80e8f85
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_featured_tile_small
+    - node.type.external_link
+    - node.type.featured_articles
+    - node.type.moj_pdf_item
+    - node.type.moj_radio_item
+    - node.type.moj_video_item
+    - node.type.page
+    - taxonomy.vocabulary.series
+  module:
+    - dynamic_entity_reference
+id: node.featured_articles.field_featured_tile_small
+field_name: field_featured_tile_small
+entity_type: node
+bundle: featured_articles
+label: 'Small featured content'
+description: 'Featured content for the small tiles. <em>Search by title or ID.</em>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  node:
+    handler: 'default:node'
+    handler_settings:
+      target_bundles:
+        moj_radio_item: moj_radio_item
+        page: page
+        external_link: external_link
+        moj_pdf_item: moj_pdf_item
+        moj_video_item: moj_video_item
+      sort:
+        field: _none
+        direction: ASC
+      auto_create: false
+      auto_create_bundle: moj_radio_item
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        series: series
+      sort:
+        field: name
+        direction: asc
+      auto_create: false
+      auto_create_bundle: ''
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings: {  }
+  file:
+    handler: 'default:file'
+    handler_settings: {  }
+  search_api_task:
+    handler: 'default:search_api_task'
+    handler_settings: {  }
+  shortcut:
+    handler: 'default:shortcut'
+    handler_settings: {  }
+  path_alias:
+    handler: 'default:path_alias'
+    handler_settings: {  }
+  user:
+    handler: 'default:user'
+    handler_settings: {  }
+field_type: dynamic_entity_reference

--- a/config/sync/field.storage.node.field_featured_tile_large.yml
+++ b/config/sync/field.storage.node.field_featured_tile_large.yml
@@ -1,0 +1,24 @@
+uuid: 95fd99dd-0f35-4885-a069-a77b5f27800b
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - node
+    - taxonomy
+id: node.field_featured_tile_large
+field_name: field_featured_tile_large
+entity_type: node
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    node: node
+    taxonomy_term: taxonomy_term
+module: dynamic_entity_reference
+locked: false
+cardinality: 2
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_featured_tile_small.yml
+++ b/config/sync/field.storage.node.field_featured_tile_small.yml
@@ -1,0 +1,24 @@
+uuid: 459cc788-2bf7-405b-8e59-a2ce831523ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - node
+    - taxonomy
+id: node.field_featured_tile_small
+field_name: field_featured_tile_small
+entity_type: node
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    node: node
+    taxonomy_term: taxonomy_term
+module: dynamic_entity_reference
+locked: false
+cardinality: 4
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -104,7 +104,8 @@ function prisoner_content_hub_profile_create_new_prison_categories(&$sandbox) {
 }
 
 /**
- * Add prison categories to $entity if there are more than 2 prisons within that category.
+ * Add prison categories to $entity if there are more than 2 prisons within
+ * that category.
  *
  * Note this is *not* a deploy hook.
  */
@@ -149,8 +150,35 @@ function prisoner_content_hub_profile_add_categories(ContentEntityInterface $ent
     }
     if (!$berwyn_included) {
       $entity->set('field_exclude_from_prison', [
-        ['target_id' => $berwyn_tid]
+        ['target_id' => $berwyn_tid],
       ]);
     }
+  }
+}
+
+/**
+ * Copy values from entity reference fields to the new dynamic entity reference fields.
+ */
+function prisoner_content_hub_profile_deploy_copy_homepage_tile_values() {
+  $result = \Drupal::entityQuery('node')
+    ->condition('type', 'featured_articles')
+    ->accessCheck(FALSE)
+    ->execute();
+  $nodes = Node::loadMultiple($result);
+
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($nodes as $node) {
+    $tile_large_value = $node->get('field_moj_featured_tile_large')->getValue();
+    foreach ($tile_large_value as $k => $v) {
+      $tile_large_value[$k]['target_type'] = 'node';
+    }
+    $node->set('field_featured_tile_large', $tile_large_value);
+
+    $tile_small_value = $node->get('field_moj_featured_tile_small')->getValue();
+    foreach ($tile_small_value as $k => $v) {
+      $tile_small_value[$k]['target_type'] = 'node';
+    }
+    $node->set('field_featured_tile_small', $tile_small_value);
+    $node->save();
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ouqhJ3R0/532-allow-homepage-tiles-to-link-to-series

### Intent

This PR adds two new fields to the homepage (featured_articles) content type.  These are exactly the same as the existing fields, but are dynamic entity reference fields (as opposed to standard entity reference fields).  This allows them to link to other entity types.  In this PR, we have enabled taxonomy terms and series.

The values from the previous two fields are copied across, and the previous two fields are then hidden from the form display.  So any content updates from this point will be to the new fields.

The two new fields are called:
- field_featured_tile_large (previously field_moj_featured_tile_large)
- field_featured_tile_small (previously field_moj_featured_tile_small)

### Considerations

This needs to be deployed _just before_ a change to the FE, that reads the new field names.  

After this PR has been deployed to prod, a second change should be made to remove the old fields.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
