### PR TITLE
Bugfix/image upload button not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN pecl install uploadprogress \
 RUN pecl install redis \
   && docker-php-ext-enable redis
 
+# Enable apache modules that are used in Drupal's htaccess.
+RUN a2enmod expires headers
+
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php composer-setup.php --install-dir=/bin --filename=composer --version=2.1.8 \
   && php -r "unlink('composer-setup.php');"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -27,6 +27,7 @@ module:
   field_group_open_non_empty: 0
   field_ui: 0
   file: 0
+  file_download_expires_fix: 0
   filter: 0
   flood_unblock: 0
   flysystem: 0

--- a/docroot/modules/custom/file_download_expires_fix/README.md
+++ b/docroot/modules/custom/file_download_expires_fix/README.md
@@ -1,0 +1,16 @@
+# File Download Expires Fix
+
+This is a small module that fixes an issue where Symfony's BinaryFileResponse sets the following
+header on all cacheable file responses.
+```
+Cache-Control: public
+```
+
+Whilst there is nothing wrong with this.  It means that Drupal's default mod_expires functionality
+(found in .htaccess) will not work.  As mod_expires only works when there are no cache headers
+already set on the response.
+This module simply removes these headers, allowing mod_expires to do it's magic.
+
+It's assumed that mod_expires is enabled, and the standard htaccess from Drupal core is being used.
+
+@see https://www.drupal.org/project/drupal/issues/3263593

--- a/docroot/modules/custom/file_download_expires_fix/file_download_expires_fix.info.yml
+++ b/docroot/modules/custom/file_download_expires_fix/file_download_expires_fix.info.yml
@@ -1,0 +1,5 @@
+name: 'File Download Expires Fix'
+type: module
+description: 'Fixes an issue in Drupal/Symfony where file downloads are missing a max-age cache header.'
+package: 'Custom'
+core_version_requirement: ^9

--- a/docroot/modules/custom/file_download_expires_fix/file_download_expires_fix.services.yml
+++ b/docroot/modules/custom/file_download_expires_fix/file_download_expires_fix.services.yml
@@ -1,0 +1,5 @@
+services:
+  file_download_expires_fix.response_subscriber:
+    class: Drupal\file_download_expires_fix\EventSubscriber\ResponseSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/file_download_expires_fix/src/EventSubscriber/ResponseSubscriber.php
+++ b/docroot/modules/custom/file_download_expires_fix/src/EventSubscriber/ResponseSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\file_download_expires_fix\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Subscribe to response events.
+ */
+class ResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse'];
+    return $events;
+  }
+
+  /**
+   * Remove Cache-Control and Expires headers on cacheable files.
+   *
+   * By removing the headers, we allow mod_expires to set cache headers from
+   * Drupal's htaccess.
+   * @see https://www.drupal.org/project/drupal/issues/3263593
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   Response event.
+   */
+  public function onResponse(ResponseEvent $event): void {
+    $response = $event->getResponse();
+    if ($response instanceof BinaryFileResponse && $response->isCacheable()) {
+      $response->headers->remove('Cache-Control');
+      $response->headers->remove('Expires');
+    }
+  }
+}

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -22,7 +22,7 @@ $settings['trusted_host_patterns'] = [
 /**
  * Flysystem S3 filesystem configuration
  */
-$flysystem_schemes = [
+$settings['flysystem'] = [
 
   'local-files' => [
     'driver' => 'local',
@@ -76,13 +76,22 @@ $flysystem_schemes = [
       // Optionally set to path style endpoint.  Used for localstack.
       'use_path_style_endpoint' => getenv('FLYSYSTEM_S3_USE_PATH_STYLE_ENDPOINT', TRUE) === "true",
     ],
-    'serve_js' => TRUE,
-    'serve_css' => TRUE,
     'cache' => TRUE, // Creates a metadata cache to speed up lookups
   ],
 ];
 
-$settings['flysystem'] = $flysystem_schemes;
+// Copy over our S3 config, and setup a new scheme that is used just for css/js.
+$settings['flysystem']['s3-css-js'] = $settings['flysystem']['s3'];
+$settings['flysystem']['s3-css-js']['serve_js'] = TRUE;
+$settings['flysystem']['s3-css-js']['serve_css'] = TRUE;
+
+// Set public to FALSE, so that files are downloaded through Drupal
+// (and not directly from S3).
+// This prevents us having to deal with S3 signatures.  Allowing css/js to be
+// cached in the users browser.
+// Also, serving JS from the same origin fixes an issue when opening dialog
+// windows in ckeditor (e.g. image upload). See https://trello.com/c/48w0up7I
+$settings['flysystem']['s3-css-js']['config']['public'] = FALSE;
 
 // Prevent file permission errors when image styles are generated.
 // @See https://www.drupal.org/project/flysystem_s3/issues/3058063#comment-14164774


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/48w0up7I/661-fix-image-upload-button-not-working-in-text-editor

### Intent

This PR fixes an issue where the image upload button in the text editor wouldn't initially work.

The issue was due to the fact that clicking the upload button triggers an ajax request, and this loads in an additional Javascript file.  For _some reason_ when this file is loaded from S3, it appears to be loaded in _after_ Drupal's calls `Drupal.attachBehaviors()` (which is like an event to say that something new has been loaded in).  Because of this, nothing happens.  When the additional Javascript file is loaded from the same hostname as the site is currently on, it's loaded in correctly (i.e. before `Drupal.attachBehaviors()`).

I couldn't work out why this is, and didn't see anyone else reporting the same issue.  

Rather than directly fix the issue, I decided to load the JS/CSS files directly via Drupal.  Using a new flysystem scheme, that streams the files from S3.  This has the additional benefit of not requiring S3 signatures, which also means the CSS/JS files can be cached in the users browser.

I had to also fix an additional issue where cache headers were not being set correctly, as part of this PR.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
