### PR TITLE
Redirect to content overview page after login.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
@@ -10,6 +10,9 @@
  * don't belong to a particular module, and are global to the site.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
 /**
  * Implements hook_toolbar_alter().
  */
@@ -48,4 +51,21 @@ function prisoner_content_hub_profile_file_validate(\Drupal\file\FileInterface $
     $errors[] = t("The file is invalid.  Please check the file and try again.");
   }
   return $errors;
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function prisoner_content_hub_profile_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'user_login_form') {
+    $form['#submit'][] = 'prisoner_content_hub_profile_submit_handler';
+  }
+}
+
+/**
+ * Custom submit handler for login form.
+ */
+function prisoner_content_hub_profile_submit_handler($form, FormStateInterface $form_state) {
+  $url = Url::fromUserInput('/admin/content');
+  $form_state->setRedirectUrl($url);
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't need a card.

### Intent

Currently when you login to Drupal you are shown your account page, which is not particularly useful to the user (it just displays how long the use has had an account for, and nothing else).

This PR will redirect them to the content overview page, once they have logged in.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
