### PR TITLE
Re-enabling view_unpublished module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -94,6 +94,7 @@ module:
   tour: 0
   update: 0
   user: 0
+  view_unpublished: 0
   views_bulk_edit: 0
   views_bulk_operations: 0
   views_ef_fieldset: 0

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -28,6 +28,7 @@ dependencies:
     - system
     - taxonomy
     - toolbar
+    - view_unpublished
 _core:
   default_config_hash: w3gv4hBMp_vQx-dpzgOKpEZ0uNN5SSNFsYLbXwC7WZU
 id: local_administrator
@@ -119,6 +120,7 @@ permissions:
   - 'take_ownership_on_clone file entity'
   - 'take_ownership_on_clone node entity'
   - 'use text format full_html'
+  - 'view any unpublished content'
   - 'view featured_articles revisions'
   - 'view help_page revisions'
   - 'view link revisions'

--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -16,6 +16,7 @@ dependencies:
     - raven
     - scheduler
     - toolbar
+    - view_unpublished
 id: moj_local_content_manager
 label: 'Local Content Manager'
 weight: -8
@@ -43,6 +44,12 @@ permissions:
   - 'schedule publishing of nodes'
   - 'send javascript errors to sentry'
   - 'use text format full_html'
+  - 'view any unpublished featured_articles content'
+  - 'view any unpublished link content'
+  - 'view any unpublished moj_pdf_item content'
+  - 'view any unpublished moj_radio_item content'
+  - 'view any unpublished moj_video_item content'
+  - 'view any unpublished page content'
   - 'view featured_articles revisions'
   - 'view moj_pdf_item revisions'
   - 'view moj_radio_item revisions'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change that doesn't need a card.

### Intent

A previous PR (todo find PR) uninstalled the views_unpublished module, it was considered to be no longer required.
However, we have since found it is still required, as otherwise DCMs (local content managers) cannot view unpublished content.

This PR adds back in the module, and configures it so that all content types excluding help pages can be viewed unpublished.

### Considerations

When a new content type is added, it will need to be included as a permission.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
