### PR TITLE
Rename "external link" to "link"

### DIFF
--- a/config/sync/core.base_field_override.node.link.promote.yml
+++ b/config/sync/core.base_field_override.node.link.promote.yml
@@ -1,0 +1,22 @@
+uuid: c022c7ac-40e4-4f6a-a247-17a2edc1d07e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.link
+id: node.link.promote
+field_name: promote
+entity_type: node
+bundle: link
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.entity_form_display.node.external_link.default.yml
+++ b/config/sync/core.entity_form_display.node.external_link.default.yml
@@ -15,7 +15,6 @@ dependencies:
     - field.field.node.external_link.field_not_in_series
     - field.field.node.external_link.field_prisons
     - field.field.node.external_link.field_release_date
-    - field.field.node.external_link.field_show_interstitial_page
     - field.field.node.external_link.field_summary
     - image.style.thumbnail
     - node.type.external_link
@@ -224,13 +223,6 @@ content:
     weight: 18
     region: content
     settings: {  }
-    third_party_settings: {  }
-  field_show_interstitial_page:
-    type: boolean_checkbox
-    weight: 5
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   field_summary:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.link.default.yml
+++ b/config/sync/core.entity_form_display.node.link.default.yml
@@ -23,7 +23,6 @@ dependencies:
     - datetime
     - field_group
     - image
-    - link
     - path
     - scheduler
     - select2
@@ -233,12 +232,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_url:
-    type: link_default
+    type: string_textfield
     weight: 3
     region: content
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   path:
     type: path

--- a/config/sync/core.entity_form_display.node.link.default.yml
+++ b/config/sync/core.entity_form_display.node.link.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.link.field_not_in_series
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
+    - field.field.node.link.field_show_interstitial_page
     - field.field.node.link.field_summary
     - field.field.node.link.field_url
     - image.style.thumbnail
@@ -125,7 +126,7 @@ content:
     third_party_settings: {  }
   field_display_url:
     type: string_textfield
-    weight: 5
+    weight: 4
     region: content
     settings:
       size: 60
@@ -216,6 +217,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_show_interstitial_page:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_summary:
     type: string_textfield
     weight: 2
@@ -226,7 +234,7 @@ content:
     third_party_settings: {  }
   field_url:
     type: link_default
-    weight: 4
+    weight: 3
     region: content
     settings:
       placeholder_url: ''

--- a/config/sync/core.entity_form_display.node.link.default.yml
+++ b/config/sync/core.entity_form_display.node.link.default.yml
@@ -1,24 +1,23 @@
-uuid: 38d6ae76-861b-4ec4-a532-7061afbad285
+uuid: 31509ba5-c4be-424a-b8bb-2a07497c7ef3
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.external_link.field_display_url
-    - field.field.node.external_link.field_exclude_from_prison
-    - field.field.node.external_link.field_external_url
-    - field.field.node.external_link.field_feature_on_category
-    - field.field.node.external_link.field_moj_episode
-    - field.field.node.external_link.field_moj_season
-    - field.field.node.external_link.field_moj_series
-    - field.field.node.external_link.field_moj_thumbnail_image
-    - field.field.node.external_link.field_moj_top_level_categories
-    - field.field.node.external_link.field_not_in_series
-    - field.field.node.external_link.field_prisons
-    - field.field.node.external_link.field_release_date
-    - field.field.node.external_link.field_show_interstitial_page
-    - field.field.node.external_link.field_summary
+    - field.field.node.link.field_display_url
+    - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_feature_on_category
+    - field.field.node.link.field_moj_episode
+    - field.field.node.link.field_moj_season
+    - field.field.node.link.field_moj_series
+    - field.field.node.link.field_moj_thumbnail_image
+    - field.field.node.link.field_moj_top_level_categories
+    - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prisons
+    - field.field.node.link.field_release_date
+    - field.field.node.link.field_summary
+    - field.field.node.link.field_url
     - image.style.thumbnail
-    - node.type.external_link
+    - node.type.link
   module:
     - datetime
     - field_group
@@ -113,9 +112,9 @@ third_party_settings:
         required_fields: '1'
         id: ''
         classes: ''
