### PR TITLE
Prevent page cache from being cleared during deployments.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   node: 0
   options: 0
   page_cache: 0
+  page_cache_persist: 0
   path: 0
   path_alias: 0
   prisoner_hub_cms_help: 0

--- a/docroot/modules/custom/page_cache_persist/README.md
+++ b/docroot/modules/custom/page_cache_persist/README.md
@@ -1,0 +1,26 @@
+# Page Cache Persist
+
+### What
+This module makes Drupal's internal page cache persist when Drupal tries to clear all caches.
+E.g. when running `drush cache:rebuild`.  By default, the page cache would also be cleared,
+but with this module enabled, the page cache contents will be retained.
+
+This prevents performance issues on production sites, particularly wth deployments.
+
+Note that if an individual page is cleared, this will still work as normal (i.e. be deleted).
+This module only prevents clearing of the entire page cache, not specific items.
+
+### Why?
+Drupal's internal page cache module is often used for smaller sites.  It's assumed that larger,
+higher-traffic websites, will use an external cache such as Varnish or a CDN.
+
+Drupal regularly clears out the entire cache, particularly on deployments.
+E.g. `drush cache-rebuild` is part of the `drush deploy` command. See https://www.drush.org/latest/deploycommand/
+
+When using an external cache, it is unlikely you would clear the entire cache on deployments.
+
+Note that if you still want to clear the entire page cache, there is a drush command provided by
+this module for doing so:
+```
+drush cache:force-clear-page
+```

--- a/docroot/modules/custom/page_cache_persist/page_cache_persist.info.yml
+++ b/docroot/modules/custom/page_cache_persist/page_cache_persist.info.yml
@@ -1,0 +1,7 @@
+name: 'Page Cache Persist'
+type: module
+description: 'Prevents the internal page cache from being cleared when all caches are cleared (e.g. drush cr).  Provides an alternative method for clearing the page cache.'
+core_version_requirement: ^8 || ^9
+package: 'Custom'
+dependencies:
+  - drupal:page_cache

--- a/docroot/modules/custom/page_cache_persist/page_cache_persist.services.yml
+++ b/docroot/modules/custom/page_cache_persist/page_cache_persist.services.yml
@@ -1,0 +1,13 @@
+services:
+  page_cache_persist.page_cache_override:
+    class: Drupal\page_cache_persist\Cache\PageCachePersist
+    decorates: cache.page
+    arguments: ['@page_cache_persist.page_cache_override.inner']
+  page_cache_persist.cache_router_rebuild_subscriber:
+    class: Drupal\page_cache_persist\EventSubscriber\CacheRouterRebuildSubscriber
+    decorates: cache_router_rebuild_subscriber
+  page_cache_persist.commands:
+    class: \Drupal\page_cache_persist\Commands\PageCachePersistCommands
+    arguments: ['@cache.page']
+    tags:
+      - { name: drush.command }

