### PR TITLE
Fixing incorrect jsonapi pager links.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,8 @@
                 "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch"
             },
             "drupal/jsonapi_page_limit": {
-                "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch"
+                "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch",
+                "Fix incorrect pager links, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/2": "patches/jsonapi_page_limit_fix_pager_links.patch"
             },
             "drupal/views_ef_fieldset": {
                 "Issue #3173822: Exposed operators are not included in fieldsets": "patches/views_ef_fieldset_3173822-operator_issue-9.patch"

--- a/patches/jsonapi_page_limit_fix_pager_links.patch
+++ b/patches/jsonapi_page_limit_fix_pager_links.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Controller/EntityResource.php b/src/Controller/EntityResource.php
+index d88bff3..e190b0b 100644
+--- a/src/Controller/EntityResource.php
++++ b/src/Controller/EntityResource.php
+@@ -43,7 +43,12 @@ class EntityResource extends \Drupal\jsonapi\Controller\EntityResource {
+   protected function getJsonApiParams(Request $request, ResourceType $resource_type) {
+     $params = parent::getJsonApiParams($request, $resource_type);
+     if ($request->query->has('page')) {
+-      $params[OffsetPage::KEY_NAME] = new OffsetPage(OffsetPage::DEFAULT_OFFSET, $this->getMax($request->query->get('page')));
++      $page_params = $request->query->get('page');
++      $offset = array_key_exists(OffsetPage::OFFSET_KEY, $page_params) ? (int) $page_params[OffsetPage::OFFSET_KEY] : OffsetPage::DEFAULT_OFFSET;
++      $params[OffsetPage::KEY_NAME] = new OffsetPage(
++        $offset,
++        $this->getMax($request->query->get('page'))
++      );
+     }
+     return $params;
+   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/w9ODRIv3/211-paginate-secondary-tags-and-series-pages

### Intent

This fixes an issue with the  [jsonapi_page_limit](https://www.drupal.org/project/jsonapi_page_limit) module we are using.  The module would override the `offset` so any pager link from the second page onewards would be incorrect.

### Considerations

The [jsonapi_page_limit](https://www.drupal.org/project/jsonapi_page_limit) is a small module that allows the default limit of 50 items to be increased (this is the limit set by Drupal core).  
At the moment we need this for the "In this section" sidebar component (as some categories have over 50 series).

Whilst the module is very basic in what it does, it's not really properly maintained.  The reason for this is that the functionality for increasing the limit is already covered in the [jsonapi_extras](https://www.drupal.org/project/jsonapi_extras) module, which is far more widely used.
However, we cannot currently use the jsonapi_extras module, due to an incompatibility with the [jsonapi_cross_bundles](https://www.drupal.org/project/jsonapi_cross_bundles) module.  Although it does look like this is might now be fixed in https://www.drupal.org/project/jsonapi_cross_bundles/issues/3070430.  But either way, we don't currently need all the functionality that jsonapi_extras comes with, so for now we will stick with jsonapi_page_limit :sweat_smile:

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