-id: node.external_link.default
+id: node.link.default
 targetEntityType: node
-bundle: external_link
+bundle: link
 mode: default
 content:
   created:
@@ -126,7 +125,7 @@ content:
     third_party_settings: {  }
   field_display_url:
     type: string_textfield
-    weight: 4
+    weight: 5
     region: content
     settings:
       size: 60
@@ -143,14 +142,6 @@ content:
       cascading_selection: 0
       cascading_selection_enforce: false
       max_depth: 0
-    third_party_settings: {  }
-  field_external_url:
-    type: link_default
-    weight: 3
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
     third_party_settings: {  }
   field_feature_on_category:
     type: options_buttons
@@ -225,13 +216,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_show_interstitial_page:
-    type: boolean_checkbox
-    weight: 5
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   field_summary:
     type: string_textfield
     weight: 2
@@ -239,6 +223,14 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_url:
+    type: link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
     third_party_settings: {  }
   path:
     type: path

--- a/config/sync/core.entity_view_display.node.external_link.default.yml
+++ b/config/sync/core.entity_view_display.node.external_link.default.yml
@@ -15,7 +15,6 @@ dependencies:
     - field.field.node.external_link.field_not_in_series
     - field.field.node.external_link.field_prisons
     - field.field.node.external_link.field_release_date
-    - field.field.node.external_link.field_show_interstitial_page
     - field.field.node.external_link.field_summary
     - node.type.external_link
   module:
@@ -117,16 +116,6 @@ content:
       format_type: medium
     third_party_settings: {  }
     weight: 108
-    region: content
-  field_show_interstitial_page:
-    type: boolean
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    weight: 116
     region: content
   field_summary:
     type: string

--- a/config/sync/core.entity_view_display.node.external_link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.external_link.teaser.yml
@@ -16,7 +16,6 @@ dependencies:
     - field.field.node.external_link.field_not_in_series
     - field.field.node.external_link.field_prisons
     - field.field.node.external_link.field_release_date
-    - field.field.node.external_link.field_show_interstitial_page
     - field.field.node.external_link.field_summary
     - node.type.external_link
   module:
@@ -45,6 +44,5 @@ hidden:
   field_not_in_series: true
   field_prisons: true
   field_release_date: true
-  field_show_interstitial_page: true
   field_summary: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.external_link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.external_link.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.external_link.field_not_in_series
     - field.field.node.external_link.field_prisons
     - field.field.node.external_link.field_release_date
+    - field.field.node.external_link.field_show_interstitial_page
     - field.field.node.external_link.field_summary
     - node.type.external_link
   module:
@@ -31,6 +32,7 @@ content:
     weight: 100
     region: content
 hidden:
+  breadcrumbs: true
   field_display_url: true
   field_exclude_from_prison: true
   field_external_url: true
@@ -43,5 +45,6 @@ hidden:
   field_not_in_series: true
   field_prisons: true
   field_release_date: true
+  field_show_interstitial_page: true
   field_summary: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.link.default.yml
+++ b/config/sync/core.entity_view_display.node.link.default.yml
@@ -1,31 +1,30 @@
-uuid: 19bf6371-5038-48ed-93e6-becc0a6e1ac0
+uuid: 1e4da77a-fb99-41e5-a9d8-93537a90dfa7
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.external_link.field_display_url
-    - field.field.node.external_link.field_exclude_from_prison
-    - field.field.node.external_link.field_external_url
-    - field.field.node.external_link.field_feature_on_category
-    - field.field.node.external_link.field_moj_episode
-    - field.field.node.external_link.field_moj_season
-    - field.field.node.external_link.field_moj_series
-    - field.field.node.external_link.field_moj_thumbnail_image
-    - field.field.node.external_link.field_moj_top_level_categories
-    - field.field.node.external_link.field_not_in_series
-    - field.field.node.external_link.field_prisons
-    - field.field.node.external_link.field_release_date
-    - field.field.node.external_link.field_show_interstitial_page
-    - field.field.node.external_link.field_summary
-    - node.type.external_link
+    - field.field.node.link.field_display_url
+    - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_feature_on_category
+    - field.field.node.link.field_moj_episode
+    - field.field.node.link.field_moj_season
+    - field.field.node.link.field_moj_series
+    - field.field.node.link.field_moj_thumbnail_image
+    - field.field.node.link.field_moj_top_level_categories
+    - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prisons
+    - field.field.node.link.field_release_date
+    - field.field.node.link.field_summary
+    - field.field.node.link.field_url
+    - node.type.link
   module:
     - datetime
     - image
     - link
     - user
