### PR TITLE
Fix issue where cache for primary nav would not clear when a prison updated their menu

### DIFF
--- a/docroot/modules/custom/prisoner_hub_primary_nav/src/Resource/PrimaryNavResource.php
+++ b/docroot/modules/custom/prisoner_hub_primary_nav/src/Resource/PrimaryNavResource.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\prisoner_hub_primary_nav\Resource;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\jsonapi\ResourceResponse;
 use Drupal\jsonapi_menu_items\Resource\MenuItemsResource;
 use Drupal\system\Entity\Menu;
@@ -30,9 +31,12 @@ class PrimaryNavResource extends MenuItemsResource {
    *   that this class is still compatible with \Drupal\jsonapi_menu_items\Resource\MenuItemsResource.
    */
   public function process(Request $request, MenuInterface $menu = NULL): ResourceResponse {
+    $cacheability = new CacheableMetadata();
+
     if (is_null($menu)) {
       $prison = \Drupal::routeMatch()->getParameter('prison');
       if ($prison instanceof TermInterface) {
+        $cacheability->addCacheableDependency($prison);
         $entities = $prison->get(\Drupal::getContainer()->getParameter('prisoner_hub_primary_nav.primary_nav_field_name'))->referencedEntities();
         if (!empty($entities)) {
           $menu = reset($entities);
@@ -42,7 +46,9 @@ class PrimaryNavResource extends MenuItemsResource {
     if (is_null($menu)) {
       $menu = Menu::load(\Drupal::getContainer()->getParameter('prisoner_hub_primary_nav.default_menu'));
     }
-    return parent::process($request, $menu);
+    $response = parent::process($request, $menu);
+    $response->addCacheableDependency($cacheability);
+    return $response;
   }
 
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/KlX1FivQ/753-implement-primary-nav-bar

### Intent

This PR fixes an issue where updating a prison (to add a menu) would not result in the cache being cleared.  Meaning the changes would not appear until the 3am cache clear cron run.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
