### PR TITLE
Make cronjob more performant

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "prisoner-content-hub-backend.fullname" . }}-search-indexing
+  name: {{ include "prisoner-content-hub-backend.fullname" . }}-drupal-cron
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
@@ -14,11 +14,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           containers:
-          - name: drupal-search-indexing-job
+          - name: drupal-cron-job
             {{- with .Values.cron.image }}
-            image: "{{ .repository }}:{{ .tag }}"
-            {{- end }}
-            args:
-            - -s
-            - {{ include "prisoner-content-hub-backend.internalHost" . }}/cron/{{ .Values.cronToken }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            command: ["drush", "cron"]
+{{ include "drupal-deployment.envs" . | nindent 12 }}
           restartPolicy: OnFailure

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -93,7 +93,4 @@ ingress:
       external-dns.alpha.kubernetes.io/aws-weight: "100"
 
 cron:
-  schedule: "*/5 * * * *"
-  image:
-    repository: curlimages/curl
-    tag: 7.71.1
+  schedule: "0 */2 * * *"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

> If this is an issue, do we have steps to reproduce?

### Intent

During a recent issue with performance directly after a prod deployment, https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3903488780/2022-03-07+Drupal+unresponsive
One of the changes we made was to disable the "search-indexing" cronjob.  As this runs every 5 minutes and uses up resources.

This PR updates the cronjob in two ways:
- Rename the job to just "drupal-cron" rather than "drupal-search-indexing". As actually, Drupal is configured to "track changes immediately", so it's not reliant on cron for indexing.  However, cron is still required to be run on Drupal for other tasks, so a generic name is more suitable.
- Run the job once every 2 hours instead of 5 mins.  (We could probably decrease this futher if we wanted).
- Use drush to run cron via the cli, rather than a curl request over http.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