-id: node.external_link.default
+id: node.link.default
 targetEntityType: node
-bundle: external_link
+bundle: link
 mode: default
 content:
   field_display_url:
@@ -35,18 +34,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 104
-    region: content
-  field_external_url:
-    type: link
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    weight: 115
     region: content
   field_feature_on_category:
     type: entity_reference_label
@@ -118,16 +105,6 @@ content:
     third_party_settings: {  }
     weight: 108
     region: content
-  field_show_interstitial_page:
-    type: boolean
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    weight: 116
-    region: content
   field_summary:
     type: string
     label: above
@@ -135,6 +112,18 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 114
+    region: content
+  field_url:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 116
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.link.default.yml
+++ b/config/sync/core.entity_view_display.node.link.default.yml
@@ -21,7 +21,6 @@ dependencies:
   module:
     - datetime
     - image
-    - link
     - user
 id: node.link.default
 targetEntityType: node
@@ -125,16 +124,12 @@ content:
     weight: 114
     region: content
   field_url:
-    type: link
+    type: string
     label: above
     settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
+      link_to_entity: false
     third_party_settings: {  }
-    weight: 116
+    weight: 118
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.link.default.yml
+++ b/config/sync/core.entity_view_display.node.link.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.link.field_not_in_series
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
+    - field.field.node.link.field_show_interstitial_page
     - field.field.node.link.field_summary
     - field.field.node.link.field_url
     - node.type.link
@@ -104,6 +105,16 @@ content:
       format_type: medium
     third_party_settings: {  }
     weight: 108
+    region: content
+  field_show_interstitial_page:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 117
     region: content
   field_summary:
     type: string

--- a/config/sync/core.entity_view_display.node.link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.link.teaser.yml
@@ -1,0 +1,48 @@
+uuid: 36ae18a4-b0e0-4295-9fb2-db297695d56d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.link.field_display_url
+    - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_feature_on_category
+    - field.field.node.link.field_moj_episode
+    - field.field.node.link.field_moj_season
+    - field.field.node.link.field_moj_series
+    - field.field.node.link.field_moj_thumbnail_image
+    - field.field.node.link.field_moj_top_level_categories
+    - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prisons
+    - field.field.node.link.field_release_date
+    - field.field.node.link.field_summary
+    - field.field.node.link.field_url
+    - node.type.link
+  module:
+    - user
+id: node.link.teaser
+targetEntityType: node
+bundle: link
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  breadcrumbs: true
+  field_display_url: true
+  field_exclude_from_prison: true
+  field_feature_on_category: true
+  field_moj_episode: true
+  field_moj_season: true
+  field_moj_series: true
+  field_moj_thumbnail_image: true
+  field_moj_top_level_categories: true
+  field_not_in_series: true
+  field_prisons: true
+  field_release_date: true
+  field_summary: true
+  field_url: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.link.teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.link.field_not_in_series
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
+    - field.field.node.link.field_show_interstitial_page
     - field.field.node.link.field_summary
     - field.field.node.link.field_url
     - node.type.link
@@ -43,6 +44,7 @@ hidden:
   field_not_in_series: true
   field_prisons: true
   field_release_date: true
+  field_show_interstitial_page: true
   field_summary: true
   field_url: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.external_link.field_show_interstitial_page.yml
