### PR TITLE
Fix content suggestions not returning consistent results.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_content_suggestions/src/Resource/ContentSuggestions.php
+++ b/docroot/modules/custom/prisoner_hub_content_suggestions/src/Resource/ContentSuggestions.php
@@ -48,6 +48,10 @@ class ContentSuggestions extends EntityQueryResourceBase {
     // Exclude the current node.
     $query->condition('nid', $node->id(), '<>');
 
+    // Exclude unpublished content as this isn't added by defaul to the query.
+    // See https://drupal.stackexchange.com/a/257370/4831
+    $query->condition('status', NodeInterface::PUBLISHED);
+
     // Exclude the current series.
     $series_value = $node->get('field_moj_series')->getValue();
     if (!empty($series_value)) {

--- a/docroot/modules/custom/prisoner_hub_content_suggestions/src/Resource/ContentSuggestions.php
+++ b/docroot/modules/custom/prisoner_hub_content_suggestions/src/Resource/ContentSuggestions.php
@@ -48,7 +48,7 @@ class ContentSuggestions extends EntityQueryResourceBase {
     // Exclude the current node.
     $query->condition('nid', $node->id(), '<>');
 
-    // Exclude unpublished content as this isn't added by defaul to the query.
+    // Exclude unpublished content as this isn't added by default to the query.
     // See https://drupal.stackexchange.com/a/257370/4831
     $query->condition('status', NodeInterface::PUBLISHED);
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/nbxMo7d4/635-you-might-like-component-is-bugged

### Intent

The you might like component was returning inconsistent results, with sometimes less than 4 items being returned inside `data`, and items appearing as `omitted`.

The issue was caused by the fact that unpublished items were not being excluded from the query.  This meant they got removed from the JSON:API response _after_ the query had run.  Resulting in a reduced total number of items being returned.

This PR adds the publishing status as a condition to the query, so that the 4 items returned by the query will always be accessible and not get excluded.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
