### PR TITLE
Adding jsonapi resource for sub terms.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   prisoner_hub_prison_access: 0
   prisoner_hub_prison_access_cms: 0
   prisoner_hub_prison_context: 0
+  prisoner_hub_sub_terms: 0
   prisoner_hub_taxonomy_access: 0
   prisoner_hub_taxonomy_child_count: 0
   prisoner_hub_taxonomy_field_ux: 0

--- a/docroot/modules/custom/prisoner_hub_sub_terms/README.md
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/README.md
@@ -1,0 +1,17 @@
+# Prisoner hub sub terms
+
+Provides a custom JSON:API resource to return "sub terms" of the given category.
+
+Example url:
+`/jsonapi/taxonomy_term/moj_categories/{uuid}/sub_terms`
+
+Note that the above url will work with a prison context.  E.g.
+`/jsonapi/prison/{prison name}}/taxonomy_term/moj_categories/{uuid}/sub_terms`
+
+The results will be a paginated list of series and sub-categories.
+- Any sub category of the {uuid} (including multiple levels, so sub-sub-sub-categories will also work)
+- Any series assigned to either the {uuid} category, or any of it's sub-categories (again on multiple levels).
+
+The results will be ordered by the most recently updated content within each sub term.
+Note that if using a prison context, this again will be applied to the results.
+So only content available in the current prison will be used for sorting.

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.info.yml
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.info.yml
@@ -1,0 +1,7 @@
+name: 'Prisoner hub sub terms'
+type: module
+description: 'Provides a custom jsonapi resource to retrieve a categories sub-terms.'
+core_version_requirement: ^8 || ^9
+package: 'Custom'
+dependencies:
+  - jsonapi_resources:jsonapi_resources

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.routing.yml
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.routing.yml
@@ -1,0 +1,12 @@
+prisoner_hub_sub_terms.jsonapi.get_sub_terms:
+  path: '/%jsonapi%/taxonomy_term/{resource_type}/{taxonomy_term}/sub_terms'
+  defaults:
+    _jsonapi_resource: Drupal\prisoner_hub_sub_terms\Resource\SubTerms
+    _jsonapi_resource_types: ['taxonomy_term--moj_categories']
+  requirements:
+    _permission: 'access content'
+  options:
+    parameters:
+      taxonomy_term:
+        type: entity:taxonomy_term
+        converter: paramconverter.jsonapi.entity_uuid

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.routing.yml
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.routing.yml
@@ -2,7 +2,6 @@ prisoner_hub_sub_terms.jsonapi.get_sub_terms:
   path: '/%jsonapi%/taxonomy_term/{resource_type}/{taxonomy_term}/sub_terms'
   defaults:
     _jsonapi_resource: Drupal\prisoner_hub_sub_terms\Resource\SubTerms