+++ b/config/sync/field.field.node.external_link.field_show_interstitial_page.yml
@@ -1,0 +1,23 @@
+uuid: 3d82c910-90bd-4af5-838b-b55474cbd7db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_show_interstitial_page
+    - node.type.external_link
+id: node.external_link.field_show_interstitial_page
+field_name: field_show_interstitial_page
+entity_type: node
+bundle: external_link
+label: 'Show interstitial page'
+description: 'Enable the "You are leaving the Hub" page.  This is normally used for external links.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.link.field_display_url.yml
+++ b/config/sync/field.field.node.link.field_display_url.yml
@@ -1,0 +1,19 @@
+uuid: 84457073-2a12-4ffc-8d31-caca29ac21a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_display_url
+    - node.type.link
+id: node.link.field_display_url
+field_name: field_display_url
+entity_type: node
+bundle: link
+label: 'Display URL'
+description: 'Set the display url, to show to users.  This should be a smaller version of the full url.   E.g. for <em>https://www.example.com</em>, you may wish to use <em>www.example.com</em>.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.link.field_display_url.yml
+++ b/config/sync/field.field.node.link.field_display_url.yml
@@ -10,7 +10,7 @@ field_name: field_display_url
 entity_type: node
 bundle: link
 label: 'Display URL'
-description: 'Set the display url, to show to users.  This should be a smaller version of the full url.   E.g. for <em>https://www.example.com</em>, you may wish to use <em>www.example.com</em>.'
+description: "Set the display url, to show to users.  This should be a smaller version of the full url.   E.g. for <em>https://www.example.com</em>, you may wish to use <em>www.example.com</em>. <br/>\r\nLeave blank to show no url."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.link.field_exclude_from_prison.yml
+++ b/config/sync/field.field.node.link.field_exclude_from_prison.yml
@@ -1,0 +1,29 @@
+uuid: 003a577a-1500-4d94-a2d8-9d1f0d9c33ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_prison
+    - node.type.link
+    - taxonomy.vocabulary.prisons
+id: node.link.field_exclude_from_prison
+field_name: field_exclude_from_prison
+entity_type: node
+bundle: link
+label: 'Exclude from prison'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prisons: prisons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.link.field_feature_on_category.yml
+++ b/config/sync/field.field.node.link.field_feature_on_category.yml
@@ -1,0 +1,29 @@
+uuid: 606d58f0-fae2-4aee-9ec3-59b7a8356ab8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_feature_on_category
+    - node.type.link
+    - taxonomy.vocabulary.moj_categories
+id: node.link.field_feature_on_category
+field_name: field_feature_on_category
+entity_type: node
+bundle: link
+label: 'Feature on category'
+description: '<small>Select whether this content should be featured on a category page.</small>'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      moj_categories: moj_categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.link.field_moj_episode.yml
+++ b/config/sync/field.field.node.link.field_moj_episode.yml
@@ -1,0 +1,23 @@
+uuid: 7b3d6105-2c6d-42d9-8ca8-0899015e17a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_moj_episode
+    - node.type.link
+id: node.link.field_moj_episode
+field_name: field_moj_episode
+entity_type: node
+bundle: link
+label: Episode
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: 999
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.link.field_moj_season.yml
+++ b/config/sync/field.field.node.link.field_moj_season.yml
@@ -1,0 +1,23 @@
+uuid: 3c23c175-d797-40f4-abfa-35c974ef60b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_moj_season
+    - node.type.link
+id: node.link.field_moj_season
+field_name: field_moj_season
+entity_type: node
+bundle: link
+label: Season
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: 999
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.link.field_moj_series.yml
+++ b/config/sync/field.field.node.link.field_moj_series.yml
@@ -1,0 +1,29 @@
+uuid: 87e756e6-7e5d-4ad8-bd96-3f6229de8874
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_moj_series
+    - node.type.link
+    - taxonomy.vocabulary.series
+id: node.link.field_moj_series
+field_name: field_moj_series
+entity_type: node
+bundle: link
+label: Series
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      series: series
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.link.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.link.field_moj_thumbnail_image.yml
@@ -1,0 +1,38 @@
+uuid: 15ad85cc-55c0-4bd1-9dab-21e1f1a542a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_moj_thumbnail_image
+    - node.type.link
+  module:
+    - image
+id: node.link.field_moj_thumbnail_image
+field_name: field_moj_thumbnail_image
+entity_type: node
+bundle: link
+label: 'Thumbnail image'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.node.link.field_moj_top_level_categories.yml
+++ b/config/sync/field.field.node.link.field_moj_top_level_categories.yml
@@ -1,0 +1,29 @@
+uuid: 3ce6280b-3691-4872-a674-ce38777d9a1e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_moj_top_level_categories
+    - node.type.link
+    - taxonomy.vocabulary.moj_categories
+id: node.link.field_moj_top_level_categories
+field_name: field_moj_top_level_categories
+entity_type: node
+bundle: link
+label: Category
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: optgroup_taxonomy_select
+  handler_settings:
+    target_bundles:
+      - moj_categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: 0
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.link.field_not_in_series.yml
+++ b/config/sync/field.field.node.link.field_not_in_series.yml
@@ -1,0 +1,23 @@
+uuid: 83a750fe-c76d-468c-b891-57ec53d4c93e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_not_in_series
+    - node.type.link
+id: node.link.field_not_in_series
+field_name: field_not_in_series
+entity_type: node
+bundle: link
+label: 'This content is not part of any series'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.link.field_prisons.yml
+++ b/config/sync/field.field.node.link.field_prisons.yml
@@ -1,0 +1,29 @@
+uuid: b27f6d04-471c-4189-bea3-856706c332d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prisons
+    - node.type.link
+    - taxonomy.vocabulary.prisons
+id: node.link.field_prisons
+field_name: field_prisons
+entity_type: node
+bundle: link
+label: Prisons
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      prisons: prisons
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.link.field_release_date.yml
+++ b/config/sync/field.field.node.link.field_release_date.yml
@@ -1,0 +1,24 @@
+uuid: a9094b8d-7539-4ba4-b81f-53ee81adef7d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_release_date
+    - node.type.link
+  module:
+    - datetime
+id: node.link.field_release_date
+field_name: field_release_date
+entity_type: node
+bundle: link
+label: Date
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.link.field_show_interstitial_page.yml
+++ b/config/sync/field.field.node.link.field_show_interstitial_page.yml
@@ -1,18 +1,18 @@
-uuid: 3d82c910-90bd-4af5-838b-b55474cbd7db
+uuid: 85c8e50c-38d5-404d-849b-ed40e184770f
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_show_interstitial_page
-    - node.type.external_link
-id: node.external_link.field_show_interstitial_page
+    - node.type.link
+id: node.link.field_show_interstitial_page
 field_name: field_show_interstitial_page
 entity_type: node
