### PR TITLE
Fix issue with empty JSON:API responses due to unpublished content

### DIFF
--- a/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -117,6 +117,13 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     $condition_group = new ConditionGroup('AND');
     $condition_group->addCondition($prisons_condition_group);
     $condition_group->addCondition($exclude_from_prison_condition_group);
+
+    // Add status (i.e. published/unpublished) to the query, as this isn't
+    // automatically added by Drupal.
+    if ($entity_type->hasKey('status')) {
+      $condition_group->addCondition('status', 1);
+    }
+
     $conditions->addCondition($condition_group);
   }
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Related to: https://trello.com/c/pm60I56L/711-implementation-of-sub-categories-design

### Intent

When testing changes for sub-categories, I noticed there were JSON:API responses returning empty data sets. 
This is because unpublished content is not filtered out _early enough_.  So it ends up getting excluded after the list of contents has been generated.
This could lead to issues with pagination, where the first page has less than 40 items of content.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
