### PR TITLE
Add breadcrumbs to jsonapi

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,7 +166,7 @@
                 "Issue #3265853: Support other modules that provide their own field widget plugins (e.g. Select2).": "patches/optgroup_taxonomy_select-3265853-support-select2.patch"
             },
             "drupal/computed_breadcrumbs": {
-                "Issue #3266585: Support other entity types.": "patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch",
+                "Issue #3266585: Support other entity types.": "patches/computed_breadcrumbs-3266585-support-other-entity-types-3.patch",
                 "Issue #3243177: Allow return relative URLs.": "patches/computed_breadcrumbs-3243177-return-relative-urls-2.patch"
             }
         },

--- a/composer.json
+++ b/composer.json
@@ -166,7 +166,8 @@
                 "Issue #3265853: Support other modules that provide their own field widget plugins (e.g. Select2).": "patches/optgroup_taxonomy_select-3265853-support-select2.patch"
             },
             "drupal/computed_breadcrumbs": {
-                "Issue #3266585: Support other entity types.": "patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch"
+                "Issue #3266585: Support other entity types.": "patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch",
+                "Issue #3243177: Allow return relative URLs.": "patches/computed_breadcrumbs-3243177-return-relative-urls-2.patch"
             }
         },
         "patches-ignore": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "drupal/autocomplete_id": "^1.4",
         "drupal/book_blocks": "^1.6",
         "drupal/cer": "4.x-dev",
+        "drupal/computed_breadcrumbs": "dev-3243613-problem-requiring-module",
         "drupal/core-composer-scaffold": "^9.0.0",
         "drupal/core-project-message": "^9.0.0",
         "drupal/core-recommended": "~9.3",
@@ -163,6 +164,9 @@
             },
             "drupal/optgroup_taxonomy_select": {
                 "Issue #3265853: Support other modules that provide their own field widget plugins (e.g. Select2).": "patches/optgroup_taxonomy_select-3265853-support-select2.patch"
+            },
+            "drupal/computed_breadcrumbs": {
+                "Issue #3266585: Support other entity types.": "patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch"
             }
         },
         "patches-ignore": {
@@ -174,6 +178,10 @@
         }
     },
     "repositories": [
+        {
+            "url": "https://git.drupalcode.org/issue/computed_breadcrumbs-3243613.git",
+            "type": "git"
+        },
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5afc4eb15f2fab275e82378d7dfcf40f",
+    "content-hash": "5df54a9f97618079ecea94642933a679",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1823,6 +1823,24 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/cer"
             }