--- a/docroot/modules/custom/page_cache_persist/src/Cache/PageCachePersist.php
+++ b/docroot/modules/custom/page_cache_persist/src/Cache/PageCachePersist.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\page_cache_persist\Cache;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
+
+/**
+ * Class PageCachePersist.
+ *
+ * This decorates the default page.cache service.
+ * Note we cannot extend another class, as we do not know which type of cache
+ * backend is being used (e.g. database, redis, etc).  So we must implement each
+ * of the interface methods and call the inner injected service.
+ */
+class PageCachePersist implements CacheBackendInterface {
+
+  /**
+   * The "inner" cache bin.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
+   * PageCacheOverride constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The "inner" cache backend service.
+   */
+  public function __construct(CacheBackendInterface $cache) {
+    $this->cache = $cache;
+  }
+
+  /**
+   * Override deleteAll() with nothing.
+   *
+   * This prevents the page cache from being cleared.
+   */
+  public function deleteAll() {
+    // Do nothing.
+  }
+
+  /**
+   * Provide an alternative way to delete the entire page cache.
+   */
+  public function forceDeleteAll() {
+    $this->cache->deleteAll();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function get($cid, $allow_invalid = FALSE) {
+    return $this->cache->get($cid, $allow_invalid);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getMultiple(&$cids, $allow_invalid = FALSE) {
+    return $this->cache->getMultiple($cids, $allow_invalid);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function set($cid, $data, $expire = Cache::PERMANENT, array $tags = []) {
+    return $this->cache->set($cid, $data, $expire, $tags);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function setMultiple(array $items) {
+    return $this->cache->setMultiple($items);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function delete($cid) {
+    $this->cache->delete($cid);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function deleteMultiple(array $cids) {
+    $this->cache->deleteMultiple($cids);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function invalidate($cid) {
+    $this->cache->invalidate($cid);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function invalidateMultiple(array $cids) {
+    $this->cache->invalidateMultiple($cids);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function invalidateAll() {
+    $this->cache->invalidateAll();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function garbageCollection() {
+    return $this->cache->garbageCollection();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeBin() {
+    return $this->cache->removeBin();
+  }
+}

--- a/docroot/modules/custom/page_cache_persist/src/Commands/PageCachePersistCommands.php
+++ b/docroot/modules/custom/page_cache_persist/src/Commands/PageCachePersistCommands.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\page_cache_persist\Commands;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Page cache persist commands.
+ */
+class PageCachePersistCommands extends DrushCommands {
+
+  /**
+   * The page cache service, which will be ovverriden by this module.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $pageCache;
+
+  public function __construct(CacheBackendInterface $page_cache) {
+    $this->pageCache = $page_cache;
+  }
+
+  /**
+   * Force delete of page cache.
+   *
+   * @command cache:force-clear-page
+   *
+   * @usage cache:force-clear-page
+   *   Force clearing page cache.
+   *
+   * @aliases fcp
+   */
+  public function forcecCacheClearPage() {
+    $this->pageCache->forceDeleteAll();
+  }
+
+}

--- a/docroot/modules/custom/page_cache_persist/src/EventSubscriber/CacheRouterRebuildSubscriber.php
+++ b/docroot/modules/custom/page_cache_persist/src/EventSubscriber/CacheRouterRebuildSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\page_cache_persist\EventSubscriber;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\EventSubscriber\CacheRouterRebuildSubscriber as CoreCacheRouterRebuildSubscriber;
+
+/**
+ * Class CacheRouterRebuildSubscriber
+ *
+ * Decorate the core CacheRouterRebuildSubscriber to prevent http_repsonse tag
+ * being cleared.
+ */
+class CacheRouterRebuildSubscriber extends CoreCacheRouterRebuildSubscriber {
+
+  /**
+   * Override the onRouterFinished method.
+   *
+   * Prevent invalidation of the 'http_response' tag.
+   */
+  public function onRouterFinished() {
+    Cache::invalidateTags(['4xx-response', 'route_match']);
+  }
+}

--- a/docroot/modules/custom/page_cache_persist/tests/src/PageCachePersistTest.php
+++ b/docroot/modules/custom/page_cache_persist/tests/src/PageCachePersistTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\Tests\page_cache_persist\ExistingSite;
+
+use Drupal\Core\Url;
+use Drush\TestTraits\DrushTestTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Test the page_cache_persist module functionality.
+ *
+ * @group page_cache_persist
+ */
+class PageCachePersistTest extends ExistingSiteBase {
+
+  use DrushTestTrait;
+
+  /**
+   * The url of the node.
+   *
+   * @var string
+   */
+  protected $nodeUrlString;
+
+  /**
+   * Set up content and generate cache.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $node = $this->createNode();
+    $url = Url::fromRoute('jsonapi.node.individual', ['entity' => $node->uuid()]);
+    $url->setAbsolute(TRUE);
+    $this->nodeUrlString = $url->toString();
+    // Visit the page to create the cache entry.
+    $this->visit($this->nodeUrlString);
+  }
+
+  /**
+   * Test that the page cache is working correctly.
+   */
+  public function testPageCacheCreated() {
+    $cid_parts = [$this->nodeUrlString, ''];
+    $cache = $this->getCacheItem();
+    $this->assertNotFalse($cache);
+    $this->assertNotEmpty($cache->data);
+  }
+
+  /**
+   * Test that the page cache isn't cleared when drush cache:rebuild is run.
+   */
+  public function testDrushCacheRebuild() {
+    $this->drush('cache:rebuild');
+    $cache = $this->getCacheItem();
+    $this->assertNotFalse($cache);
+    $this->assertNotEmpty($cache->data);
+  }
+
+  /**
+   * Test that the page cache isn't cleared when drupal_flush_all_caches() is
+   * called.
+   */
+  public function testCacheClearAll() {
+    drupal_flush_all_caches();
+    $cache = $this->getCacheItem();
+    $this->assertNotFalse($cache);
+    $this->assertNotEmpty($cache->data);
+  }
+
+  /**
+   * Test that we can still clear the page cache using drush cache:force-clear-page.
+   */
+  public function testDrushForceCacheClear() {
+    $this->drush('cache:force-clear-page');
+    $cache = $this->getCacheItem();
+    $this->assertFalse($cache);
+  }
+
+  /**
+   * Helper function to get the cache item for the node jsonapi page we are
+   * testing with.
+   *
+   * @return FALSE|object
+   *   Either the cache object if found, otherwise FALSE.
+   */
+  private function getCacheItem() {
+    $cid_parts = [$this->nodeUrlString, ''];
+    $cid = implode(':', $cid_parts);
+    return \Drupal::cache('page')->get($cid);
+  }
+
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/LQ6xpxSV/581-fix-performance-issues-during-drupal-deployments

### Intent

This PR adds a new Drupal module that overrides the cache.page service, to prevent the page cache from being cleared when `drush cache:rebuild` is called.

This will mean the page cache is retained during deployments, fixing performance issues that effect the site immediately after a deployment (where Drupal has to rebuild the page cache for every request).

There is an alternative method for implicitly clearing the page cache.
```
drush cache:force-clear-page
```

Details of this will be added to https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal

### Considerations

When Drupal clears out the cache, it also rebuilds the router, picking up any new or modified routes.
After this is done, it invalidates the entire page cache (it does not check to see whether there are actually any changes).  The module in this PR prevents the page cache from being invalidated.
This _should_ be fine, as each item in the page cache is stored with its url, so if a url on a route has changed, it will be considered a new cache entry (same goes for new routes, these will not exist as cache items).  
However, if there is a change within the router that does not effect the urls itself (e.g. an update to a parameter type on an existing route), the existing cache may prevent these changes from appearing immediately. For those situations, `drush cache:force-clear-page` will need to be called.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [ ] Tested in Development
