### PR TITLE
Add ability to sort taxonomy terms by the most recently updated content.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Add the series_sort_value field to the node entity type.
@@ -14,4 +15,49 @@ function prisoner_hub_taxonomy_sorting_update_9001(&$sandbox) {
   $definition = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node')['series_sort_value'];
   \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
 
+}
+
+/**
+ * Add the content_updated field to the taxonomy term entity type.
+ */
+function prisoner_hub_taxonomy_sorting_update_9002(&$sandbox) {
+  $definition = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('taxonomy_term')['content_updated'];
+  \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
+
+}
+
+/**
+ * Update existing taxonomy terms with values for content_updated.
+ */
+function prisoner_hub_taxonomy_sorting_update_9003(&$sandbox) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['result'] = \Drupal::entityQuery('taxonomy_term')
+      ->condition('vid', ['series', 'moj_categories'],'IN')
+      ->execute();
+
+    $sandbox['progress'] = 0;
+  }
+  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['result'], 50, TRUE));
+
+  /** @var \Drupal\taxonomy\TermInterface $term */
+  foreach ($terms as $term) {
+    $result = \Drupal::entityQuery('node', 'OR')
+      ->condition('field_moj_top_level_categories', $term->id())
+      ->condition('field_moj_series', $term->id())
+      ->sort('changed', 'DESC')
+      ->range(0, 1)
+      ->execute();
+    $nodes = Node::loadMultiple($result);
+    if (!empty($nodes)) {
+      $node = reset($nodes);
+      $term->set('content_updated', $node->get('changed')->value);
+      $term->save();
+    }
+    $sandbox['progress']++;
+  }
+  $sandbox['#finished'] = $sandbox['progress'] >= count($sandbox['result']);
+  if ($sandbox['#finished'] ) {
+    return 'Completed updated, processed total of: ' . $sandbox['progress'];
+  }
+  return 'Processed taxonomy terms: ' . $sandbox['progress'];
 }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -24,69 +25,24 @@ function prisoner_hub_taxonomy_sorting_entity_base_field_info(\Drupal\Core\Entit
       ->setDescription(t('A calculated sorting value for a content within a series.'))
       ->setReadOnly(TRUE);
   }
+  elseif ($entity_type->id() == 'taxonomy_term') {
+    $fields['content_updated'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Content updated'))
+      ->setDescription(t('A timestamp of when the last piece of content within this taxonomy term was updated.'))
+      ->setReadOnly(TRUE);
+  }
   return $fields;
 }
 
 /**
  * Implements hook_entity_presave().
  *
- * Copy sorting value from either season+episode OR release date fields to the
- * series_sort_value field.
+ * Update values for sorting when content is created and updated.
  */
 function prisoner_hub_taxonomy_sorting_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
