### PR TITLE
Setting correct order on breadcrumbs for content in a series.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
@@ -91,10 +91,11 @@ class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     /** @var \Drupal\taxonomy\TermInterface $category */
     $category = reset($categories);
     $parents = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category->id());
+    $breadcrumb_terms = array_reverse($parents);
     if ($series) {
-      $parents[] = $series;
+      $breadcrumb_terms[] = $series;
     }
-    foreach (array_reverse($parents) as $term) {
+    foreach ($breadcrumb_terms as $term) {
       $term = $this->entityRepository->getTranslationFromContext($term);
       $breadcrumb->addCacheableDependency($term);
       $breadcrumb->addLink(Link::createFromRoute($term->getName(), 'entity.taxonomy_term.canonical', ['taxonomy_term' => $term->id()]));

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
@@ -49,18 +49,23 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
     $this->secondaryTagTerm = $this->createTerm($vocab_secondary_tags);
 
     $vocab_categories = Vocabulary::load('moj_categories');
-    $parentTerm = $this->createTerm($vocab_categories);
+    $parentTerm = $this->createTerm($vocab_categories, [
+      'name' => 'Parent category term'
+    ]);
     $subCategoryTerm = $this->createTerm($vocab_categories, [
+      'name' => 'Sub category term',
       'parent' => [
         ['target_id' => $parentTerm->id()],
       ],
     ]);
     $subSubCategoryTerm = $this->createTerm($vocab_categories, [
+      'name' => 'Sub sub category term',
       'parent' => [
         ['target_id' => $subCategoryTerm->id(),],
       ],
     ]);
     $this->createNode([
+      'name' => 'Series term',
       'field_moj_top_level_categories' => [
         ['target_id' => $subSubCategoryTerm->id()]
       ],
@@ -71,6 +76,7 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
 
     $vocab_series = Vocabulary::load('series');
     $this->seriesTerm = $this->createTerm($vocab_series, [
+      'name' => 'Series term',
       'field_category' =>
         ['target_id' => $subSubCategoryTerm->id()],
     ]);
@@ -104,7 +110,7 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
   /**
    * Test content assigned to a category has the correct breadcrumbs.
    */
-  public function testContentWithCategoryBreadcumb() {
+  public function testContentWithCategoryBreadcrumb() {
     $categories = $this->categoryTerms;
     $category = end($categories);
     $node = $this->createNode([
@@ -119,7 +125,7 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
   /**
    * Test content assigned to a series has the corret breadcrumbs.
    */
-  public function testContentWithSeriesBreadcumb() {
+  public function testContentWithSeriesBreadcrumb() {
     $node = $this->createNode([
       'field_moj_series' => [
         ['target_id' => $this->seriesTerm->id()],
@@ -166,7 +172,7 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
           'options' => [],
         ];
       }
-      $this->assertEqualsCanonicalizing($breadcrumbs, $response_document['data']['attributes']['breadcrumbs'], $message);
+      $this->assertEquals($breadcrumbs, $response_document['data']['attributes']['breadcrumbs'], $message);
     }
   }
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Q74RwuL2/735-extend-breadcrumb-to-all-pages-on-hub

### Intent

Bugfix for content in a series.  The series was appearing at the beginning of the breadcrumb when it should be at the end.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