-bundle: external_link
+bundle: link
 label: 'Show interstitial page'
 description: 'Enable the "You are leaving the Hub" page.  This is normally used for external links.'
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 1

--- a/config/sync/field.field.node.link.field_summary.yml
+++ b/config/sync/field.field.node.link.field_summary.yml
@@ -1,0 +1,19 @@
+uuid: 95ed6458-6f73-4d95-898a-e60a4d717ba9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_summary
+    - node.type.link
+id: node.link.field_summary
+field_name: field_summary
+entity_type: node
+bundle: link
+label: Summary
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.link.field_url.yml
+++ b/config/sync/field.field.node.link.field_url.yml
@@ -1,0 +1,23 @@
+uuid: cefa7b5a-1db5-4356-843a-a124deb92463
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_url
+    - node.type.link
+  module:
+    - link
+id: node.link.field_url
+field_name: field_url
+entity_type: node
+bundle: link
+label: Url
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 17
+field_type: link

--- a/config/sync/field.field.node.link.field_url.yml
+++ b/config/sync/field.field.node.link.field_url.yml
@@ -1,23 +1,19 @@
-uuid: cefa7b5a-1db5-4356-843a-a124deb92463
+uuid: 9c81ee76-4ee4-46aa-95db-6d53ffac8115
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_url
     - node.type.link
-  module:
-    - link
 id: node.link.field_url
 field_name: field_url
 entity_type: node
 bundle: link
 label: Url
-description: ''
+description: 'You can enter either an external url, e.g. https://www.example.com (please include the https:// part) or an internal one, such as /profile.'
 required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  title: 0