-  if ($entity instanceof ContentEntityInterface && $entity->hasField('field_moj_series')) {
-    $series_result = $entity->field_moj_series->referencedEntities();
-    if (empty($series_result)) {
-      // No series attached to content, do nothing.
-      return;
-    }
-    $series_entity = current($series_result);
-    $sort_by_value = $series_entity->field_sort_by->getString();
-    switch ($sort_by_value) {
-      case 'season_and_episode_asc':
-      case 'season_and_episode_desc':
-        $season_number = $entity->field_moj_season->value;
-        $episode_number = $entity->field_moj_episode->value;
-
-        if ($season_number >= 1 && $season_number <= 999 && $episode_number >= 1 && $episode_number <= 999) {
-          // Episode number must be padded to account for the different lengths
-          // upto 999.  E.g. season 1 episode 15 could be mixed up
-          // with season 11 episode 5.
-          $episode_number_padded = str_pad($episode_number, 3, '0', STR_PAD_LEFT);
-          $calculated_sort_value = (int)$season_number . $episode_number_padded;
-        }
-        else {
-          // If either season or episode number are out of range, set the value
-          // to 0 and warn the user.  This should only ever happen if content is
-          // being bulk updated. (As when editing the content directly, the
-          // fields are made mandatory and dont allow numbers outside the range).
-          \Drupal::messenger()->addWarning(t('Missing season or episode number for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
-          $calculated_sort_value = 0;
-        }
-        break;
-      case 'release_date_asc':
-      case 'release_date_desc':
-        if ($entity->field_release_date->date) {
-          $calculated_sort_value = $entity->field_release_date->date->getTimestamp();
-        }
-        else {
-          // If release date field is empty, set the value to 0 and
-          // warn the user.  This should only ever happen if content is being
-          // bulk updated. (As when editing the content directly, the field is
-          // made mandatory).
-          \Drupal::messenger()->addWarning(t('Missing release date for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
-          $calculated_sort_value = 0;
-        }
-        break;
-    }
-
-    // If the sorting is descending, cast this as a negative number to invert
-    // the direction.  This allows us to always use ASC direction when running
-    // queries, e.g. through JSON:API.
-    if (substr($sort_by_value, -4) == 'desc') {
-      $calculated_sort_value = -$calculated_sort_value;
-    }
-    $entity->set('series_sort_value', $calculated_sort_value);
+  if ($entity instanceof NodeInterface) {
+    \Drupal::service('prisoner_hub_taxonomy_sorting.entity_presave')->updatesSeriesSortValue($entity);
+    \Drupal::service('prisoner_hub_taxonomy_sorting.entity_presave')->updateTaxonomyContentUpdatedValue($entity);
   }
 }
 

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.services.yml
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.services.yml
@@ -1,0 +1,3 @@
+services:
+  prisoner_hub_taxonomy_sorting.entity_presave:
+    class: Drupal\prisoner_hub_taxonomy_sorting\EntityPreSave

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/EntityPreSave.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/EntityPreSave.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\prisoner_hub_taxonomy_sorting;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Class EntityPreSave
+ *
+ * @package Drupal\prisoner_hub_taxonomy_sorting
+ */
+class EntityPreSave {
+
+  /**
+   * Update 'series_sort_value' on nodes.
+   *
+   * Copy sorting value from either season+episode OR release date fields to the
+   * series_sort_value field.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   */
+  public function updatesSeriesSortValue(NodeInterface $entity) {
+    if (!$entity->hasField('field_moj_series')) {
+      return;
+    }
+    $series_result = $entity->field_moj_series->referencedEntities();
+    if (empty($series_result)) {
+      // No series attached to content, do nothing.
+      return;
+    }
+    $series_entity = current($series_result);
+    $sort_by_value = $series_entity->field_sort_by->getString();
+    switch ($sort_by_value) {
+      case 'season_and_episode_asc':
+      case 'season_and_episode_desc':
+        $season_number = $entity->field_moj_season->value;
+        $episode_number = $entity->field_moj_episode->value;
+
+        if ($season_number >= 1 && $season_number <= 999 && $episode_number >= 1 && $episode_number <= 999) {
+          // Episode number must be padded to account for the different lengths
+          // upto 999.  E.g. season 1 episode 15 could be mixed up
+          // with season 11 episode 5.
+          $episode_number_padded = str_pad($episode_number, 3, '0', STR_PAD_LEFT);
+          $calculated_sort_value = (int)$season_number . $episode_number_padded;
+        }
+        else {
+          // If either season or episode number are out of range, set the value
+          // to 0 and warn the user.  This should only ever happen if content is
+          // being bulk updated. (As when editing the content directly, the
+          // fields are made mandatory and dont allow numbers outside the range).
+          \Drupal::messenger()->addWarning(t('Missing season or episode number for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
+          $calculated_sort_value = 0;
+        }
+        break;
+      case 'release_date_asc':
+      case 'release_date_desc':
+        if ($entity->field_release_date->date) {
+          $calculated_sort_value = $entity->field_release_date->date->getTimestamp();
+        }
+        else {
+          // If release date field is empty, set the value to 0 and
+          // warn the user.  This should only ever happen if content is being
+          // bulk updated. (As when editing the content directly, the field is
+          // made mandatory).
+          \Drupal::messenger()->addWarning(t('Missing release date for :content. This could effect how the content is sorted within a series.', [':content' => $entity->label()]));
+          $calculated_sort_value = 0;
+        }
+        break;
+    }
+
+    // If the sorting is descending, cast this as a negative number to invert
+    // the direction.  This allows us to always use ASC direction when running
+    // queries, e.g. through JSON:API.
+    if (substr($sort_by_value, -4) == 'desc') {
+      $calculated_sort_value = -$calculated_sort_value;
+    }
+    $entity->set('series_sort_value', $calculated_sort_value);
+  }
+
+  /**
+   * Update 'content_updated' value for associated taxonomy terms.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   */
+  public function updateTaxonomyContentUpdatedValue(NodeInterface $entity) {
+    $taxonomy_terms_to_update = [];
+    if ($entity->hasField('field_moj_top_level_categories')) {
+      $taxonomy_terms_to_update += $entity->get('field_moj_top_level_categories')->referencedEntities();
+    }
+    if ($entity->hasField('field_moj_series')) {
+      $taxonomy_terms_to_update += $entity->get('field_moj_series')->referencedEntities();
+    }
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    foreach ($taxonomy_terms_to_update as $term) {
+      $term->set('content_updated', \Drupal::time()->getRequestTime());
+      $term->save();
+    }
+  }
+
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/TyCifGHX/719-collections-are-dynamically-ordered-based-on-the-most-recently-updated-piece-of-content-within-them-including-subsequent-collect

### Intent

Adds a new `content_updated` field that can be used for sorting taxonomy terms via JSON:API.
The field has the timestamp of the most recently updated content within that series or category.

There is also an update hook to bulk update existing taxonomy terms with the most recent updated date.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
