### PR TITLE
Fixing failed publication date module install.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -312,3 +312,11 @@ function prisoner_content_hub_profile_update_8020(&$sandbox) {
   return 'Processed terms: ' . $sandbox['progress'];
 
 }
+
+/**
+ * Fix failed publication_date module install.
+ */
+function prisoner_content_hub_profile_update_8021(&$sandbox) {
+  $definition = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node')['published_at'];
+  \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Fixes issue with deployment of https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/393

### Intent

The above PR installed the publication_date module, this failed to install properly on prod.  The error was 
```
Error Output:
  ================

  In DiscoveryTrait.php line 53:


    The "field_item:published_at" plugin does not exist
```
I'm not 100% sure why this happened (and only occurred on prod).  It looks as though the post-install hook ran too early, and the code wasn't there (as the plugin mentioned above should have been available).  Possibly there is a cache of the plugins that wasn't cleared in time.

Either way, the issue now is that the module is technically installed, but it didn't create the necessary column in the database, and didn't run the update to populate the data for existing content.

This PR adds an update hook to ensure the necessary column is created, the updates from the publication_date module will then run without any issues.


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