-  link_type: 17
-field_type: link
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_show_interstitial_page.yml
+++ b/config/sync/field.storage.node.field_show_interstitial_page.yml
@@ -1,0 +1,18 @@
+uuid: 870d4265-5bc2-4557-9a4a-d8a2e4537cb5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_show_interstitial_page
+field_name: field_show_interstitial_page
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_url.yml
+++ b/config/sync/field.storage.node.field_url.yml
@@ -1,16 +1,18 @@
-uuid: bee65c61-c23f-4d4d-b998-648182d0479a
+uuid: 4e5b2c71-bb0c-425f-af01-d45bd8019a21
 langcode: en
 status: true
 dependencies:
   module:
-    - link
     - node
 id: node.field_url
 field_name: field_url
 entity_type: node
-type: link
-settings: {  }
-module: link
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/sync/field.storage.node.field_url.yml
+++ b/config/sync/field.storage.node.field_url.yml
@@ -1,0 +1,19 @@
+uuid: bee65c61-c23f-4d4d-b998-648182d0479a
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_url
+field_name: field_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.link.yml
+++ b/config/sync/node.type.link.yml
@@ -1,0 +1,31 @@
+uuid: 176c94c4-c53f-4672-a3e1-24a29232a347
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
+name: Link
+type: link
+description: 'Use <em>link</em> for creating a content tile that links to either an externally hosted website, or another page on the Hub.  Externally hosted websites must have gone through a security process, and have been allowlisted by the Digital Prisons Network team.'
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/config/sync/pathauto.pattern.link.yml
+++ b/config/sync/pathauto.pattern.link.yml
@@ -1,0 +1,22 @@
+uuid: 7c4654b1-1969-4e5c-855c-ceea979f5097
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: link
+label: Link
+type: 'canonical_entities:node'
+pattern: 'link/[node:nid]'
+selection_criteria:
+  743e0301-52f6-470b-b995-6b7c717934da:
+    id: node_type
+    negate: false
+    uuid: 743e0301-52f6-470b-b995-6b7c717934da
+    context_mapping:
+      node: node
+    bundles:
+      link: link
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.external_link
     - node.type.featured_articles
     - node.type.help_page
+    - node.type.link
     - node.type.moj_pdf_item
     - node.type.moj_radio_item
     - node.type.moj_video_item
@@ -58,6 +59,7 @@ permissions:
   - 'create external_link content'
   - 'create featured_articles content'
   - 'create help_page content'
+  - 'create link content'
   - 'create moj_pdf_item content'
   - 'create moj_radio_item content'
   - 'create moj_video_item content'
@@ -68,16 +70,20 @@ permissions:
   - 'create terms in tags'
   - 'delete any external_link content'
   - 'delete any help_page content'
+  - 'delete any link content'
   - 'delete external_link revisions'
   - 'delete help_page revisions'
+  - 'delete link revisions'
   - 'delete own external_link content'
   - 'delete own help_page content'
+  - 'delete own link content'
   - 'delete terms in moj_categories'
   - 'delete terms in series'
   - 'delete terms in tags'
   - 'edit any external_link content'
   - 'edit any featured_articles content'
   - 'edit any help_page content'
+  - 'edit any link content'
   - 'edit any moj_pdf_item content'
   - 'edit any moj_radio_item content'
   - 'edit any moj_video_item content'
@@ -85,6 +91,7 @@ permissions:
   - 'edit own external_link content'
   - 'edit own featured_articles content'
   - 'edit own help_page content'
+  - 'edit own link content'
   - 'edit own moj_pdf_item content'
   - 'edit own moj_radio_item content'
   - 'edit own moj_video_item content'
@@ -110,6 +117,7 @@ permissions:
   - 'revert external_link revisions'
   - 'revert featured_articles revisions'
   - 'revert help_page revisions'
+  - 'revert link revisions'
   - 'revert moj_pdf_item revisions'
   - 'revert moj_radio_item revisions'
   - 'revert moj_video_item revisions'
@@ -122,6 +130,7 @@ permissions:
   - 'view external_link revisions'
   - 'view featured_articles revisions'
   - 'view help_page revisions'
