### PR TITLE
Removing permissions to use bulk update tool

### DIFF
--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -10,7 +10,6 @@ dependencies:
     - node.type.moj_video_item
     - node.type.page
   module:
-    - actions_permissions
     - filter
     - node
     - raven
@@ -39,8 +38,6 @@ permissions:
   - 'edit own moj_radio_item content'
   - 'edit own moj_video_item content'
   - 'edit own page content'
-  - 'execute entity:publish_action node'
-  - 'execute entity:unpublish_action node'
   - 'schedule publishing of nodes'
   - 'send javascript errors to sentry'
   - 'use text format full_html'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

Currently, DCM's (local content managers) can only edit content owned by their own prison.
However, the bulk update tool circumnavigates these restrictions, so they could use this to publish content that was owned by another prison.

The reason for this is that the restrictions on editing content are only placed on the content edit form, and are not global permissions.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
