### PR TITLE
Fixing 500 error when a referenced entity is deleted.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
             "drupal/core": {
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
                 "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
-                "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-34.patch",
+                "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-40.patch",
                 "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch"
             },
             "drupal/jsonapi_page_limit": {

--- a/patches/drupal-3057545-40.patch
+++ b/patches/drupal-3057545-40.patch
@@ -1,20 +1,20 @@
 diff --git a/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php b/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php
-index 01761e14c5..726a2defc9 100644
+index 0bf634ea5e..e1af2d0276 100644
 --- a/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php
 +++ b/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php
-@@ -39,7 +39,7 @@
+@@ -40,7 +40,7 @@
   *   list_class = "\Drupal\Core\Field\EntityReferenceFieldItemList",
   * )
   */
 -class EntityReferenceItem extends FieldItemBase implements OptionsProviderInterface, PreconfiguredFieldUiOptionsInterface {
 +class EntityReferenceItem extends FieldItemBase implements EntityReferenceItemInterface, OptionsProviderInterface, PreconfiguredFieldUiOptionsInterface {
- 
+
    /**
     * {@inheritdoc}
-@@ -708,4 +708,19 @@ public static function getPreconfiguredOptions() {
+@@ -726,4 +726,19 @@ public static function getPreconfiguredOptions() {
      return $options;
    }
- 
+
 +  /**
 +   * {@inheritdoc}
 +   */
@@ -64,12 +64,12 @@ index 0000000000..92bd86f497
 +
 +}
 diff --git a/core/modules/jsonapi/src/Context/FieldResolver.php b/core/modules/jsonapi/src/Context/FieldResolver.php
-index 9790d4804b..959bd4037a 100644
+index 58d1e4c405..1c2e9529e4 100644
 --- a/core/modules/jsonapi/src/Context/FieldResolver.php
 +++ b/core/modules/jsonapi/src/Context/FieldResolver.php
-@@ -330,9 +330,10 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
+@@ -346,9 +346,10 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
        $resource_types = $this->getRelatableResourceTypes($resource_types, $candidate_definitions);
- 
+
        $at_least_one_entity_reference_field = FALSE;
 -      $candidate_property_names = array_unique(NestedArray::mergeDeepArray(array_map(function (FieldItemDataDefinitionInterface $definition) use (&$at_least_one_entity_reference_field) {
 +      $data_reference_target_property_name = FALSE;
@@ -80,9 +80,9 @@ index 9790d4804b..959bd4037a 100644
            $property_definition = $property_definitions[$property_name];
            $is_data_reference_definition = $property_definition instanceof DataReferenceTargetDefinition;
            if (!$property_definition->isInternal()) {
-@@ -341,6 +342,18 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
-             // representation. Hence it must also not be exposed in 400
-             // responses' error messages.
+@@ -356,6 +357,18 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
+             // (usually `target_id`) is exposed in the JSON:API representation
+             // with a prefix.
              $property_names[] = $is_data_reference_definition ? 'id' : $property_name;
 +            if ($is_data_reference_definition) {
 +              if ($data_reference_target_property_name && $data_reference_target_property_name !== $property_name) {
@@ -99,7 +99,7 @@ index 9790d4804b..959bd4037a 100644
            }
            if ($is_data_reference_definition) {
              $at_least_one_entity_reference_field = TRUE;
-@@ -426,6 +439,9 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
+@@ -442,6 +455,9 @@ public function resolveInternalEntityQueryPath(ResourceType $resource_type, $ext
          }
          // The property is a reference, so add it to the breadcrumbs and
          // continue resolving fields.
@@ -109,7 +109,7 @@ index 9790d4804b..959bd4037a 100644
          $reference_breadcrumbs[] = array_shift($parts);
        }
      }
-@@ -603,9 +619,19 @@ protected static function getAllDataReferencePropertyNames(array $candidate_defi
+@@ -621,9 +637,19 @@ protected static function getAllDataReferencePropertyNames(array $candidate_defi
        $property_definitions = $definition->getPropertyDefinitions();
        foreach ($property_definitions as $property_name => $property_definition) {
          if ($property_definition instanceof DataReferenceDefinitionInterface) {
@@ -133,7 +133,7 @@ index 9790d4804b..959bd4037a 100644
        }
        return $reference_property_names;
 diff --git a/core/modules/jsonapi/src/IncludeResolver.php b/core/modules/jsonapi/src/IncludeResolver.php
-index e68c9b218e..9a5e950a5d 100644
+index 2aad83386f..a1dd05b580 100644
 --- a/core/modules/jsonapi/src/IncludeResolver.php
 +++ b/core/modules/jsonapi/src/IncludeResolver.php
 @@ -6,7 +6,7 @@
@@ -145,7 +145,7 @@ index e68c9b218e..9a5e950a5d 100644
  use Drupal\jsonapi\Access\EntityAccessChecker;
  use Drupal\jsonapi\Context\FieldResolver;
  use Drupal\jsonapi\Exception\EntityAccessDeniedHttpException;
-@@ -136,10 +136,19 @@ protected function resolveIncludeTree(array $include_tree, Data $data, Data $inc
+@@ -138,10 +138,21 @@ protected function resolveIncludeTree(array $include_tree, Data $data, Data $inc
            continue;
          }
          $target_type = $field_list->getFieldDefinition()->getFieldStorageDefinition()->getSetting('target_type');
@@ -162,15 +162,17 @@ index e68c9b218e..9a5e950a5d 100644
 +        else {
 +          foreach ($field_list as $field_item) {
 +            assert($field_item instanceof EntityReferenceItemInterface);
-+            // Support entity reference fields, which don't have the referenced
-+            // target type stored in settings.
-+            $references[$field_item->entity->getEntityTypeId()][] = $field_item->get($field_item::mainPropertyName())->getValue();
++            if ($field_item->entity instanceof EntityInterface) {
++              // Support entity reference fields, which don't have the referenced
++              // target type stored in settings.
++              $references[$field_item->entity->getEntityTypeId()][] = $field_item->get($field_item::mainPropertyName())->getValue();
++            }
 +          }
          }
        }
        foreach ($references as $target_type => $ids) {
 diff --git a/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php b/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php
-index fe508b9708..eb636fde44 100644
+index 2223956a65..a558fd480f 100644
 --- a/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php
 +++ b/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php
 @@ -15,6 +15,7 @@
@@ -179,9 +181,9 @@ index fe508b9708..eb636fde44 100644
  use Drupal\Core\Installer\InstallerKernel;
 +use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItemInterface;
  use Drupal\Core\TypedData\DataReferenceTargetDefinition;
- use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
-@@ -425,29 +426,40 @@ protected function calculateRelatableResourceTypes(ResourceType $resource_type,
+@@ -439,29 +440,40 @@ protected function calculateRelatableResourceTypes(ResourceType $resource_type,
    protected function getRelatableResourceTypesFromFieldDefinition(FieldDefinitionInterface $field_definition, array $resource_types) {
      $item_definition = $field_definition->getItemDefinition();
      $entity_type_id = $item_definition->getSetting('target_type');
@@ -194,7 +196,7 @@ index fe508b9708..eb636fde44 100644
 +    }
 +    else {
 +      $handler_settings = $item_definition->getSetting('handler_settings');
- 
+
 -    foreach ($target_bundles as $target_bundle) {
 -      if ($resource_type = static::lookupResourceType($resource_types, $entity_type_id, $target_bundle)) {
 -        $relatable_resource_types[] = $resource_type;
@@ -242,4 +244,4 @@ index fe508b9708..eb636fde44 100644
 +        }
        }
      }
- 
+


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

Yesterday an error was discovered on prod, a series had been deleted that was being referenced from the Berwyn homepage.
When this happens, the referencing content should still work, but just not load in the deleted item.  However, the page crashed. There was a 500 error coming from the Drupal JSON:API response.

The issue was caused by the fact we are using a patch on Drupal core to allow it to support the `dynamic_entity_reference` module (which is used on the homepage so you can reference both content and series/categories).  The patch did not work with deleted entities.

I've updated the patch to fix the issue.
See https://www.drupal.org/project/drupal/issues/3057545#comment-14464137

### Considerations

> Is there any additional information that would help when reviewing this PR?

Lots of the diff on this PR are because the patch had to be updated to work with the latest version of Drupal core.  So they aren't real changes.
The only _real_ change is the following part
```
+            if ($field_item->entity instanceof EntityInterface) {
+              // Support entity reference fields, which don't have the referenced
+              // target type stored in settings.
+              $references[$field_item->entity->getEntityTypeId()][] = $field_item->get($field_item::mainPropertyName())->getValue();
+            }
+          }
```

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
