### PR TITLE
Revert method for stripping itok query param.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         },
         "patches": {
             "drupal/flysystem_s3": {
-                "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-58-presigned-urls.patch",
+                "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-59-presigned-urls.patch",
                 "Issue #3248956 - Disable other fields when uploading files": "patches/flysystem_s3-3248956-disable-other-fields-when-uploading-3.patch"
             },
             "twistor/stream-util": {

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -93,6 +93,15 @@ $settings['flysystem']['s3-css-js']['serve_css'] = TRUE;
 // windows in ckeditor (e.g. image upload). See https://trello.com/c/48w0up7I
 $settings['flysystem']['s3-css-js']['config']['public'] = FALSE;
 
+// Remove the ?itok parameter from image style urls, these interfere with the
+// aws signature.  The itok param is related to DDoS protection: SA-CORE-2013-002
+// However the protection itself is actually handled by a different setting:
+// `allow_insecure_derivatives` which we leave as FALSE.
+//  I.e. there is no vulnerability in using `suppress_itok_output = TRUE`.
+// @see \Drupal\image\Entity\ImageStyle::buildUrl().
+// @see \Drupal\image\Controller\ImageStyleDownloadController::deliver().
+$config['image.settings']['suppress_itok_output'] = TRUE;
+
 $settings['hash_salt'] = getenv('HASH_SALT', true);
 $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';

--- a/patches/flysystem_2772847-59-presigned-urls.patch
+++ b/patches/flysystem_2772847-59-presigned-urls.patch
@@ -1,5 +1,5 @@
 diff --git a/README.md b/README.md
-index 13811fc..4c44c10 100644
+index 13811fc..f882c97 100644
 --- a/README.md
 +++ b/README.md
 @@ -39,7 +39,7 @@ $schemes = [
@@ -24,8 +24,26 @@ index 13811fc..4c44c10 100644
        // 'cors' => TRUE,                          // Set to TRUE if CORS upload
                                                    // support is enabled for the
                                                    // bucket.
+@@ -77,3 +83,16 @@ $schemes = [
+
+ $settings['flysystem'] = $schemes;
+ ```
++
++## Pre-signed urls
++To enable pre-signed urls, set:
++```php
++$settings['flysystem']['s3']['config']['options']['ACL'] = 'private';
++$settings['flysystem']['s3']['config']['public'] = TRUE;
++```
++
++You must then add the following to your settings.php file:
++```php
++$config['image.settings']['suppress_itok_output'] = TRUE;
++```
++As the itok parameter will interfere with the signature in the url.
+\ No newline at end of file
 diff --git a/flysystem_s3.module b/flysystem_s3.module
-index 6db5014..7f22534 100644
+index 6db5014..4c82d83 100644
 --- a/flysystem_s3.module
 +++ b/flysystem_s3.module
 @@ -5,6 +5,11 @@
@@ -40,7 +58,7 @@ index 6db5014..7f22534 100644
  use Drupal\flysystem_s3\S3CorsManagedFileHelper;
 
  /**
-@@ -13,3 +18,44 @@ use Drupal\flysystem_s3\S3CorsManagedFileHelper;
+@@ -13,3 +18,28 @@ use Drupal\flysystem_s3\S3CorsManagedFileHelper;
  function flysystem_s3_element_info_alter(array &$types) {
    S3CorsManagedFileHelper::alterInfo($types);
  }
@@ -67,22 +85,6 @@ index 6db5014..7f22534 100644
 +        );
 +      }
 +    }
-+  }
-+}
-+
-+/**
-+ * Implements hook_preprocess_HOOK().
-+ *
-+ * Remove 'itok' query parameter from presigned S3 urls.  As they cause the
-+ * signature to be invalid.
-+ */
-+function flysystem_s3_preprocess_image_style(&$variables) {
-+  $settings = Settings::get('flysystem');
-+  $scheme = StreamWrapperManager::getScheme($variables['uri']);
-+  if (isset($settings[$scheme]) && $settings[$scheme]['config']['options']['ACL'] != 'public-read' && $settings[$scheme]['config']['public']) {
-+    $parsed_uri = UrlHelper::parse($variables['image']['#uri']);
-+    $query_params = UrlHelper::filterQueryParameters($parsed_uri['query'], ['itok']);
-+    $variables['image']['#uri'] = $parsed_uri['path'] . '?' . UrlHelper::buildQuery($query_params);
 +  }
 +}
 diff --git a/src/Flysystem/S3.php b/src/Flysystem/S3.php


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Related to: 
- https://trello.com/c/bD1oEkd0/826-re-instate-drupal-image-resizing-ddos-protection
- https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/383

### Intent

Previous PR used a different method for stripping out the `?itok` parameter from resized image urls.  However, this didn't work in all situations - most notably via JSON:API, so image urls were considered invalid by s3.

This PR reverts back to using the `$config['image.settings']['suppress_itok_output'] = TRUE;` setting.  Which I initially thought was a security concern, but turns out that there is a separate setting that actually handles the DDoS protection (i.e. allowing images to be resized without a token).  I've updated the comments above the setting to explain this.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
