### PR TITLE
Add a prison field to the user.

### DIFF
--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -3,11 +3,28 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.user.user.user_picture
-    - image.style.thumbnail
+    - field.field.user.user.field_user_prisons
   module:
-    - image
+    - field_group
+    - term_reference_tree
     - user
+third_party_settings:
+  field_group:
+    group_prisons:
+      children:
+        - field_user_prisons
+      label: Prisons
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: "Select the prison(s) this user is associated with.</br>\r\nThis will determine the content the user can make changes to.</br>\r\nMultiple prisons can be selected, and if a prison category is selected the user will be able to make changes to all content owned by any prison within that category."
+        required_fields: true
 _core:
   default_config_hash: LLAieeozVsoZDb-2PbFxRJpQqnKmpR7-4OoRJnduz-U
 id: user.user.default
@@ -16,7 +33,7 @@ bundle: user
 mode: default
 content:
   account:
-    weight: -10
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -25,22 +42,19 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  language:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  timezone:
-    weight: 6
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  user_picture:
-    type: image_image
-    weight: -1
+  field_user_prisons:
+    type: term_reference_tree
+    weight: 5
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      start_minimized: false
+      leaves_only: false
+      select_parents: false
+      cascading_selection: 1
+      cascading_selection_enforce: true
+      max_depth: 0
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  language: true
+  path: true
+  timezone: true

--- a/config/sync/core.entity_view_display.user.user.compact.yml
+++ b/config/sync/core.entity_view_display.user.user.compact.yml
@@ -4,10 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.user.compact
-    - field.field.user.user.user_picture
-    - image.style.thumbnail
+    - field.field.user.user.field_user_prisons
   module:
-    - image
     - user
 _core:
   default_config_hash: C3k_McOy8bL8rTnIjspy5OfFdgqV1z6OdGZaI-tO5eM
@@ -15,16 +13,8 @@ id: user.user.compact
 targetEntityType: user
 bundle: user
 mode: compact
-content:
-  user_picture:
-    type: image
-    label: hidden
-    settings:
-      image_link: content
-      image_style: thumbnail
-    third_party_settings: {  }
-    weight: 0
-    region: content
+content: {  }
 hidden:
+  field_user_prisons: true
   member_for: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.user.user.default.yml
+++ b/config/sync/core.entity_view_display.user.user.default.yml
@@ -3,10 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.user.user.user_picture
-    - image.style.thumbnail
+    - field.field.user.user.field_user_prisons
   module:
-    - image
     - user
 _core:
   default_config_hash: L2mtwGWH_7wDRCMIR4r_Iu_jmvQ10DV1L8ht8iNZ5qY
@@ -15,19 +13,18 @@ targetEntityType: user
 bundle: user
 mode: default
 content:
+  field_user_prisons:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
   member_for:
     settings: {  }
     third_party_settings: {  }
     weight: 5
-    region: content
-  user_picture:
-    type: image
-    label: hidden
-    settings:
-      image_link: content
-      image_style: thumbnail
-    third_party_settings: {  }
-    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/field.field.user.user.field_user_prisons.yml
+++ b/config/sync/field.field.user.user.field_user_prisons.yml
@@ -1,0 +1,30 @@
+uuid: fe52e116-e73d-4bc1-9cf3-5c6509953c11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_user_prisons
+    - taxonomy.vocabulary.prisons
+  module:
+    - user
+id: user.user.field_user_prisons
+field_name: field_user_prisons
+entity_type: user
+bundle: user
+label: Prisons
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prisons: prisons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.user.field_user_prisons.yml
+++ b/config/sync/field.storage.user.field_user_prisons.yml
@@ -1,0 +1,20 @@
+uuid: a1ec5ef6-4fb9-4c25-b2a6-cfbf4d981cf4
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: user.field_user_prisons
+field_name: field_user_prisons
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/mtYpgoDF/575-allow-any-user-from-a-prison-to-edit-content-published-by-anyone-from-that-prison

### Intent

> What changes are introduced by this PR that correspond to the above card?

This PR adds a new `field_user_prisons` to the user entity type, this will allow us to start associating users with prisons. 
We can then complete the changes from https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/335

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
