### PR TITLE
Fixing "content has been modified by another user" error when re-saving content

### DIFF
--- a/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
+++ b/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
@@ -42,11 +42,19 @@ function prisoner_hub_edit_only_form_alter(&$form, FormStateInterface $form_stat
 }
 
 /**
- * Submit handler that removes the redirect on node edit forms.
+ * Submit handler for node edit forms.
  */
-function prisoner_hub_edit_only_form_submit($form, FormStateInterface $form_state) {
+function prisoner_hub_edit_only_form_submit(&$form, FormStateInterface $form_state) {
   // Only disable redirects if there is none specified in the url.
   if (empty(\Drupal::request()->query->get('destination'))) {
     $form_state->disableRedirect();
+
+    // Update the changed value on the reloaded form to be greater than that of
+    // the saved entity.  Otherwise, the form cannot be re-saved, as Drupal
+    // thinks the modifications came before the ones we previously saved.
+    //
+    // This issue only occurs when a user is shown the same edit form immediately
+    // after saving.
+    $form['changed']['#value'] = $form_state->getFormObject()->getEntity()->getChangedTime() + 1;
   }
 }

--- a/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
+++ b/docroot/modules/custom/prisoner_hub_edit_only/prisoner_hub_edit_only.module
@@ -49,12 +49,12 @@ function prisoner_hub_edit_only_form_submit(&$form, FormStateInterface $form_sta
   if (empty(\Drupal::request()->query->get('destination'))) {
     $form_state->disableRedirect();
 
-    // Update the changed value on the reloaded form to be greater than that of
-    // the saved entity.  Otherwise, the form cannot be re-saved, as Drupal
+    // Update the changed value on the reloaded form.  Otherwise, the previous
+    // value will be used, which means the form cannot be re-saved, as Drupal
     // thinks the modifications came before the ones we previously saved.
     //
     // This issue only occurs when a user is shown the same edit form immediately
     // after saving.
-    $form['changed']['#value'] = $form_state->getFormObject()->getEntity()->getChangedTime() + 1;
+    $form['changed']['#value'] = \Drupal::time()->getRequestTime();
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/e6MQjFUu/587-fix-this-content-has-been-modified-by-another-user-issue

### Intent

Previously, Drupal would redirect the user to the "View" page after saving content.  Since we disabled this page, the user is shown the same edit form they were previously on.
When content is saved, Drupal checks to see if a more recent change was made to the same content.  If so, it assumes that there is a more recent modification, and the current one is stale.  Showing the user the "The content has been modified by another user" error.
The date it checks from is when the edit form was originally loaded, in our case this was when the form was first loaded, i.e. the value wasn't being updated after the edit page is refreshed (when the content is saved). 
This could be considered a bug in Drupal, but because the scenario of the same content form being reloaded never occurs (as it would always redirect to another page), it's something we have run into with our own modifications.

The fix is to update the changed value on the form to the current time.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
