### PR TITLE
Update prisoner_hub_taxonomy_sorting.module

### DIFF
--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/prisoner_hub_taxonomy_sorting.module
@@ -42,7 +42,8 @@ function prisoner_hub_taxonomy_sorting_entity_base_field_info(\Drupal\Core\Entit
 function prisoner_hub_taxonomy_sorting_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
     \Drupal::service('prisoner_hub_taxonomy_sorting.entity_presave')->updatesSeriesSortValue($entity);
-    \Drupal::service('prisoner_hub_taxonomy_sorting.entity_presave')->updateTaxonomyContentUpdatedValue($entity);
+    // Temporarily commenting out as this causes cascading cache invalidations
+    // \Drupal::service('prisoner_hub_taxonomy_sorting.entity_presave')->updateTaxonomyContentUpdatedValue($entity);
   }
 }
 


### PR DESCRIPTION
When a piece of content is updated, it updates the timestamp of the associated category.
This invalidates the category from the cache and in turn removes all associated content from the cache
