### PR TITLE
Adding image field to category taxonomy.

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
@@ -4,12 +4,15 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.moj_categories.field_exclude_from_prison
+    - field.field.taxonomy_term.moj_categories.field_featured_image
     - field.field.taxonomy_term.moj_categories.field_featured_tiles
     - field.field.taxonomy_term.moj_categories.field_prisons
+    - image.style.thumbnail
     - taxonomy.vocabulary.moj_categories
   module:
     - dynamic_entity_reference
     - field_group
+    - image
     - path
     - term_reference_tree
     - text
@@ -79,6 +82,14 @@ content:
       cascading_selection: 0
       cascading_selection_enforce: false
       max_depth: 0
+    third_party_settings: {  }
+  field_featured_image:
+    type: image_image
+    weight: 9
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
   field_featured_tiles:
     type: dynamic_entity_reference_default

--- a/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.moj_categories.field_exclude_from_prison
+    - field.field.taxonomy_term.moj_categories.field_featured_image
     - field.field.taxonomy_term.moj_categories.field_featured_tiles
     - field.field.taxonomy_term.moj_categories.field_prisons
     - taxonomy.vocabulary.moj_categories
   module:
     - dynamic_entity_reference
+    - image
     - text
 id: taxonomy_term.moj_categories.default
 targetEntityType: taxonomy_term
@@ -29,6 +31,15 @@ content:
       link: true
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_featured_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_featured_tiles:
     type: dynamic_entity_reference_label

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_featured_image.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_featured_image.yml
@@ -1,20 +1,20 @@
-uuid: 21fcc091-dd59-4178-887e-384d9d9071fb
+uuid: 9b628fb8-0cc7-4396-836f-fdf06bb056e9
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.taxonomy_term.field_featured_image
-    - taxonomy.vocabulary.series
+    - taxonomy.vocabulary.moj_categories
   module:
     - image
-id: taxonomy_term.series.field_featured_image
+id: taxonomy_term.moj_categories.field_featured_image
 field_name: field_featured_image
 entity_type: taxonomy_term
-bundle: series
+bundle: moj_categories
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pm60I56L/711-implementation-of-sub-categories-design

### Intent

Add the image field (same as on series) to the category Taxonomy.  So that CMS users can upload images for sub-categories.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
