### PR TITLE
Remove s3 file check for resized image urls.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,8 @@
         "patches": {
             "drupal/flysystem_s3": {
                 "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-58-presigned-urls.patch",
-                "Issue #3248956 - Disable other fields when uploading files": "patches/flysystem_s3-3248956-disable-other-fields-when-uploading-3.patch"
+                "Issue #3248956 - Disable other fields when uploading files": "patches/flysystem_s3-3248956-disable-other-fields-when-uploading-3.patch",
+                "Issue #3271681 - Improve performance when generating image style urls": "patches/flysystem_s3-3271681-improve-performance-when-generating-image-style-urls-2.patch"
             },
             "twistor/stream-util": {
                 "PR #3 - More robust version of getSize() ": "patches/stream_util-pr3-more-robust-version-of-getsize.patch"

--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,10 @@
                 "Issue #3270141: Allow other modules to extend MenuItemsResource.": "patches/jsonapi_menu_items-3270141-allow-other-modules-to-extend-2.patch"
             },
             "drupal/config_ignore": {
-                "Issue #2857247:Support for export filtering via Drush.": "patches/config_ignore_2857247-75.patch"
+                "Issue #2857247: Support for export filtering via Drush.": "patches/config_ignore_2857247-75.patch"
+            },
+            "drupal/image_style_warmer": {
+                "Issue #3117806: Allow processing of temporary files.": "patches/image_style_warmer-3117806-1.1-4.patch"
             }
         },
         "patches-ignore": {

--- a/patches/flysystem_s3-3271681-improve-performance-when-generating-image-style-urls-2.patch
+++ b/patches/flysystem_s3-3271681-improve-performance-when-generating-image-style-urls-2.patch
@@ -1,0 +1,37 @@
+diff --git a/src/Flysystem/S3.php b/src/Flysystem/S3.php
+index 7a07c87..b80d759 100644
+--- a/src/Flysystem/S3.php
++++ b/src/Flysystem/S3.php
+@@ -196,7 +196,7 @@ class S3 implements FlysystemPluginInterface, ContainerFactoryPluginInterface {
+ 
+     $target = $this->getTarget($uri);
+ 
+-    if (strpos($target, 'styles/') === 0 && !file_exists($uri)) {
++    if (strpos($target, 'styles/') === 0 && !$this->isUsingImageStyleWarmer($target) && !file_exists($uri)) {
+       $this->generateImageStyle($target);
+     }
+ 
+@@ -267,4 +267,23 @@ class S3 implements FlysystemPluginInterface, ContainerFactoryPluginInterface {
+     return $protocol . '://' . $cname . $bucket . $prefix;
+   }
+ 
++  /**
++   * Checks whether the image_style_warmer module has been used for $target.
++   *
++   * @param string $target
++   *   The target url, containing the image style name.
++   *
++   * @return bool
++   *   TRUE if image_style_warmer is configured to generate styles for $target,
++   *   otherwise FALSE.
++   */
++  protected function isUsingImageStyleWarmer($target) {
++    if (!\Drupal::moduleHandler()->moduleExists('image_style_warmer')) {
++      return FALSE;
++    }
++    $initialImageStyles = \Drupal::config('image_style_warmer.settings')->get('initial_image_styles');
++    [, $imageStyle] = explode('/', $target, 4);
++    return isset($initialImageStyles[$imageStyle]);
++  }
++
+ }

--- a/patches/image_style_warmer-3117806-1.1-4.patch
+++ b/patches/image_style_warmer-3117806-1.1-4.patch
@@ -1,0 +1,21 @@
+diff --git a/src/ImageStylesWarmer.php b/src/ImageStylesWarmer.php
+index 4ca17bf..a638847 100644
+--- a/src/ImageStylesWarmer.php
++++ b/src/ImageStylesWarmer.php
+@@ -144,12 +144,10 @@ class ImageStylesWarmer implements ImageStylesWarmerInterface {
+    * {@inheritdoc}
+    */
+   public function validateImage(FileInterface $file) {
+-    if ($file->isPermanent()) {
+-      $image = $this->image->get($file->getFileUri());
+-      $extensions = implode(' ', $image->getToolkit()->getSupportedExtensions());
+-      if ($image->isValid() && empty(file_validate_extensions($file, $extensions))) {
+-        return TRUE;
+-      }
++    $image = $this->image->get($file->getFileUri());
++    $extensions = implode(' ', $image->getToolkit()->getSupportedExtensions());
++    if ($image->isValid() && empty(file_validate_extensions($file, $extensions))) {
++      return TRUE;
+     }
+     return FALSE;
+   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/VMoQOLQb/271-improve-performance-by-removing-s3-resized-image-check

### Intent

Adds a patch to the flysystem_s3 module, that prevents the `file_exists()` check when the `image_style_warmer` module is being used.

The `image_style_warmer` is a separate module, that pre-generates resized images.  The patch to the flysystem_s3 module checks that the `image_style_warmer` is enabled, and has been configured for the current image being requested.  If so, then it assumes the file already exists and avoids running the check.

This patch has been added to https://www.drupal.org/project/flysystem_s3/issues/3271681

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
