### PR TITLE
Adding 'Browse all topics' to topic breadcrumbs.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.services.yml
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/prisoner_hub_breadcrumbs.services.yml
@@ -4,8 +4,12 @@ services:
     arguments: ['@entity_type.manager', '@entity.repository']
     tags:
       - { name: breadcrumb_builder, priority: 1003}
-  prisoner_hub_breadcrumbs.term_breadcrumb_builder:
-    class: Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+  prisoner_hub_breadcrumbs.series_term_breadcrumb_builder:
+    class: Drupal\prisoner_hub_breadcrumbs\SeriesTermBreadcrumbBuilder
     arguments: ['@entity_type.manager', '@entity.repository']
+    tags:
+      - { name: breadcrumb_builder, priority: 1003}
+  prisoner_hub_breadcrumbs.topics_term_breadcrumb_builder:
+    class: Drupal\prisoner_hub_breadcrumbs\TopicsTermBreadcrumbBuilder
     tags:
       - { name: breadcrumb_builder, priority: 1003}

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/NodeBreadcrumbBuilder.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
  * Class NodeBreadcrumbBuilder.
  *
  * Build breadcrumbs for nodes.
- * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+ * @see \Drupal\prisoner_hub_breadcrumbs\SeriesTermBreadcrumbBuilder
  */
 class NodeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   use StringTranslationTrait;

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/SeriesTermBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/SeriesTermBreadcrumbBuilder.php
@@ -12,12 +12,11 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\taxonomy\TermInterface;
 
 /**
- * Class TermBreadcrumbBuilder.
+ * Class SeriesTermBreadcrumbBuilder.
  *
- * Build breadcrumbs for taxonomy terms.
- * @see \Drupal\prisoner_hub_breadcrumbs\TermBreadcrumbBuilder
+ * Build breadcrumbs for series taxonomy terms.
  */
-class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+class SeriesTermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   use StringTranslationTrait;
 
   /**
@@ -35,7 +34,7 @@ class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   protected $entityTypeManager;
 
   /**
-   * Constructs the TermBreadcrumbBuilder.
+   * Constructs the SeriesTermBreadcrumbBuilder.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
@@ -75,7 +74,7 @@ class TermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     if (empty($categories)) {
       return $breadcrumb;
     }
-    
+
     /** @var \Drupal\taxonomy\TermInterface $category */
     $category = reset($categories);
     $parents = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category->id());

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TopicsTermBreadcrumbBuilder.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/src/TopicsTermBreadcrumbBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\prisoner_hub_breadcrumbs;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Class SeriesTermBreadcrumbBuilder.
+ *
+ * Build breadcrumbs for topics taxonomy terms.
+ */
+class TopicsTermBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    if ($route_match->getRouteName() == 'entity.taxonomy_term.canonical') {
+      $term = $route_match->getParameter('taxonomy_term');
+      return $term instanceof TermInterface && $term->bundle() == 'tags';
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+    $breadcrumb->addLink(Link::fromTextAndUrl($this->t('Browse all topics'), Url::fromUri('internal:/topics')));
+
+    $breadcrumb->addCacheContexts(['route']);
+
+    return $breadcrumb;
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
@@ -137,6 +137,29 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
     $this->assertJsonApiBreadcrumbResponse($node, $breadcrumbs);
   }
 
+  public function testTopicsBreadcrumb() {
+    $vocab = Vocabulary::load('tags');
+    $term = $this->createTerm($vocab);
+    $url = Url::fromUri('internal:/jsonapi/taxonomy_term/tags/' . $term->uuid());
+    $response = $this->getJsonApiResponse($url);
+    $this->assertSame(200, $response->getStatusCode(), $url->toString() . ' returns a 200 response.');
+    $response_document = Json::decode((string) $response->getBody());
+    $message = 'JSON response returns the correct results on url: ' . $url->toString();
+    $expected_breadcrumbs = [
+      [
+        'uri' => '/',
+        'title' => 'Home',
+        'options' => [],
+      ],
+      [
+        'uri' => '/topics',
+        'title' => 'Browse all topics',
+        'options' => [],
+      ]
+    ];
+    $this->assertSame($expected_breadcrumbs, $response_document['data']['attributes']['breadcrumbs']);
+  }
+
   /**
    * Helper function to assert that a jsonapi response returns the expected
    * entities.


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ug462lia/770-add-browse-all-topics-to-breadcrumb-when-viewing-a-topics-page

### Intent

<img width="555" alt="Screenshot 2022-03-21 at 11 40 24" src="https://user-images.githubusercontent.com/436483/159254099-096a3f03-81a9-4a3d-aaba-a43b807568f4.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