+        },
+        {
+            "name": "drupal/computed_breadcrumbs",
+            "version": "dev-3243613-problem-requiring-module",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/issue/computed_breadcrumbs-3243613.git",
+                "reference": "3fd3972ce3f9fe2e7a7fd5a44260013d089e591a"
+            },
+            "require": {
+                "drupal/core": "^8.8.0 || ^9.0"
+            },
+            "type": "drupal-module",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Provides breadcrumbs as computed fields.",
+            "time": "2022-02-25T14:32:26+00:00"
         },
         {
             "name": "drupal/core",
@@ -17067,6 +17085,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/cer": 20,
+        "drupal/computed_breadcrumbs": 20,
         "drupal/entity_clone": 10,
         "drupal/form_state_empty": 15,
         "drupal/jsonapi_image_styles": 10,

--- a/config/sync/computed_breadcrumbs.settings.yml
+++ b/config/sync/computed_breadcrumbs.settings.yml
@@ -1,0 +1,1 @@
+use_relative_urls: true

--- a/config/sync/core.entity_view_display.node.external_link.default.yml
+++ b/config/sync/core.entity_view_display.node.external_link.default.yml
@@ -131,6 +131,7 @@ content:
     weight: 100
     region: content
 hidden:
+  breadcrumbs: true
   field_exclude_from_prison: true
   field_prisons: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.featured_articles.default.yml
+++ b/config/sync/core.entity_view_display.node.featured_articles.default.yml
@@ -81,4 +81,5 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.moj_pdf_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_pdf_item.default.yml
@@ -165,4 +165,5 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
@@ -171,6 +171,7 @@ content:
     weight: 15
     region: content
 hidden:
+  breadcrumbs: true
   field_moj_audio: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_video_item.default.yml
@@ -180,5 +180,6 @@ content:
     weight: 7
     region: content
 hidden:
+  breadcrumbs: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -174,4 +174,5 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
@@ -47,4 +47,5 @@ content:
     weight: 5
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.prisons.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.prisons.default.yml
@@ -19,4 +19,5 @@ content:
     weight: 0
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
@@ -87,5 +87,6 @@ content:
     weight: 13
     region: content
 hidden:
+  breadcrumbs: true
   field_category: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.tags.default.yml
@@ -59,4 +59,5 @@ content:
     weight: 7
     region: content
 hidden:
+  breadcrumbs: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   page_cache_persist: 0
   path: 0
   path_alias: 0
+  prisoner_hub_breadcrumbs: 0
   prisoner_hub_cms_help: 0
   prisoner_hub_content_suggestions: 0
   prisoner_hub_edit_only: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,7 @@ module:
   breakpoint: 0
   cer: 0
   ckeditor: 0
+  computed_breadcrumbs: 0
   config: 0
   contextual: 0
   ctools: 0

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/README.md
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/README.md
@@ -1,0 +1,37 @@
+# Prisoner hub breadcrumbs
+
+This module provides custom breadcrumb integration for the Prisoner content hub.
+
+It does this using two BreadcrumbBuilder services:
+### NodeBreadcrumbBuilder
+Builds breadcrumbs for nodes that are assigned to a series or category.
+e.g.
+- Tier 1 category
+  - Sub-category
+    - Sub-sub-category
+      - Series
+        - Content (node)
+
+### TermBreadcrumbBuilder
+Builds breadcrumbs for taxonomy terms based on their assigned categories.
+e.g.
+- Tier 1 category
+  - Sub-category
+    - Sub-sub-category
+      - Series
+
+Note this currently only applies to series, as the core TermBreadcrumbBuilder covers the requirements
+of categories themselves (which just use their own hierachy for breadcrumbs).  The tests in this module cover
+both series and categories.
+
+### Dependencies
+- node module (drupal core)
+- taxonomy module (drupal core)
+
+### Test dependencies
+- computed_breadcrumbs (contrib)
+
+This module provides the Drupal breadcrumb trail as a computed field, which means it gets
+outputted in JSON:API.
+The tests from this module use JSON:API for retrieving breadcrumbs, so the computed_breadcrumbs
+module must be enabled for the tests to pass.

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/README.md
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/README.md
@@ -1,6 +1,15 @@
 # Prisoner hub breadcrumbs
 
-This module provides custom breadcrumb integration for the Prisoner content hub.
+This module provides Drupal breadcrumb integration for the Prisoner content hub.
+
+By default, Drupal's breadcrumbs are path based (see Drupal\system\PathBasedBreadcrumbBuilder)
+and hierarchy based for taxonomy pages (see Drupal\taxonomy\TermBreadcrumbBuilder).
+
+The TermBreadcrumbBuilder works for our breadcrumbs on categories.  But for series and content a
+custom implementation is required.  This is provided in this module by two new BreadcrumbBuilder
+services.
+(See https://kporras07.medium.com/creating-breadcrumbs-in-drupal-8-3a5e6d888e5b for more info
+on creating BreadcrumbBuilder services).
 
 It does this using two BreadcrumbBuilder services:
 ### NodeBreadcrumbBuilder
@@ -13,16 +22,12 @@ e.g.
         - Content (node)
 
 ### TermBreadcrumbBuilder
-Builds breadcrumbs for taxonomy terms based on their assigned categories.
+Builds breadcrumbs for series taxonomy terms based on their assigned categories.
 e.g.
 - Tier 1 category
   - Sub-category
     - Sub-sub-category
       - Series
-
-Note this currently only applies to series, as the core TermBreadcrumbBuilder covers the requirements
-of categories themselves (which just use their own hierachy for breadcrumbs).  The tests in this module cover
-both series and categories.
 
 ### Dependencies
 - node module (drupal core)

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.info.yml
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.info.yml
@@ -1,0 +1,10 @@
+name: 'Prisoner content hub breadcrumbs'
+type: module
+description: 'Provides breadcrumb implementation for the Prisoner content hub.'
+core_version_requirement: ^9
+package: 'Custom'
+dependencies:
+  - drupal:node
+  - drupal:taxonomy
+test_dependencies:
+  - computed_breadcrumbs:computed_breadcrumbs

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.services.yml
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.services.yml
@@ -1,0 +1,11 @@
+services:
+  prisoner_hub_breadcrumbs.node_breadcrumb_builder:
+    class: Drupal\prisoner_hub_breadcrumbs\NodeBreadcrumbBuilder
+    arguments: ['@entity_type.manager', '@entity.repository']
+    tags:
+      - { name: breadcrumb_builder, priority: 1003}
+  prisoner_hub_breadcrumbs.term_breadcrumb_builder:
+    class: Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+    arguments: ['@entity_type.manager', '@entity.repository']
+    tags:
+      - { name: breadcrumb_builder, priority: 1003}

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeInterface;
 
 /**
@@ -17,6 +18,7 @@ use Drupal\node\NodeInterface;
  * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
  */
 class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
 
   /**
    * The entity repository manager.

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
@@ -51,11 +51,11 @@ class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    * {@inheritdoc}
    */
   public function applies(RouteMatchInterface $route_match) {
-    // Only apply to nodes that have either the category or series field.
+    // Only apply to nodes that have either a category or a series.
     if ($route_match->getRouteName() == 'entity.node.canonical') {
       $node = $route_match->getParameter('node');
-      if ($node instanceof NodeInterface) {
-        return $node->hasField('field_moj_top_level_categories') || $node->hasField('field_moj_series');
+      if ($node instanceof NodeInterface && $node->hasField('field_moj_top_level_categories') && $node->hasField('field_moj_series')) {
+        return !empty($node->get('field_moj_top_level_categories')->getValue()) || !empty($node->get('field_moj_series')->getValue());
       }
     }
     return FALSE;
@@ -81,6 +81,11 @@ class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     }
     else {
       $categories = $node->get('field_moj_top_level_categories')->referencedEntities();
+    }
+
+    // If no categories found, return the breadcrumb with just "Home" link.
+    if (empty($categories)) {
+      return $breadcrumb;
     }
 
     /** @var \Drupal\taxonomy\TermInterface $category */

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\prisoner_hub_breadcrumbs;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Class NodeBreadcrumbBuilder.
+ *
+ * Build breadcrumbs for nodes.
+ * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+ */
+class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  /**
+   * The entity repository manager.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs the NodeBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityRepository = $entity_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    // Only apply to nodes that have either the category or series field.
+    if ($route_match->getRouteName() == 'entity.node.canonical') {
+      $node = $route_match->getParameter('node');
+      if ($node instanceof NodeInterface) {
+        return $node->hasField('field_moj_top_level_categories') || $node->hasField('field_moj_series');
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+    /** @var NodeInterface $node */
+    $node = $route_match->getParameter('node');
+
+    $breadcrumb->addCacheableDependency($node);
+
+    $series_value = $node->get('field_moj_series')->referencedEntities();
+    $series = NULL;
+    if (!empty($series_value)) {
+      /** @var \Drupal\taxonomy\TermInterface $series */
+      $series = reset($series_value);
+      $categories = $series->get('field_category')->referencedEntities();
+    }
+    else {
+      $categories = $node->get('field_moj_top_level_categories')->referencedEntities();
+    }
+
+    /** @var \Drupal\taxonomy\TermInterface $category */
+    $category = reset($categories);
+    $parents = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category->id());
+    if ($series) {
+      $parents[] = $series;
+    }
+    foreach (array_reverse($parents) as $term) {
+      $term = $this->entityRepository->getTranslationFromContext($term);
+      $breadcrumb->addCacheableDependency($term);
+      $breadcrumb->addLink(Link::createFromRoute($term->getName(), 'entity.taxonomy_term.canonical', ['taxonomy_term' => $term->id()]));
+    }
+
+    // This breadcrumb builder is based on a route parameter, and hence it
+    // depends on the 'route' cache context.
+    $breadcrumb->addCacheContexts(['route']);
+
+    return $breadcrumb;
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\prisoner_hub_breadcrumbs;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Class TermBreadcrumbBuilder.
+ *
+ * Build breadcrumbs for taxonomy terms.
+ * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+ */
+class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  /**
+   * The entity repository manager.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs the TermBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityRepository = $entity_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    if ($route_match->getRouteName() == 'entity.taxonomy_term.canonical') {
+      $term = $route_match->getParameter('taxonomy_term');
+      return $term instanceof TermInterface && $term->bundle() == 'series';
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+    /** @var TermInterface $term */
+    $term = $route_match->getParameter('taxonomy_term');
+
+    $breadcrumb->addCacheableDependency($term);
+
+    $categories = $term->get('field_category')->referencedEntities();
+    /** @var \Drupal\taxonomy\TermInterface $category */
+    $category = reset($categories);
+    $parents = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category->id());
+    foreach (array_reverse($parents) as $term) {
+      $term = $this->entityRepository->getTranslationFromContext($term);
+      $breadcrumb->addCacheableDependency($term);
+      $breadcrumb->addLink(Link::createFromRoute($term->getName(), 'entity.taxonomy_term.canonical', ['taxonomy_term' => $term->id()]));
+    }
+
+    // This breadcrumb builder is based on a route parameter, and hence it
+    // depends on the 'route' cache context.
+    $breadcrumb->addCacheContexts(['route']);
+
+    return $breadcrumb;
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
@@ -8,7 +8,7 @@ use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\taxonomy\TermInterface;
 
 /**
@@ -18,6 +18,7 @@ use Drupal\taxonomy\TermInterface;
  * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
  */
 class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
 
   /**
    * The entity repository manager.

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TermBreadcrumbBuilder.php
@@ -70,6 +70,12 @@ class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $breadcrumb->addCacheableDependency($term);
 
     $categories = $term->get('field_category')->referencedEntities();
+
+    // If no categories found, return the breadcrumb with just "Home" link.
+    if (empty($categories)) {
+      return $breadcrumb;
+    }
+    
     /** @var \Drupal\taxonomy\TermInterface $category */
     $category = reset($categories);
     $parents = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category->id());

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Drupal\Tests\prisoner_hub_breadcrumbs\ExistingSite;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use GuzzleHttp\RequestOptions;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Test the the breadcrumb suggestions JSON:API resource works correctly
+ *
+ * @group prisoner_hub_breadcrumbs
+ */
+class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
+
+  use JsonApiRequestTestTrait;
+  use NodeCreationTrait;
+  use TaxonomyCreationTrait;
+
+  /**
+   * An array of category taxonomy term entities.
+   *
+   * @var array
+   */
+  protected $categoryTerms;
+
+  /**
+   * A generated series term, that is linked to $this->$categoryTerm.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
+  protected $seriesTerm;
+
+  /**
+   * Set up content and taxonomy terms to test with.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $vocab_secondary_tags = Vocabulary::load('tags');
+    $this->secondaryTagTerm = $this->createTerm($vocab_secondary_tags);
+
+    $vocab_categories = Vocabulary::load('moj_categories');
+    $parentTerm = $this->createTerm($vocab_categories);
+    $subCategoryTerm = $this->createTerm($vocab_categories, [
+      'parent' => [
+        ['target_id' => $parentTerm->id()],
+      ],
+    ]);
+    $subSubCategoryTerm = $this->createTerm($vocab_categories, [
+      'parent' => [
+        ['target_id' => $subCategoryTerm->id(),],
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_top_level_categories' => [
+        ['target_id' => $subSubCategoryTerm->id()]
+      ],
+      'field_not_in_series' => 1,
+    ]);
+
+    $this->categoryTerms = [$parentTerm, $subCategoryTerm, $subSubCategoryTerm];
+
+    $vocab_series = Vocabulary::load('series');
+    $this->seriesTerm = $this->createTerm($vocab_series, [
+      'field_category' =>
+        ['target_id' => $subSubCategoryTerm->id()],
+    ]);
+    $this->createNode([
+      'field_moj_series' => [
+        ['target_id' => $this->seriesTerm ->id()]
+      ],
+      'field_not_in_series' => 0,
+    ]);
+  }
+
+  /**
+   * Test that a sub category has the correct breadrumbs.
+   */
+  public function testSubCategoryBreadcrumb() {
+    // Use array_pop to remove the last category from the list (as this won't
+    // appear in the breadcrumbs).
+    $category = array_pop($this->categoryTerms);
+    $this->assertJsonApiBreadcrumbResponse($category, $this->categoryTerms);
+  }
+
+  /**
+   * Test that a series has the correct breadcrumbs.
+   */
+  public function testSeriesBreadcrumb() {
+    // The series has been assigned to the sub-sub-category.
+    // So all categories should appear in the breadcrumbs.
+    $this->assertJsonApiBreadcrumbResponse($this->seriesTerm, $this->categoryTerms);
+  }
+
+  /**
+   * Test content assigned to a category has the correct breadcrumbs.
+   */
+  public function testContentWithCategoryBreadcumb() {
+    $categories = $this->categoryTerms;
+    $category = end($categories);
+    $node = $this->createNode([
+      'field_moj_top_level_categories' => [
+        ['target_id' => $category->id()],
+      ],
+      'field_not_in_series' => 1,
+    ]);
+    $this->assertJsonApiBreadcrumbResponse($node, $this->categoryTerms);
+  }
+
+  /**
+   * Test content assigned to a series has the corret breadcrumbs.
+   */
+  public function testContentWithSeriesBreadcumb() {
+    $node = $this->createNode([
+      'field_moj_series' => [
+        ['target_id' => $this->seriesTerm->id()],
+      ],
+      'field_not_in_series' => 0,
+    ]);
+    $breadcrumbs = $this->categoryTerms;
+    $breadcrumbs[] = $this->seriesTerm;
+    $this->assertJsonApiBreadcrumbResponse($node, $breadcrumbs);
+  }
+
+  /**
+   * Helper function to assert that a jsonapi response returns the expected
+   * entities.
+   *
+   * @param array $entities_to_check
+   *   A list of entity uuids to check for in the JSON response.
+   * @param NodeInterface $node
+   *   The node to check suggestions for.
+   */
+  protected function assertJsonApiBreadcrumbResponse(ContentEntityInterface $entity, array $breadcrumb_entities) {
+    $url = Url::fromUri('internal:/jsonapi/' . $entity->getEntityTypeId() . '/' . $entity->bundle() . '/' . $entity->uuid());
+    $response = $this->getJsonApiResponse($url);
+    $this->assertSame(200, $response->getStatusCode(), $url->toString() . ' returns a 200 response.');
+    $response_document = Json::decode((string) $response->getBody());
+    $message = 'JSON response returns the correct results on url: ' . $url->toString();
+
+    if (empty($breadcrumb_entities)) {
+      $this->assertEmpty($response_document['data']['attributes']['breadcrumbs'], $message);
+    }
+    else {
+      $breadcrumbs = [
+        [
+          'uri' => Url::fromRoute('<front>')->toString(),
+          'title' => 'Home',
+          'options' => [],
+        ],
+      ];
+      /** @var ContentEntityInterface $breadcrumb_entity */
+      foreach ($breadcrumb_entities as $breadcrumb_entity) {
+        $breadcrumbs[] = [
+          'uri' => $breadcrumb_entity->toUrl()->toString(),
+          'title' => $breadcrumb_entity->label(),
+          'options' => [],
+        ];
+      }
+      $this->assertEqualsCanonicalizing($breadcrumbs, $response_document['data']['attributes']['breadcrumbs'], $message);
+    }
+  }
+
+  /**
+   * Get a response from a JSON:API url.
+   *
+   * @param \Drupal\Core\Url $url
+   *   The url object to use for the JSON:API request.
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   *   The response object.
+   */
+  function getJsonApiResponse(Url $url) {
+    $request_options = [];
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    return $this->request('GET', $url, $request_options);
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -117,6 +117,13 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     $condition_group = new ConditionGroup('AND');
     $condition_group->addCondition($prisons_condition_group);
     $condition_group->addCondition($exclude_from_prison_condition_group);
+
+    // Add status (i.e. published/unpublished) to the query, as this isn't
+    // automatically added by Drupal.
+    if ($entity_type->hasKey('status')) {
+      $condition_group->addCondition('status', 1);
+    }
+
     $conditions->addCondition($condition_group);
   }
 

