### PR TITLE
Fix incorrect property being used in deployment script

### DIFF
--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.install
@@ -37,7 +37,7 @@ function prisoner_hub_taxonomy_sorting_update_9003(&$sandbox) {
 
     $sandbox['progress'] = 0;
   }
-  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['result'], 50, TRUE));
+  $terms = Term::loadMultiple(array_slice($sandbox['result'], $sandbox['progress'], 50, TRUE));
 
   /** @var \Drupal\taxonomy\TermInterface $term */
   foreach ($terms as $term) {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Fixes an issue that was merged in with https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/353

### Intent

Typo in the property name, the previous deployment would have run, but would have not updated everything in the database.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
