### PR TITLE
Fix issue with broken PHP streams that results in empty CSS/JS.

### DIFF
--- a/patches/stream_util-pr3-more-robust-version-of-getsize.patch
+++ b/patches/stream_util-pr3-more-robust-version-of-getsize.patch
@@ -1,17 +1,8 @@
-From 133d35e9cfc125335656ab8afe89b1a7daf6d5c1 Mon Sep 17 00:00:00 2001
-From: Benji Fisher <benji@FisherFam.org>
-Date: Wed, 10 Feb 2021 11:17:40 -0500
-Subject: [PATCH] More robust version of getSize()
-
----
- src/StreamUtil.php | 19 ++++++++++++++++---
- 1 file changed, 16 insertions(+), 3 deletions(-)
-
 diff --git a/src/StreamUtil.php b/src/StreamUtil.php
-index 09907ef..428bf4b 100644
+index 09907ef..81640d3 100644
 --- a/src/StreamUtil.php
 +++ b/src/StreamUtil.php
-@@ -84,13 +84,26 @@ public static function getUsableUri($stream)
+@@ -84,13 +84,27 @@ public static function getUsableUri($stream)
       *
       * @param resource $stream The stream.
       *
@@ -22,10 +13,11 @@ index 09907ef..428bf4b 100644
      {
 -        $stat = fstat($stream);
 +        $stat = stream_get_meta_data($stream);
- 
+
 -        return $stat['size'];
 +        switch ($stat['wrapper_type']) {
 +            case 'plainfile':
++            case 'PHP':
 +                $stats = fstat($stream);
 +                return is_array($stats) && isset($stats['size']) ? $stats['size'] : false;
 +                break;
@@ -39,5 +31,5 @@ index 09907ef..428bf4b 100644
 +                return false;
 +        }
      }
- 
+
      /**


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/48w0up7I/661-fix-image-upload-button-not-working-in-text-editor

### Intent

This PR fixes an issue introduced by the changes in https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/340

As we are now streaming CSS/JS through Drupal (from S3), there was an issue with one of the PHP libraries being used, which was using a patch that didn't support streaming through PHP in this way.

The issue and fix is better described here:
https://www.drupal.org/project/drupal/issues/3179014#comment-14410242

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
