### PR TITLE
Making the alt tag field required on thumbnail images.

### DIFF
--- a/config/sync/field.field.node.moj_radio_item.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_moj_thumbnail_image.yml
@@ -27,7 +27,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: false
+  alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.node.moj_video_item.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.moj_video_item.field_moj_thumbnail_image.yml
@@ -27,7 +27,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: false
+  alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't need a card.

### Intent

This PR enables the alt tag field for thumbnail images on the audio and video content type.
It also makes this field required.

Previously this field was not enabled, meaning we are not capturing and outputting alt tag attributes for images on video and audio items.

### Considerations

Once the alt tag is required, you won't be able to update existing content without adding it.  Even if you were trying to update something unrelated to the image.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
