### PR TITLE
Updating category field to be single value.

### DIFF
--- a/config/sync/field.storage.node.field_moj_top_level_categories.yml
+++ b/config/sync/field.storage.node.field_moj_top_level_categories.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.taxonomy_term.field_category.yml
+++ b/config/sync/field.storage.taxonomy_term.field_category.yml
@@ -12,7 +12,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
+++ b/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
@@ -16,7 +16,7 @@
         .once()
         .on('change', function(e) {
           if ($(e.currentTarget).is(":visible")) {
-            filterCheckboxes($(e.currentTarget).val());
+            filterCheckboxes([$(e.currentTarget).val()]);
           }
         });
       // Trigger change event if value is not empty.

--- a/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
+++ b/docroot/modules/custom/prisoner_hub_featured_content/js/prisoner-hub-featured-content.js
@@ -5,7 +5,7 @@
   Drupal.behaviors.prisonerHubFeaturedContent = {
     attach: function(context) {
       const $checkboxes = $('[name^="field_feature_on_category"]'); // Use name^ to account for multiple checkbox fields.
-      const $categoryField = $('[name="field_moj_top_level_categories[]"], [name="field_category[]"]');
+      const $categoryField = $('[name^="field_moj_top_level_categories"], [name^="field_category"]');
       const $seriesField = $('[name="field_moj_series"]');
       const $notInSeries = $('[name="field_not_in_series[value]"]');
 

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -179,3 +179,44 @@ function prisoner_content_hub_profile_update_8017() {
     $term->delete();
   }
 }
+
+/**
+ * Update all content/series with more than one category.
+ */
+function prisoner_content_hub_profile_update_8018() {
+  $result = \Drupal::entityQuery('node')
+    ->accessCheck(FALSE)
+    ->condition('field_moj_top_level_categories' . '.%delta', 1)
+    ->execute();
+
+  $entities = array_values(Node::loadMultiple($result));
+
+  $result = \Drupal::entityQuery('taxonomy_term')
+    ->accessCheck(FALSE)
+    ->condition('field_category' . '.%delta', 1)
+    ->execute();
+
+  $entities = array_merge($entities, array_values(Term::loadMultiple($result)));
+
+  /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+  foreach ($entities as $entity) {
+    $new_category_value = [];
+    $field_name = $entity->getEntityTypeId() == 'node' ? 'field_moj_top_level_categories' : 'field_category';
+    $categories = $entity->get($field_name)->referencedEntities();
+    foreach ($categories as $category) {
+      if (!empty($category->get('parent')->getValue())) {
+        // Only include sub-categories, not tier 1 categories.
+        $new_category_value[] = ['target_id' => $category->id()];
+        break;
+      }
+    }
+    if ($entity->getEntityType()->isRevisionable()) {
+      $entity->setNewRevision(TRUE);
+      $entity->revision_log = 'Bulk updating content with more than one category.';
+      $entity->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    }
+
+    $entity->set($field_name, $new_category_value);
+    $entity->save();
+  }
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pm60I56L/711-implementation-of-sub-categories-design

### Intent

Updates the category fields (on content and series) to accept just one value.

This includes bulk updating existing content/series with more than value.  Although most of which should have already been manually updated, there may still be some (including unpublished) content.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
