### PR TITLE
Setting the content overview page as the homepage.

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /user/login
+  front: /admin/content
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

This sets the homepage in Drupal as the /admin/content page.  This means when a user logs in, they are immediately taken to this page (rather than the /user page).

### Considerations

The previous homepage was /user/login, which presented a logged out user with a login form.  
However as the /admin/content page is not accessible when logged out, the user will still see the login form (so it will appear the same as it did before).  There is a small difference:

Before:
<img width="671" alt="Screenshot 2022-03-31 at 12 45 58" src="https://user-images.githubusercontent.com/436483/161047839-197c0837-db57-4cf6-8deb-205bc4000d1e.png">
After:
<img width="607" alt="Screenshot 2022-03-31 at 12 46 01" src="https://user-images.githubusercontent.com/436483/161047860-88c15766-2a2c-4fe3-b737-38090ab800d3.png">


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
