### PR TITLE
Add missing functionality from content+taxonomy overview pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "drupal/views_bulk_operations": "^3.10",
         "drupal/views_ef_fieldset": "^1.5",
         "drupal/views_entity_form_field": "^1.0@beta",
+        "drupal/views_filters_populate": "^2.0",
         "drush/drush": "^10.3",
         "mhor/php-mediainfo": "^5.1.0",
         "npm-asset/select2": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8eccb1cd452fbd2f0074c5ff5060eb79",
+    "content-hash": "dcfc06b600ca615e51f55d7cd4481326",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5335,6 +5335,54 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/views_entity_form_field",
                 "issues": "https://www.drupal.org/project/issues/views_entity_form_field"
+            }
+        },
+        {
+            "name": "drupal/views_filters_populate",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/views_filters_populate.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/views_filters_populate-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "8797f4834990a0e00a6b6e0b5eee3ecefe9fe52e"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1635451970",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "fgiudici",
+                    "homepage": "https://www.drupal.org/user/2893509"
+                },
+                {
+                    "name": "hanoii",
+                    "homepage": "https://www.drupal.org/user/23157"
+                }
+            ],
+            "description": "Allows one filter to populate other filters value.",
+            "homepage": "https://www.drupal.org/project/views_filters_populate",
+            "support": {
+                "source": "https://git.drupalcode.org/project/views_filters_populate"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -98,6 +98,7 @@ module:
   views_bulk_operations: 0
   views_ef_fieldset: 0
   views_entity_form_field: 0
+  views_filters_populate: 0
   views_ui: 0
   menu_link_content: 1
   pathauto: 1

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -90,19 +90,29 @@ display:
           buttons: false
           action_title: Action
           clear_on_exposed: true
+          force_selection_info: false
           selected_actions:
-            1:
+            0:
               action_id: node_assign_owner_action
-            2:
-              action_id: node_delete_action
-            5:
-              action_id: node_publish_action
-            9:
-              action_id: node_unpublish_action
-            11:
+              preconfiguration:
+                add_confirmation: 0
+            6:
               action_id: views_bulk_edit
               preconfiguration:
+                add_confirmation: 0
                 get_bundles_from_results: 1
+            7:
+              action_id: views_bulk_operations_delete_entity
+              preconfiguration:
+                label_override: 'Delete content'
+            8:
+              action_id: 'entity:publish_action:node'
+              preconfiguration:
+                add_confirmation: 1
+            10:
+              action_id: 'entity:unpublish_action:node'
+              preconfiguration:
+                add_confirmation: 1
         title:
           id: title
           table: node_field_data

--- a/config/sync/views.view.taxonomy_overview.yml
+++ b/config/sync/views.view.taxonomy_overview.yml
@@ -8,6 +8,7 @@ dependencies:
     - taxonomy
     - user
     - views_bulk_operations
+    - views_filters_populate
 id: taxonomy_overview
 label: 'Taxonomy overview'
 module: views
@@ -24,6 +25,71 @@ display:
     display_options:
       title: 'Taxonomy overview'
       fields:
+        parent_target_id:
+          id: parent_target_id
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: field
+          label: 'Term Parents'
+          exclude: true
+          alter:
+            alter_text: false
+            text: '{{ name_1 }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         views_bulk_operations_bulk_form:
           id: views_bulk_operations_bulk_form
           table: views
@@ -142,21 +208,21 @@ display:
           separator: ', '
           field_api_classes: false
           convert_spaces: false
-        parent_target_id:
-          id: parent_target_id
-          table: taxonomy_term__parent
-          field: parent_target_id
-          relationship: none
+        name_1:
+          id: name_1
+          table: taxonomy_term_field_data
+          field: name
+          relationship: field_category
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
-          entity_field: parent
-          plugin_id: field
-          label: 'Term Parents'
-          exclude: false
+          entity_field: name
+          plugin_id: term_name
+          label: 'Category from series name'
+          exclude: true
           alter:
             alter_text: false
-            text: ''
+            text: '{{ parent_target_id }} {{ name_1 }}'
             make_link: false
             path: ''
             absolute: false
@@ -193,11 +259,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
+          click_sort_column: value
+          type: string
           settings:
-            link: true
-          group_column: target_id
+            link_to_entity: true
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -207,6 +273,7 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          convert_spaces: false
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -272,6 +339,55 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: 'Parent categories'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ parent_target_id }}{{ name_1 }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
         changed:
           id: changed
           table: taxonomy_term_field_revision
@@ -451,7 +567,7 @@ display:
           expose:
             operator_id: name_op
             label: Name
-            description: ''
+            description: 'The name of the taxonomy term.<br/>Case intensive. '
             use_operator: false
             operator: name_op
             operator_limit_selection: false
@@ -479,6 +595,53 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        populate:
+          id: populate
+          table: views_filters_populate
+          field: populate
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: views_filters_populate
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Parent category'
+            description: 'Either the parent category or the category for the series.<br/>Case insensitive.'
+            use_operator: false
+            operator: populate_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: populate
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          filters:
+            name_1: name_1
+            name_3: name_3
+            name_4: name_4
+            name_2: name_2
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -512,51 +675,6 @@ display:
               local_administrator: '0'
               administrator: '0'
             reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        name_1:
-          id: name_1
-          table: taxonomy_term_field_data
-          field: name
-          relationship: parent_target_id
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: name_1_op
-            label: Name
-            description: ''
-            use_operator: false
-            operator: name_1_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: name_1
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              moj_local_content_manager: '0'
-              local_administrator: '0'
-              administrator: '0'
-            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -613,10 +731,179 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        name_1:
+          id: name_1
+          table: taxonomy_term_field_data
+          field: name
+          relationship: parent_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 2
+          exposed: false
+          expose:
+            operator_id: name_1_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name_1
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name_3:
+          id: name_3
+          table: taxonomy_term_field_data
+          field: name
+          relationship: parent_target_id_1
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name_4:
+          id: name_4
+          table: taxonomy_term_field_data
+          field: name
+          relationship: parent_target_id_2
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name_2:
+          id: name_2
+          table: taxonomy_term_field_data
+          field: name
+          relationship: field_category
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+          2: OR
       style:
         type: table
         options:
@@ -694,6 +981,37 @@ display:
           relationship: none
           group_type: group
           admin_label: Parent
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: standard
+          required: false
+        field_category:
+          id: field_category
+          table: taxonomy_term__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: 'Category from series'
+          plugin_id: standard
+          required: false
+        parent_target_id_1:
+          id: parent_target_id_1
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: parent_target_id
+          group_type: group
+          admin_label: 'Parents parent'
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: standard
+          required: false
+        parent_target_id_2:
+          id: parent_target_id_2
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: parent_target_id_1
+          group_type: group
+          admin_label: 'Parents parents parent'
           entity_type: taxonomy_term
           entity_field: parent
           plugin_id: standard


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No, this is a small change that doesn't warrant a card.

### Intent

Updates the /admin/content page to include the following bulk operation options:
<img width="380" alt="Screenshot 2022-03-23 at 14 31 56" src="https://user-images.githubusercontent.com/436483/159723475-926e4aed-1ce1-4f59-ab03-afe1bec63a47.png">

A new filter on the /admin/content/taxonomy page that lets you search the parent category.  This field works across both series and categories, and takes into account parents that are 2 or 3 levels above. (I.e. if you search for "Leaving" you will get not just the sub-categories but also the sub-sub-categories).

<img width="652" alt="Screenshot 2022-03-23 at 14 32 38" src="https://user-images.githubusercontent.com/436483/159723794-223d4b91-886e-43b7-8fc7-d08e9ef4cd74.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