-    _jsonapi_resource_types: ['taxonomy_term--moj_categories']
   requirements:
     _permission: 'access content'
   options:

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -90,10 +90,6 @@ class SubTerms extends EntityQueryResourceBase {
     // This calls loadResourceObjectsByEntityIds() which we override below.
     $data = $this->loadResourceObjectDataFromEntityQuery($query, $cacheability);
 
-    // Add the current taxonomy term as a cacheable dependency, as this won't
-    // be returned as part of the query.
-    $cacheability->addCacheableDependency($taxonomy_term);
-
     $pagination_links = $paginator->getPaginationLinks($query, $cacheability, TRUE);
     $response = $this->createJsonapiResponse($data, $request, 200, [], $pagination_links);
     $response->addCacheableDependency($cacheability);

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -86,12 +86,17 @@ class SubTerms extends EntityQueryResourceBase {
     $paginator->applyToQuery($query, $cacheability);
 
     // Use the standard entity query executor from jsonapi_resources module.
-    // This handles things like pagination for us.
+    // This handles things like pagination, and cacheability for us.
     // This calls loadResourceObjectsByEntityIds() which we override below.
     $data = $this->loadResourceObjectDataFromEntityQuery($query, $cacheability);
 
+    // Add the current taxonomy term as a cacheable dependency, as this won't
+    // be returned as part of the query.
+    $cacheability->addCacheableDependency($taxonomy_term);
+
     $pagination_links = $paginator->getPaginationLinks($query, $cacheability, TRUE);
     $response = $this->createJsonapiResponse($data, $request, 200, [], $pagination_links);
+    $response->addCacheableDependency($cacheability);
     return $response;
 
   }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -116,4 +116,13 @@ class SubTerms extends EntityQueryResourceBase {
     return parent::loadResourceObjectsByEntityIds('taxonomy_term', $filtered_ids, $load_latest_revisions, $check_access);
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * This tells jsonapi_resources module that our resource works with all
+   * taxonomy types.
+   */
+  public function getRouteResourceTypes(Route $route, string $route_name): array {
+    return $this->getResourceTypesByEntityTypeId('taxonomy_term');
+  }
 }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\prisoner_hub_sub_terms\Resource;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\jsonapi\JsonApiResource\ResourceObjectData;
+use Drupal\jsonapi\ResourceResponse;
+use Drupal\jsonapi_resources\Resource\EntityQueryResourceBase;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+
+/**
+ * Processes a request for sub terms.
+ *
+ * For more info on how this class works, see examples in
+ * jsonapi_resources/tests/modules/jsonapi_resources_test/src/Resource
+ *
+ * @internal
+ */
+class SubTerms extends EntityQueryResourceBase {
+
+  /**
+   * Process the resource request.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   * @param TermInterface $taxonomy_term
+   *   The taxonomy term.
+   *
+   * @return \Drupal\jsonapi\ResourceResponse
+   *   The response.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function process(Request $request, TermInterface $taxonomy_term): ResourceResponse {
+    $cacheability = new CacheableMetadata();
+    $cacheability->addCacheContexts(['url.path']);
+
+    $tids = [$taxonomy_term->id()];
+
+    // Check content also assigned to any sub-category (multiple levels) of the
+    // current category.
+    $children = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree($taxonomy_term->bundle(), $taxonomy_term->id());
+    foreach ($children as $child) {
+      $tids[] = $child->tid;
+    }
+
+    // Use aggregate entity query, so that we can use groupBy on the category
+    // and series fields.  Removing duplicate category and series ids.
+    // @see https://www.drupal.org/node/1918702
+    $query = $this->entityTypeManager->getStorage('node')->getAggregateQuery();
+
+    // Check for content that's...
+    $condition_group = $query->orConditionGroup()
+      // Assigned to a category that has a parent (multiple levels) which is the
+      // current category.
+      ->condition('field_moj_top_level_categories.entity:taxonomy_term.parent', $tids, 'IN')
+
+      // Assigned to a series that is assigned to the current category (or one
+      // of it's children).
+      ->condition('field_moj_series.entity:taxonomy_term.field_category', $tids, 'IN');
+
+    $query->condition($condition_group);
+
+    // Filter for published content.
+    $query->condition('status', NodeInterface::PUBLISHED);
+
+    // Note that prison filtering is automatically applied to the query.
+    // @see \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber
+
+    // Add groupBy's to the query.  Note that by adding these, the target id
+    // of the taxonomy term will become available in the query result.
+    // We can then convert these to taxonomy entities in
+    // $this->loadResourceObjectsByEntityIds().
+    $query->groupBy('field_moj_top_level_categories');
+    $query->groupBy('field_moj_series');
+
+    // Aggregate the groupings by the most recently created, and sort by that.
+    $query->sortAggregate('changed', 'MAX', 'DESC');
+
+    $paginator = $this->getPaginatorForRequest($request);
+    $paginator->applyToQuery($query, $cacheability);
+
+    // Use the standard entity query executor from jsonapi_resources module.
+    // This handles things like pagination for us.
+    // This calls loadResourceObjectsByEntityIds() which we override below.
+    $data = $this->loadResourceObjectDataFromEntityQuery($query, $cacheability);
+
+    $pagination_links = $paginator->getPaginationLinks($query, $cacheability, TRUE);
+    $response = $this->createJsonapiResponse($data, $request, 200, [], $pagination_links);
+    return $response;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Override parent method so that we load in the correct entities.
+   * As our original entity query was for nodes, but we actually want to load in
+   * taxonomy terms from the entity reference field values.
+   *
+   * Overriding this method is a bit of a workaround, so that we can still call
+   * $this->loadResourceObjectDataFromEntityQuery().
+   * We would have otherwise used $this->entityQueryExecutor directly, but it's
+   * private.
+   */
+  protected function loadResourceObjectsByEntityIds($entity_type_id, array $ids, $load_latest_revisions = FALSE, $check_access = TRUE): ResourceObjectData {
+    $filtered_ids = array_map(static function ($item) {
+      // Return either category id or series id, first non NULL value.
+      return $item['field_moj_top_level_categories_target_id'] ?? $item['field_moj_series_target_id'];
+    }, $ids);
+    return parent::loadResourceObjectsByEntityIds('taxonomy_term', $filtered_ids, $load_latest_revisions, $check_access);
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Drupal\Tests\prisoner_hub_sub_terms\ExistingSite;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use GuzzleHttp\RequestOptions;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Test the the content suggestions JSON:API resource works correctly
+ *
+ * @group prisoner_hub_content_suggestions
+ */
+class PrisonerHubSubTermsTest extends ExistingSiteBase {
+
+  use JsonApiRequestTestTrait;
+  use NodeCreationTrait;
+  use TaxonomyCreationTrait;
+
+  /**
+   * A generated category term.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
+  protected $categoryTerm;
+
+  /**
+   * A generated category term.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
+  protected $subCategoryTerm;
+
+  /**
+   * A generated series term, that is linked to $this->$categoryTerm.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
+  protected $seriesTerm;
+
+  /**
+   * Set up taxonomy terms to test with.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $vocab_categories = Vocabulary::load('moj_categories');
+    $this->categoryTerm = $this->createTerm($vocab_categories);
+    $this->jsonApiUrl = Url::fromUri('internal:/jsonapi/taxonomy_term/moj_categories/' . $this->categoryTerm->uuid() . '/sub_terms');
+    $this->subCategoryTerm = $this->createTerm($vocab_categories, [
+      'parent' => [
+        'target_id' => $this->categoryTerm->id(),
+      ],
+    ]);
+
+    $vocab_series = Vocabulary::load('series');
+    $this->seriesTerm = $this->createTerm($vocab_series, ['field_category' => ['target_id' => $this->categoryTerm->id()]]);
+  }
+
+  /**
+   * Test the resource returns the correct taxonomy terms, in the correct order.
+   *
+   * @Todo split this out into several more discrete tests.
+   */
+  public function testSubTermsHaveCorrectSorting() {
+    $vocab_categories = Vocabulary::load('moj_categories');
+    $vocab_series = Vocabulary::load('series');
+
+    $first_term = $this->createTerm($vocab_categories, [
+      'parent' => [
+        'target_id' => $this->categoryTerm->id(),
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $first_term->id()]],
+      'field_not_in_series' => 1,
+      'changed' => time(),
+    ]);
+
+    $last_term = $this->createTerm($vocab_categories, [
+      'parent' => [
+        'target_id' => $this->categoryTerm->id(),
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
+      'field_not_in_series' => 1,
+      'changed' => strtotime('-2 years'),
+    ]);
+
+    // Also create some unpublished content to ensure this doesn't effect
+    // sorting.
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
+      'field_not_in_series' => 1,
+      'changed' => time(),
+      'status' => 0,
+    ]);
+
+    $second_term = $this->createTerm($vocab_series, [
+      'field_category' => [
+        'target_id' => $this->subCategoryTerm->id()
+      ]
+    ]);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $second_term->id()]],
+      'changed' => strtotime('-10 minutes'),
+    ]);
+
+    $third_term = $this->createTerm($vocab_categories, [
+      'parent' => [
+        'target_id' => $this->categoryTerm->id(),
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $third_term->id()]],
+      'field_not_in_series' => 1,
+      'changed' => strtotime('-1 week'),
+    ]);
+
+    $fourth_term = $this->createTerm($vocab_series, [
+      'field_category' => [
+        'target_id' => $this->categoryTerm->id()
+      ]
+    ]);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $fourth_term->id()]],
+      'changed' => strtotime('-6 months'),
+    ]);
+
+    $fifth_term = $this->createTerm($vocab_series, [
+      'field_category' => [
+        'target_id' => $this->subCategoryTerm->id()
+      ]
+    ]);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $fifth_term->id()]],
+      'changed' => strtotime('-7 months'),
+    ]);
+
+    $correct_order_sub_terms = [
+      $first_term->uuid(),
+      $second_term->uuid(),
+      $third_term->uuid(),
+      $fourth_term->uuid(),
+      $fifth_term->uuid(),
+      $last_term->uuid(),
+    ];
+
+    // Create some other categories and series that should not appear in the
+    // results.
+    $another_category = $this->createTerm($vocab_categories);
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $another_category->id()]],
+      'field_not_in_series' => 1,
+    ]);
+
+    $another_sub_category = $this->createTerm($vocab_categories, [
+      'parent' => [
+        'target_id' => $another_category->id(),
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $another_sub_category->id()]],
+      'field_not_in_series' => 1,
+    ]);
+
+    $another_series = $this->createTerm($vocab_series, [
+      'field_category' => [
+        'target_id' => $another_category->id(),
+      ],
+    ]);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $another_series->id()]],
+    ]);
+
+    // Also create content on the main category itself, to ensure that
+    // this also isn't returned (we should only receive sub-terms).
+    $this->createNode([
+      'field_moj_top_level_categories' => [['target_id' => $this->categoryTerm->id()]],
+      'field_not_in_series' => 1,
+    ]);
+
+    $request_options = [];
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    $response = $this->request('GET', $this->jsonApiUrl, $request_options);
+    $this->assertSame(200, $response->getStatusCode());
+    $response_document = Json::decode((string) $response->getBody());
+    foreach ($response_document['data'] as $item) {
+      $this->assertEquals($correct_order_sub_terms, array_map(static function (array $data) {
+        return $data['id'];
+      }, $response_document['data']));
+    }
+  }
+
+
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Ar0dte1r/820-change-sorting-of-subcats-series-to-show-relevant-order-in-specific-prisons

### Intent

Provides a new custom jsonapi resource for sub-categories and series:
`/jsonapi/prison/{prison name}}/taxonomy_term/moj_categories/{uuid}/sub_terms`
This is ordered by the most recently updated content (in the current prison).

### Considerations

The current method for retrieving sub-categories and series will continue to work.  A subsequent PR is needed to clean up the old method for sorting by content updated date (as there were performance issues related to this).  

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
