### PR TITLE
Bugfix/fix empty jsonapi subcategory query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,6 @@ jobs:
             set -x
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make install-drupal
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make run-tests
-          no_output_timeout: 1500
       - run:
           name: Copy test results output
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
             set -x
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make install-drupal
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make run-tests
+          no_output_timeout: 1500
       - run:
           name: Copy test results output
           command: |

--- a/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
+++ b/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
@@ -29,7 +29,7 @@ function prisoner_hub_prison_access_entity_access(\Drupal\Core\Entity\EntityInte
  */
 function prisoner_hub_prison_access_jsonapi_entity_filter_access(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Session\AccountInterface $account) {
   // We need to ensure our QueryAccessSubscriber will be applied to the query.
-  if (\Drupal::routeMatch()->getParameter('prison')) {
+  if (!\Drupal::routeMatch()->getParameter('prison')) {
     return [];
   }
 

--- a/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
+++ b/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
@@ -5,6 +5,8 @@
  * Primary hook implementations for Prisoner hub entity access module.
  */
 
+use Drupal\Core\Access\AccessResult;
+
 
 /**
  * Implements hook_search_api_query_alter().
@@ -18,4 +20,17 @@ function prisoner_hub_prison_access_search_api_query_alter(\Drupal\search_api\Qu
  */
 function prisoner_hub_prison_access_entity_access(\Drupal\Core\Entity\EntityInterface $entity, $operation, \Drupal\Core\Session\AccountInterface $account) {
   return \Drupal::service('prisoner_hub_prison_access.entity_access_check')->checkAccess($entity);
+}
+
+/**
+ * Implements hook_jsonapi_entity_filter_access().
+ *
+ * Fix for empty results being returned when a OR condition group is used.
+ * @see https://www.drupal.org/project/drupal/issues/3072384#comment-14432203
+ */
+function prisoner_hub_prison_access_jsonapi_entity_filter_access(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Session\AccountInterface $account) {
+  if (\Drupal::routeMatch()->getParameter('prison')) {
+    return [JSONAPI_FILTER_AMONG_ALL => AccessResult::allowed()];
+  }
+  return [];
 }

--- a/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
+++ b/docroot/modules/custom/prisoner_hub_prison_access/prisoner_hub_prison_access.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Access\AccessResult;
 
-
 /**
  * Implements hook_search_api_query_alter().
  */
@@ -25,11 +24,22 @@ function prisoner_hub_prison_access_entity_access(\Drupal\Core\Entity\EntityInte
 /**
  * Implements hook_jsonapi_entity_filter_access().
  *
- * Fix for empty results being returned when a OR condition group is used.
+ * Fix for incorrect results being returned when an OR condition group is used.
  * @see https://www.drupal.org/project/drupal/issues/3072384#comment-14432203
  */
 function prisoner_hub_prison_access_jsonapi_entity_filter_access(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Session\AccountInterface $account) {
+  // We need to ensure our QueryAccessSubscriber will be applied to the query.
   if (\Drupal::routeMatch()->getParameter('prison')) {
+    return [];
+  }
+
+  // Only apply to nodes and taxonomy terms.
+  // This ensures that Drupal\jsonapi\Access\TemporaryQueryGuard::secureQuery()
+  // is still run on other entity types, that we may have not necessarily "secured"
+  // in QueryAccessSubscriber.
+  // Note this may mean the issue #3072384 may still be present if other entity
+  // types are ever requested.
+  if (in_array($entity_type->id(), ['node', 'taxonomy_term'])) {
     return [JSONAPI_FILTER_AMONG_ALL => AccessResult::allowed()];
   }
   return [];

--- a/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/src/EventSubscriber/QueryAccessSubscriber.php
@@ -118,8 +118,9 @@ class QueryAccessSubscriber implements EventSubscriberInterface {
     $condition_group->addCondition($prisons_condition_group);
     $condition_group->addCondition($exclude_from_prison_condition_group);
 
-    // Add status (i.e. published/unpublished) to the query, as this isn't
-    // automatically added by Drupal.
+    // Add status (i.e. published/unpublished) to the query, this is no longer
+    // being added by jsonapi, since we have returned JSONAPI_FILTER_AMONG_ALL
+    // in prisoner_hub_prison_access_jsonapi_entity_filter_access().
     if ($entity_type->hasKey('status')) {
       $condition_group->addCondition('status', 1);
     }

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessJsonApiByBundleTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessJsonApiByBundleTest.php
@@ -169,7 +169,6 @@ class PrisonerHubQueryAccessJsonApiByBundleTest extends PrisonerHubQueryAccessTe
         'query' => ['filter' => $filter],
       ];
       $uri = $this->getJsonApiUri($this->prisonTermMachineName, $entity_type_id, $bundle, $options);
-      var_dump($uri->toString());
       $this->assertJsonApiListResponse($entities_to_check, $uri);
     }
   }

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessJsonApiByBundleTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessJsonApiByBundleTest.php
@@ -169,6 +169,7 @@ class PrisonerHubQueryAccessJsonApiByBundleTest extends PrisonerHubQueryAccessTe
         'query' => ['filter' => $filter],
       ];
       $uri = $this->getJsonApiUri($this->prisonTermMachineName, $entity_type_id, $bundle, $options);
+      var_dump($uri->toString());
       $this->assertJsonApiListResponse($entities_to_check, $uri);
     }
   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/pm60I56L/711-implementation-of-sub-categories-design

### Intent

When working on the sub-categories, or bug in Drupal core jsonapi was discovered, where filtering using an OR group on two different entity reference fields causes incorrect results to be returned.

The bug is better described in https://www.drupal.org/project/drupal/issues/3072384
and the fix in this PR in my comment https://www.drupal.org/project/drupal/issues/3072384#comment-14432203

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