--- a/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -117,13 +117,6 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     $condition_group = new ConditionGroup('AND');
     $condition_group->addCondition($prisons_condition_group);
     $condition_group->addCondition($exclude_from_prison_condition_group);
-
-    // Add status (i.e. published/unpublished) to the query, as this isn't
-    // automatically added by Drupal.
-    if ($entity_type->hasKey('status')) {
-      $condition_group->addCondition('status', 1);
-    }
-
     $conditions->addCondition($condition_group);
   }
 

--- a/patches/computed_breadcrumbs-3243177-return-relative-urls-2.patch
+++ b/patches/computed_breadcrumbs-3243177-return-relative-urls-2.patch
@@ -1,0 +1,130 @@
+diff --git a/computed_breadcrumbs.links.menu.yml b/computed_breadcrumbs.links.menu.yml
+new file mode 100644
+index 0000000..059df04
+--- /dev/null
++++ b/computed_breadcrumbs.links.menu.yml
+@@ -0,0 +1,5 @@
++computed_breadcrumbs.settings:
++  title: 'Computed breadcrumbs settings'
++  route_name: computed_breadcrumbs.settings
++  description: 'Computed breadcrumbs settings.'
++  parent: system.admin_config_ui
+diff --git a/computed_breadcrumbs.permissions.yml b/computed_breadcrumbs.permissions.yml
+new file mode 100644
+index 0000000..929287d
+--- /dev/null
++++ b/computed_breadcrumbs.permissions.yml
+@@ -0,0 +1,2 @@
++administer computed breadcrumbs:
++  title: 'Allow users to access module configuration form.'
+diff --git a/computed_breadcrumbs.routing.yml b/computed_breadcrumbs.routing.yml
+new file mode 100644
+index 0000000..4b2863a
+--- /dev/null
++++ b/computed_breadcrumbs.routing.yml
+@@ -0,0 +1,7 @@
++computed_breadcrumbs.settings:
++  path: '/admin/config/user-interface/computed-breadcrumbs'
++  defaults:
++    _form: '\Drupal\computed_breadcrumbs\Form\SettingsForm'
++    _title: 'Computed Breadcrumbs settings'
++  requirements:
++    _permission: 'administer computed breadcrumbs'
+diff --git a/config/install/computed_breadcrumbs.settings.yml b/config/install/computed_breadcrumbs.settings.yml
+new file mode 100644
+index 0000000..d02dd37
+--- /dev/null
++++ b/config/install/computed_breadcrumbs.settings.yml
+@@ -0,0 +1 @@
++use_relative_urls: false
+diff --git a/config/schema/computed_breadcrumbs.schema.yml b/config/schema/computed_breadcrumbs.schema.yml
+new file mode 100644
+index 0000000..a19185c
+--- /dev/null
++++ b/config/schema/computed_breadcrumbs.schema.yml
+@@ -0,0 +1,7 @@
++computed_breadcrumbs.settings:
++  type: config_object
++  label: 'Computed breadcrumbs settings'
++  mapping:
++    use_relative_urls:
++      type: boolean
++      label: 'Use relative urls'
+diff --git a/src/Field/ComputedBreadcrumbsItemList.php b/src/Field/ComputedBreadcrumbsItemList.php
+index 8761505..c2b5d2d 100644
+--- a/src/Field/ComputedBreadcrumbsItemList.php
++++ b/src/Field/ComputedBreadcrumbsItemList.php
+@@ -60,7 +60,11 @@ class ComputedBreadcrumbsItemList extends FieldItemList {
+       $items = [];
+       \Drupal::service('renderer')->executeInRenderContext(new RenderContext(), function () use ($links, &$items) {
+         foreach ($links as $index => $link) {
+-          $uri = $link->getUrl()->setAbsolute()->toString();
++          $absolute = TRUE;
++          if (\Drupal::config('computed_breadcrumbs.settings')->get('use_relative_urls')) {
++            $absolute = FALSE;
++          }
++          $uri = $link->getUrl()->setAbsolute($absolute)->toString();
+           if (empty($uri)) {
+             $uri = 'internal:#';
+           }
+diff --git a/src/Form/SettingsForm.php b/src/Form/SettingsForm.php
+new file mode 100644
+index 0000000..01b0703
+--- /dev/null
++++ b/src/Form/SettingsForm.php
+@@ -0,0 +1,55 @@
++<?php
++
++namespace Drupal\computed_breadcrumbs\Form;
++
++use Drupal\Core\Form\ConfigFormBase;
++use Drupal\Core\Form\FormStateInterface;
++
++/**
++ * Computed Breadcrumbs settings form.
++ */
++class SettingsForm extends ConfigFormBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getFormId() {
++    return 'computed_breadcrumbs_settings_form';
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function getEditableConfigNames() {
++    return [
++      'computed_breadcrumbs.settings',
++    ];
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function buildForm(array $form, FormStateInterface $form_state) {
++    $form = parent::buildForm($form, $form_state);
++    $config = $this->config('computed_breadcrumbs.settings');
++    $form['use_relative_urls'] = [
++      '#type' => 'checkbox',
++      '#title' => $this->t('Use relative urls.'),
++      '#description' => $this->t('Enable to use relative urls, otherwise absolute urls will be used.'),
++      '#default_value' => $config->get('use_relative_urls'),
++    ];
++
++    return $form;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function submitForm(array &$form, FormStateInterface $form_state) {
++    $config = $this->config('computed_breadcrumbs.settings');
++    $config->set('use_relative_urls', $form_state->getValue('use_relative_urls'));
++    $config->save();
++    parent::submitForm($form, $form_state);
++  }
++
++}

--- a/patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch
+++ b/patches/computed_breadcrumbs-3266585-support-other-entity-types-2.patch
@@ -1,0 +1,39 @@
+diff --git a/computed_breadcrumbs.info.yml b/computed_breadcrumbs.info.yml
+index e97011a..f981c9c 100644
+--- a/computed_breadcrumbs.info.yml
++++ b/computed_breadcrumbs.info.yml
+@@ -1,5 +1,5 @@
+ name: Computed Breadcrumbs
+-description: Provides breadcrumbs as computed fields in nodes.
++description: Provides breadcrumbs as computed fields for content entities.
+ type: module
+ core_version_requirement: ^8.8 || 9
+ dependencies:
+diff --git a/computed_breadcrumbs.module b/computed_breadcrumbs.module
+index d5c2459..bfae295 100644
+--- a/computed_breadcrumbs.module
++++ b/computed_breadcrumbs.module
+@@ -1,5 +1,6 @@
+ <?php
+ 
++use Drupal\Core\Entity\ContentEntityTypeInterface;
+ use Drupal\Core\Entity\EntityTypeInterface;
+ use Drupal\Core\Field\BaseFieldDefinition;
+ use Drupal\Core\Field\FieldStorageDefinitionInterface;
+@@ -9,7 +10,7 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
+  */
+ function computed_breadcrumbs_entity_base_field_info(EntityTypeInterface $entity_type) {
+   $fields = [];
+-  if ($entity_type->id() === 'node') {
++  if ($entity_type instanceof ContentEntityTypeInterface) {
+     $fields['breadcrumbs'] = BaseFieldDefinition::create('computed_breadcrumbs')
+       ->setName('breadcrumbs')
+       ->setLabel(t('Breadcrumbs'))
+@@ -19,6 +20,7 @@ function computed_breadcrumbs_entity_base_field_info(EntityTypeInterface $entity
+       ->setDisplayConfigurable('view', TRUE)
+       ->setDisplayOptions('view', [
+         'label' => 'hidden',
++        'region' => 'hidden',
+         'weight' => -5,
+       ]);
+   }

--- a/patches/computed_breadcrumbs-3266585-support-other-entity-types-3.patch
+++ b/patches/computed_breadcrumbs-3266585-support-other-entity-types-3.patch
@@ -15,7 +15,7 @@ index d5c2459..bfae295 100644
 +++ b/computed_breadcrumbs.module
 @@ -1,5 +1,6 @@
  <?php
- 
+
 +use Drupal\Core\Entity\ContentEntityTypeInterface;
  use Drupal\Core\Entity\EntityTypeInterface;
  use Drupal\Core\Field\BaseFieldDefinition;
@@ -37,3 +37,16 @@ index d5c2459..bfae295 100644
          'weight' => -5,
        ]);
    }
+diff --git a/src/Field/ComputedBreadcrumbsItemList.php b/src/Field/ComputedBreadcrumbsItemList.php
+index 8761505..c2bcaf0 100644
+--- a/src/Field/ComputedBreadcrumbsItemList.php
++++ b/src/Field/ComputedBreadcrumbsItemList.php
+@@ -23,7 +23,7 @@ class ComputedBreadcrumbsItemList extends FieldItemList {
+     $requestStack = \Drupal::service('request_stack');
+
+     $parent = $this->getEntity();
+-    if ($parent->isNew()) {
++    if ($parent->isNew() || !$parent->hasLinkTemplate('canonical')) {
+       return;
+     }
+     $url = $parent->toUrl();


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pm60I56L/711-implementation-of-sub-categories-design

### Intent

This PR brings in breadcrumbs to the JSON:API response.

Breadcrumbs in JSON:API were required for two reasons:
1) It's easier/cleaner/quicker than having to request each parent category to build the breadcrumb trail. Avoiding having to include multiple parents, e.g. `?include=parent,parent.parent,parnet.parent.parent`
2) There doesn't appear to be a way of including _just_ the parent categories name, without having to include all fields.  `?include=parent.name` doesn't work (as `name` is not a relationship) and `?include=parent&fields[taxonomy_term--moj_categories]=name` also doesn't work.
<img width="559" alt="Screenshot 2022-02-28 at 12 13 11" src="https://user-images.githubusercontent.com/436483/155981627-a2974215-9f44-4cac-82e8-e1a5e08cde25.png">


### Considerations

To bring in the breadcrumbs into JSON:API, the module [computed_breadcrumbs](https://www.drupal.org/project/computed_breadcrumbs) was used.  This module does quite a simple task of bringing in Drupal's breadcrumbs as a "computed field" which means it gets automatically outputted in JSON:API.  However there are a few things to note about this setup:
1) The module is not being actively maintained, we are already having to use three patches/changes.  I can request to get maintainership of the module so we can update everything.
2) For some reason, the module uses a sub-request to retrieve the breadcrumbs.  This may have a performance impact.  Note this is a Symfony sub-request and not a real HTTP request.
3) Drupal has its own breadcrumb system, so any changes to this will effect the breadcrumbs being outputted by JSON:API.  

Also, for series and content breadcrumbs, a custom module has been added.  

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