+  - 'view link revisions'
   - 'view moj_pdf_item revisions'
   - 'view moj_radio_item revisions'
   - 'view moj_video_item revisions'

--- a/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
+++ b/docroot/modules/custom/prisoner_hub_featured_content/tests/src/ExistingSiteJavascript/FeaturedContentFieldsFormTest.php
@@ -61,7 +61,7 @@ class FeaturedContentFieldsFormTest extends ExistingSiteWebDriverTestBase {
    *
    * @var string[]
    */
-  protected static $studioAdminContentTypes = ['moj_radio_item', 'page', 'moj_video_item', 'moj_pdf_item', 'external_link'];
+  protected static $studioAdminContentTypes = ['moj_radio_item', 'page', 'moj_video_item', 'moj_pdf_item', 'link'];
 
   /**
    * Content types to test on for local content managers.

--- a/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/tests/src/ExistingSiteJavascript/TaxonomyFieldsFormStatesTest.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/tests/src/ExistingSiteJavascript/TaxonomyFieldsFormStatesTest.php
@@ -46,7 +46,7 @@ class TaxonomyFieldsFormStatesTest extends ExistingSiteWebDriverTestBase {
    *
    * @var string[]
    */
-  protected static $studioAdminContentTypes = ['moj_radio_item', 'page', 'moj_video_item', 'moj_pdf_item', 'external_link'];
+  protected static $studioAdminContentTypes = ['moj_radio_item', 'page', 'moj_video_item', 'moj_pdf_item', 'link'];
 
   /**
    * Content types to test on for local content managers.

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -298,3 +298,32 @@ function prisoner_content_hub_profile_deploy_update_prison_owners(&$sandbox) {
   }
   return 'Updated nodes: ' . $sandbox['progress'];
 }
+
+/**
+ * Copy over content from "external_link" to "link" content type.
+ */
+function prisoner_content_hub_profile_deploy_copy_link_content_type() {
+  $result = \Drupal::entityQuery('node')
+    ->accessCheck(FALSE)
+    ->condition('type', 'external_link')
+    ->execute();
+
+  $nodes = Node::loadMultiple($result);
+
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($nodes as $node) {
+    $node_values = $node->toArray();
+    $node_values['type'] = 'link';
+    unset($node_values['nid']);
+    unset($node_values['uuid']);
+    unset($node_values['vid']);
+
+    $node_values['field_url'] = $node_values['field_external_url'];
+    unset($node_values['field_external_url']);
+
+    $node_values['field_show_interstitial_page'] = ['value' => 1];
+
+    $new_node = Node::create($node_values);
+    $new_node->save();
+  }
+}

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -317,11 +317,12 @@ function prisoner_content_hub_profile_deploy_copy_link_content_type() {
     unset($node_values['nid']);
     unset($node_values['uuid']);
     unset($node_values['vid']);
+    unset($node_values['path']);
 
     $node_values['field_url'] = $node_values['field_external_url'];
     unset($node_values['field_external_url']);
 
-    $node_values['field_show_interstitial_page'] = ['value' => 1];
+    $node_values['field_show_interstitial_page'] = 1;
 
     $new_node = Node::create($node_values);
     $new_node->save();

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -319,7 +319,9 @@ function prisoner_content_hub_profile_deploy_copy_link_content_type() {
     unset($node_values['vid']);
     unset($node_values['path']);
 
-    $node_values['field_url'] = $node_values['field_external_url'];
+    $node_values['field_url'] = [
+      ['value' => $node_values['field_external_url'][0]['uri']]
+    ];
     unset($node_values['field_external_url']);
 
     $node_values['field_show_interstitial_page'] = 1;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/KZhEpxrh/710-expand-concept-of-external-link-tile-to-cover-internal-links-and-remove-interstitial-page

### Intent

- Rename `external_link` to `link`.  (This can only be done by creating a new content type, copying everything across, and then deleting the old one.  Another PR will be opened to delete the old one).
- Renamed `field_external_url` to `field_url`, and allow internal urls to be added.
- Added `field_show_interstitial_page`, with a default set to "on".

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
