### PR TITLE
Feature/recently added resource

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.moj_categories.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.taxonomy_term.moj_categories.field_exclude_from_prison
     - field.field.taxonomy_term.moj_categories.field_featured_image
     - field.field.taxonomy_term.moj_categories.field_featured_tiles
+    - field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image
     - field.field.taxonomy_term.moj_categories.field_prisons
     - image.style.thumbnail
     - taxonomy.vocabulary.moj_categories
@@ -83,14 +84,6 @@ content:
       cascading_selection_enforce: false
       max_depth: 0
     third_party_settings: {  }
-  field_featured_image:
-    type: image_image
-    weight: 2
-    region: content
-    settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
-    third_party_settings: {  }
   field_featured_tiles:
     type: dynamic_entity_reference_default
     weight: 4
@@ -100,6 +93,14 @@ content:
       match_limit: 10
       size: 40
       placeholder: ''
+    third_party_settings: {  }
+  field_moj_thumbnail_image:
+    type: image_image
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
   field_prisons:
     type: term_reference_tree
@@ -134,4 +135,5 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_featured_image: true

--- a/config/sync/core.entity_form_display.taxonomy_term.series.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.series.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.taxonomy_term.series.field_exclude_from_prison
     - field.field.taxonomy_term.series.field_feature_programme_code
     - field.field.taxonomy_term.series.field_featured_image
+    - field.field.taxonomy_term.series.field_moj_thumbnail_image
     - field.field.taxonomy_term.series.field_prisons
     - field.field.taxonomy_term.series.field_sort_by
     - image.style.thumbnail
@@ -27,7 +28,7 @@ third_party_settings:
       label: 'Where would you like this content to appear?'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 6
       format_type: fieldset
       format_settings:
         classes: ''
@@ -72,7 +73,7 @@ content:
     third_party_settings: {  }
   field_exclude_feedback:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -91,13 +92,13 @@ content:
     third_party_settings: {  }
   field_feature_programme_code:
     type: string_textfield
-    weight: 6
+    weight: 4
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_featured_image:
+  field_moj_thumbnail_image:
     type: image_image
     weight: 5
     region: content
@@ -133,10 +134,11 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 9
+    weight: 8
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
 hidden:
+  field_featured_image: true
   path: true

--- a/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.taxonomy_term.topics.field_exclude_feedback
     - field.field.taxonomy_term.topics.field_exclude_from_prison
     - field.field.taxonomy_term.topics.field_featured_image
+    - field.field.taxonomy_term.topics.field_moj_thumbnail_image
     - field.field.taxonomy_term.topics.field_prisons
     - image.style.thumbnail
     - taxonomy.vocabulary.topics
@@ -24,7 +25,7 @@ third_party_settings:
       label: "\tWhere would you like this content to appear?"
       region: content
       parent_name: ''
-      weight: 4
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -62,7 +63,7 @@ content:
     third_party_settings: {  }
   field_exclude_feedback:
     type: boolean_checkbox
-    weight: 6
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -79,7 +80,7 @@ content:
       cascading_selection_enforce: false
       max_depth: 0
     third_party_settings: {  }
-  field_featured_image:
+  field_moj_thumbnail_image:
     type: image_image
     weight: 2
     region: content
@@ -109,15 +110,16 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 3
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_featured_image: true

--- a/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.moj_categories.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.taxonomy_term.moj_categories.field_exclude_from_prison
     - field.field.taxonomy_term.moj_categories.field_featured_image
     - field.field.taxonomy_term.moj_categories.field_featured_tiles
+    - field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image
     - field.field.taxonomy_term.moj_categories.field_prisons
     - taxonomy.vocabulary.moj_categories
   module:
@@ -48,6 +49,15 @@ content:
       link: true
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_moj_thumbnail_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_prisons:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.series.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.taxonomy_term.series.field_exclude_from_prison
     - field.field.taxonomy_term.series.field_feature_programme_code
     - field.field.taxonomy_term.series.field_featured_image
+    - field.field.taxonomy_term.series.field_moj_thumbnail_image
     - field.field.taxonomy_term.series.field_prisons
     - field.field.taxonomy_term.series.field_sort_by
     - taxonomy.vocabulary.series
@@ -61,6 +62,15 @@ content:
       image_style: ''
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_moj_thumbnail_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 19
     region: content
   field_prisons:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.taxonomy_term.topics.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.topics.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.taxonomy_term.topics.field_exclude_feedback
     - field.field.taxonomy_term.topics.field_exclude_from_prison
     - field.field.taxonomy_term.topics.field_featured_image
+    - field.field.taxonomy_term.topics.field_moj_thumbnail_image
     - field.field.taxonomy_term.topics.field_prisons
     - taxonomy.vocabulary.topics
   module:
@@ -49,6 +50,15 @@ content:
       image_style: ''
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_moj_thumbnail_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_prisons:
     type: entity_reference_label

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   prisoner_hub_prison_access: 0
   prisoner_hub_prison_access_cms: 0
   prisoner_hub_prison_context: 0
+  prisoner_hub_recently_added: 0
   prisoner_hub_sub_terms: 0
   prisoner_hub_taxonomy_access: 0
   prisoner_hub_taxonomy_child_count: 0

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image.yml
@@ -1,0 +1,38 @@
+uuid: eabf3eec-95d4-48c8-8a92-03a870c567f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_moj_thumbnail_image
+    - taxonomy.vocabulary.moj_categories
+  module:
+    - image
+id: taxonomy_term.moj_categories.field_moj_thumbnail_image
+field_name: field_moj_thumbnail_image
+entity_type: taxonomy_term
+bundle: moj_categories
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.taxonomy_term.series.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.series.field_moj_thumbnail_image.yml
@@ -1,0 +1,38 @@
+uuid: 0fb06104-3cfe-4ab8-aa1c-d1878088a60a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_moj_thumbnail_image
+    - taxonomy.vocabulary.series
+  module:
+    - image
+id: taxonomy_term.series.field_moj_thumbnail_image
+field_name: field_moj_thumbnail_image
+entity_type: taxonomy_term
+bundle: series
+label: Image
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.taxonomy_term.topics.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.topics.field_moj_thumbnail_image.yml
@@ -1,0 +1,38 @@
+uuid: dda1b9de-7173-4df6-aec8-7824b81985f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_moj_thumbnail_image
+    - taxonomy.vocabulary.topics
+  module:
+    - image
+id: taxonomy_term.topics.field_moj_thumbnail_image
+field_name: field_moj_thumbnail_image
+entity_type: taxonomy_term
+bundle: topics
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.storage.taxonomy_term.field_moj_thumbnail_image.yml
+++ b/config/sync/field.storage.taxonomy_term.field_moj_thumbnail_image.yml
@@ -1,0 +1,30 @@
+uuid: bb996a77-3617-4877-99ae-99fec3a7e661
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+id: taxonomy_term.field_moj_thumbnail_image
+field_name: field_moj_thumbnail_image
+entity_type: taxonomy_term
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: s3
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/prisoner_hub_recently_added/README.md
+++ b/docroot/modules/custom/prisoner_hub_recently_added/README.md
@@ -1,0 +1,17 @@
+# Prisoner hub recently added
+
+Provides a custom JSON:API resource to return recently added content and series.
+
+Example url:
+`/jsonapi/recently-added`
+
+This returns a mixture of nodes and taxonomy terms.
+
+The order is based on the most recently published content (via the publication_date module).
+For content that is in a series, the series taxonomy entity is returned instead of the node.
+For content not in a series, the content entity is returned.
+
+Content that is in the same series is de-duped, so that only one instance of each series entity will appear.
+
+Note this resource does not currently support pagination, but does support a limit.  I.e.
+`/jsonapi/recently-added?page[limit]=4`

--- a/docroot/modules/custom/prisoner_hub_recently_added/README.md
+++ b/docroot/modules/custom/prisoner_hub_recently_added/README.md
@@ -15,3 +15,26 @@ Content that is in the same series is de-duped, so that only one instance of eac
 
 Note this resource does not currently support pagination, but does support a limit.  I.e.
 `/jsonapi/recently-added?page[limit]=4`
+
+## Custom cache tags
+As the cache for the recently added resource will need to be regularly updated, custom cache tags are used to invalidate
+the cache when new published content is created.
+(This avoids having to use a more generic cache tag such as `node_list`, which clears on any node CRUD operation).
+The cache tags also include the prison context, so that only updates relevant to a specific prison are invalidated.
+
+Example of cache tags used by this module:
+`prisoner_hub_recently_added:wayland`
+
+This cache tag is invalidated whenever:
+- New content is published to Wayland
+- Existing content, that is published to Wayland, is updated,
+  and a change has been made to the published date
+  (normally this would be content that was previously unpublished and is now published,
+  but this could also include a manual update to the published date).
+
+The custom cache tag only takes care of potential new content.
+For updates/deletions to existing content previously outputted in the resource, Drupal's standard cache tags take care
+of.  E.g. `node:1234`
+
+
+

--- a/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.info.yml
+++ b/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.info.yml
@@ -1,0 +1,9 @@
+name: 'Prisoner hub recently added'
+type: module
+description: 'Provides a custom jsonapi resource to retrieve recently added content and series.'
+core_version_requirement: ^8 || ^9
+package: 'Custom'
+dependencies:
+  - jsonapi_resources:jsonapi_resources
+  - publication_date:publication_date
+  - prisoner_hub_prison_context:prisoner_hub_prison_context

--- a/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.module
+++ b/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.module
@@ -1,0 +1,53 @@
+<?php
+
+use Drupal\Core\Cache\Cache;
+use Drupal\node\NodeInterface;
+use Drupal\prisoner_hub_recently_added\Resource\RecentlyAdded;
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function prisoner_hub_recently_added_node_update(NodeInterface $entity) {
+  if ($entity->isPublished() && in_array($entity->bundle(), RecentlyAdded::$content_types)) {
+    // Clear cache if the previous version was not published, or a change has
+    // been made to the published date.
+    if (!$entity->original->isPublished() || $entity->original->get('published_at')->value != $entity->get('published_at')->value) {
+      prisoner_hub_recently_added_clear_cache_tags($entity);
+    }
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function prisoner_hub_recently_added_node_insert(NodeInterface $entity) {
+  if ($entity->isPublished() && in_array($entity->bundle(), RecentlyAdded::$content_types)) {
+    prisoner_hub_recently_added_clear_cache_tags($entity);
+  }
+}
+
+/**
+ * Clear custom cache tags.
+ *
+ * These are set in are set in \Drupal\prisoner_hub_recently_added\Resource\RecentlyAdded::process()
+ * and include the current prison context.
+ *
+ * @param \Drupal\node\NodeInterface $entity
+ */
+function prisoner_hub_recently_added_clear_cache_tags(NodeInterface $entity) {
+  $cache_tag = 'prisoner_hub:homepage:recently_added';
+  $tags = [$cache_tag];
+
+  // Loop through all prisons and clear cache tags for each one.
+  $prisons = $entity->get('field_prisons')->referencedEntities();
+  foreach ($prisons as $prison) {
+    $children = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadChildren($prison->id());
+    if (empty($children)) {
+      $tags[] = $cache_tag . ':' . $prison->get('machine_name')->getString();
+    }
+    foreach ($children as $child) {
+      $tags[] = $cache_tag . ':' . $child->get('machine_name')->getString();
+    }
+  }
+  Cache::invalidateTags($tags);
+}

--- a/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.module
+++ b/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.module
@@ -35,7 +35,7 @@ function prisoner_hub_recently_added_node_insert(NodeInterface $entity) {
  * @param \Drupal\node\NodeInterface $entity
  */
 function prisoner_hub_recently_added_clear_cache_tags(NodeInterface $entity) {
-  $cache_tag = 'prisoner_hub:homepage:recently_added';
+  $cache_tag = 'prisoner_hub_recently_added';
   $tags = [$cache_tag];
 
   // Loop through all prisons and clear cache tags for each one.

--- a/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.routing.yml
+++ b/docroot/modules/custom/prisoner_hub_recently_added/prisoner_hub_recently_added.routing.yml
@@ -1,0 +1,6 @@
+prisoner_hub_recently_added.jsonapi.get_recently_added:
+  path: '/%jsonapi%/recently-added'
+  defaults:
+    _jsonapi_resource: Drupal\prisoner_hub_recently_added\Resource\RecentlyAdded
+  requirements:
+    _permission: 'access content'

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -123,11 +123,12 @@ class RecentlyAdded extends EntityResourceBase {
     // See \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber
     $query->condition('status', NodeInterface::PUBLISHED);
 
-    // If timestamps are already set, ensure we only query for newer content.
-    // (This avoids having to unnecessarily load entities).
-    if (!empty($published_at_timestamps)) {
+    // If already have enough entities set, ensure we only query for newer
+    // content. (This avoids having to unnecessarily load entities).
+    if (count($entities) >= $size) {
       $query->condition('published_at', min($published_at_timestamps), '>');
     }
+
     $query->range(0, $size);
     $results = $this->executeQueryInRenderContext($query);
     foreach ($results as $result) {
@@ -164,11 +165,12 @@ class RecentlyAdded extends EntityResourceBase {
     // See \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber
     $query->condition('status', NodeInterface::PUBLISHED);
 
-    // If timestamps are already set, ensure we only query for newer content.
-    // (This avoids having to unnecessarily load entities).
-    if (!empty($published_at_timestamps)) {
+    // If already have enough entities set, ensure we only query for newer
+    // content. (This avoids having to unnecessarily load entities).
+    if (count($entities) >= $size) {
       $query->condition('published_at', min($published_at_timestamps), '>');
     }
+
     $query->sort('published_at', 'DESC');
     $query->range(0, $size);
     $result = $this->executeQueryInRenderContext($query);

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Drupal\prisoner_hub_recently_added\Resource;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Http\Exception\CacheableBadRequestHttpException;
+use Drupal\Core\Render\RenderContext;
+use Drupal\jsonapi\Query\OffsetPage;
+use Drupal\jsonapi\ResourceResponse;
+use Drupal\jsonapi\ResourceType\ResourceType;
+use Drupal\jsonapi_resources\Resource\EntityResourceBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Processes a request for recently added content/series.
+ *
+ * For more info on how this class works, see examples in
+ * jsonapi_resources/tests/modules/jsonapi_resources_test/src/Resource
+ *
+ * @internal
+ */
+class RecentlyAdded extends EntityResourceBase {
+
+  /**
+   * Array of content types to use in the resource.
+   *
+   * @var array|string[]
+   */
+  static array $content_types = ['moj_radio_item', 'page', 'link', 'moj_pdf_item', 'moj_video_item'];
+
+  /**
+   * Process the resource request.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Drupal\jsonapi\ResourceResponse
+   *   The response.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function process(Request $request): ResourceResponse {
+    $cacheability = new CacheableMetadata();
+    $cacheability->addCacheContexts(['url.path']);
+
+    // This is a custom cache tag that is invalidated in prisoner_hub_recently_added_node_update().
+    $cache_tag = 'prisoner_hub:homepage:recently_added';
+    $prison = \Drupal::routeMatch()->getParameter('prison');
+    if ($prison) {
+      $cache_tag .= ':' . $prison->get('machine_name')->getString();
+    }
+    $cacheability->addCacheTags([$cache_tag]);
+
+    $pagination = $this->getPagination($request);
+    if ($pagination->getOffset() != 0) {
+      throw new CacheableBadRequestHttpException($cacheability, sprintf('This resource does not currently support and offset greater than 0.'));
+    }
+    if ($pagination->getSize() <= 0) {
+      throw new CacheableBadRequestHttpException($cacheability, sprintf('The page size needs to be a positive integer.'));
+    }
+
+    /** @var \Drupal\Core\Entity\ContentEntityInterface[] $entities */
+    // An array of either node or series entities.
+    $entities = [];
+
+    /** @var int[] $published_at_timestamps */
+    // The published_at timestamps, keyed to correspond with $entities.
+    $published_at_timestamps = [];
+
+    // Load in series and content entities separately.
+    // We are unable to run everything in one db query, due to the different
+    // rules for content in a series.
+    $this->loadSeriesEntities($entities, $published_at_timestamps, $pagination->getSize());
+    $this->loadContentEntities($entities, $published_at_timestamps, $pagination->getSize());
+
+    // Sort the $published_at_timestamps array and update the $entities to use
+    // the same order.
+    array_multisort($published_at_timestamps, SORT_DESC, SORT_NUMERIC, $entities);
+
+    $data = $this->createCollectionDataFromEntities(array_slice($entities, 0, $pagination->getSize()));
+    $response = $this->createJsonapiResponse($data, $request);
+    $response->addCacheableDependency($cacheability);
+    return $response;
+
+  }
+
+  /**
+   * Load series taxonomy term entities, that have the most recent content.
+   *
+   * This function runs a query that finds the most recently published content,
+   * that is in a series.  Groups them by series (to remove duplicates) and
+   * appends them onto $entities.
+   *
+   * @param array $entities
+   *   The array of content entities, passed in by reference, to be appended to.
+   * @param array $published_at_timestamps
+   *   The array of timestamps, passed in by reference, to be appended to.
+   * @param int $size
+   *   The size requested.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function loadSeriesEntities(array &$entities, array &$published_at_timestamps, int $size) {
+    // Use aggregateQuery instead of standard entity query, so that we can group
+    // by series (to remove duplicates).
+    $query = $this->entityTypeManager->getStorage('node')->getAggregateQuery();
+    $query->groupBy('field_moj_series');
+    $query->sortAggregate('published_at', 'MAX', 'DESC');
+    $query->condition('type', self::$content_types, 'IN');
+
+    // Only query for content that _is_ in a series.
+    $query->condition('field_moj_series', NULL, 'IS NOT NULL');
+
+    // Ensure we only check for published content.
+    // Note that prison category rules are automatically applied to the query.
+    // See \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber
+    $query->condition('status', NodeInterface::PUBLISHED);
+
+    // If timestamps are already set, ensure we only query for newer content.
+    // (This avoids having to unnecessarily load entities).
+    if (!empty($published_at_timestamps)) {
+      $query->condition('published_at', min($published_at_timestamps), '>');
+    }
+    $query->range(0, $size);
+    $results = $this->executeQueryInRenderContext($query);
+    foreach ($results as $result) {
+      $term = Term::load($result['field_moj_series_target_id']);
+      if ($term) {
+        $entities[] = $term;
+        $published_at_timestamps[] = $result['published_at_max'];
+      }
+    }
+  }
+
+  /**
+   * Load content entities that are no in a series.
+   *
+   * @param array $entities
+   *   The array of content entities, passed in by reference, to be appended to.
+   * @param array $published_at_timestamps
+   *   The array of timestamps, passed in by reference, to be appended to.
+   * @param int $size
+   *   The size requested.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function loadContentEntities(array &$entities, array &$published_at_timestamps, int $size) {
+    $query = $this->entityTypeManager->getStorage('node')->getQuery();
+    $query->condition('type', self::$content_types, 'IN');
+
+    // Only get back content not in a series.
+    $query->condition('field_moj_series', NULL, 'IS NULL');
+
+    // Ensure we only check for published content.
+    // Note that prison category rules are automatically applied to the query.
+    // See \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber
+    $query->condition('status', NodeInterface::PUBLISHED);
+
+    // If timestamps are already set, ensure we only query for newer content.
+    // (This avoids having to unnecessarily load entities).
+    if (!empty($published_at_timestamps)) {
+      $query->condition('published_at', min($published_at_timestamps), '>');
+    }
+    $query->sort('published_at', 'DESC');
+    $query->range(0, $size);
+    $result = $this->executeQueryInRenderContext($query);
+    $nodes = Node::loadMultiple($result);
+    foreach ($nodes as $node) {
+      $entities[] = $node;
+      $published_at_timestamps[] = $node->get('published_at')->value;
+    }
+  }
+
+  /**
+   * Executes the query in a render context.
+   *
+   * This avoids a fatal error, as running entity queries at this stage causes
+   * Drupal to break.
+   * @see \Drupal\jsonapi\Controller\EntityResource::executeQueryInRenderContext()
+   * @todo Remove this after https://www.drupal.org/project/drupal/issues/3028976 is fixed.
+   *
+   * @param \Drupal\Core\Entity\Query\QueryInterface $query
+   *   The query to execute to get the return results.
+   *
+   * @return int|array
+   *   Returns the result of the query.
+   */
+  protected function executeQueryInRenderContext(QueryInterface $query) {
+    $context = new RenderContext();
+    $results = \Drupal::service('renderer')->executeInRenderContext($context, function () use ($query) {
+      return $query->execute();
+    });
+    return $results;
+  }
+
+  /**
+   * Get pagination for the request.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Drupal\jsonapi\Query\OffsetPage
+   *   The pagination object.
+   */
+  private function getPagination(Request $request): OffsetPage {
+    return $request->query->has('page')
+      ? OffsetPage::createFromQueryParameter($request->query->get('page'))
+      : new OffsetPage(OffsetPage::DEFAULT_OFFSET, OffsetPage::SIZE_MAX);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * This tells jsonapi_resources module that our resource works only works with
+   * certain content types and series taxonomy terms.
+   */
+  public function getRouteResourceTypes(Route $route, string $route_name): array {
+    return array_filter($this->resourceTypeRepository->all(), function (ResourceType $type) {
+      return $type->getEntityTypeId() == 'node' && in_array($type->getBundle(), self::$content_types) ||
+        $type->getEntityTypeId() == 'taxonomy_term' && $type->getBundle() == 'series';
+    });
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -140,7 +140,7 @@ class RecentlyAdded extends EntityResourceBase {
   }
 
   /**
-   * Load content entities that are no in a series.
+   * Load content entities that are not in a series.
    *
    * @param array $entities
    *   The array of content entities, passed in by reference, to be appended to.

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -50,7 +50,7 @@ class RecentlyAdded extends EntityResourceBase {
     $cacheability->addCacheContexts(['url.path']);
 
     // This is a custom cache tag that is invalidated in prisoner_hub_recently_added_node_update().
-    $cache_tag = 'prisoner_hub:homepage:recently_added';
+    $cache_tag = 'prisoner_hub_recently_added';
     $prison = \Drupal::routeMatch()->getParameter('prison');
     if ($prison) {
       $cache_tag .= ':' . $prison->get('machine_name')->getString();

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -95,8 +95,7 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
     // Ensure we get a cache HIT on the second time we make a request.
     $response = $this->request('GET', $this->jsonApiUrl, $request_options);
     $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'HIT');
-    print_r($response->getHeaders());
-    $this->assertStringContainsString('prisoner_hub_recently_added', $response->getHeader('X-Drupal-Cache-Tags')[0]);
+
     $new_entity = $this->createNode([
       'field_not_in_series' => 1,
       'published_at' => strtotime('+1 second'),

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -95,6 +95,7 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
     // Ensure we get a cache HIT on the second time we make a request.
     $response = $this->request('GET', $this->jsonApiUrl, $request_options);
     $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'HIT');
+    print_r($response->getHeaders());
     $this->assertStringContainsString('prisoner_hub_recently_added', $response->getHeader('X-Drupal-Cache-Tags')[0]);
     $new_entity = $this->createNode([
       'field_not_in_series' => 1,

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -94,6 +94,7 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
     // Ensure we get a cache HIT on the second time we make a request.
     $response = $this->request('GET', $this->jsonApiUrl, $request_options);
     $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'HIT');
+    $this->assertStringContainsString('prisoner_hub_recently_added', $response->getHeader('X-Drupal-Cache-Tags')[0]);
     $new_entity = $this->createNode([
       'field_not_in_series' => 1,
       'published_at' => strtotime('+1 second'),

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -46,26 +46,27 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
 
     $vocab_series = Vocabulary::load('series');
 
+    $current_time = time();
     $first_entity = $this->createNode([
       'field_not_in_series' => 1,
-      'published_at' => time(),
+      'published_at' => $current_time,
     ]);
 
     $third_entity = $this->createTerm($vocab_series);
     $this->createNode([
       'field_moj_series' => [['target_id' => $third_entity->id()]],
-      'published_at' => strtotime('-5 seconds'),
+      'published_at' => strtotime('-5 seconds', $current_time),
     ]);
 
     $second_entity = $this->createTerm($vocab_series);
     $this->createNode([
       'field_moj_series' => [['target_id' => $second_entity->id()]],
-      'published_at' => strtotime('-1 second'),
+      'published_at' => strtotime('-1 second', $current_time),
     ]);
 
     $fourth_entity = $this->createNode([
       'field_not_in_series' => 1,
-      'published_at' => strtotime('-7 seconds'),
+      'published_at' => strtotime('-7 seconds', $current_time),
     ]);
 
     $this->correctOrderUuids = [

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\Tests\prisoner_hub_recently_added\ExistingSite;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Url;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use GuzzleHttp\RequestOptions;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Test the the recently added JSON:API resource works correctly
+ *
+ * @group prisoner_hub_recently_added
+ */
+class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
+
+  use JsonApiRequestTestTrait;
+  use NodeCreationTrait;
+  use TaxonomyCreationTrait;
+
+  /**
+   * The jsonapi url to run tests on.
+   *
+   * @var \Drupal\Core\Url
+   */
+  protected $jsonApiUrl;
+
+  /**
+   * An array of uuids in the correct oder.
+   *
+   * @var array
+   */
+  protected $correctOrderUuids;
+
+  /**
+   * Set up content and taxonomy terms to test with.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->jsonApiUrl = Url::fromUri('internal:/jsonapi/recently-added', ['query' => ['page[limit]' => 4]]);
+
+    $vocab_series = Vocabulary::load('series');
+
+    $first_entity = $this->createNode([
+      'field_not_in_series' => 1,
+      'published_at' => time(),
+    ]);
+
+    $third_entity = $this->createTerm($vocab_series);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $third_entity->id()]],
+      'published_at' => strtotime('-5 seconds'),
+    ]);
+
+    $second_entity = $this->createTerm($vocab_series);
+    $this->createNode([
+      'field_moj_series' => [['target_id' => $second_entity->id()]],
+      'published_at' => strtotime('-1 second'),
+    ]);
+
+    $fourth_entity = $this->createNode([
+      'field_not_in_series' => 1,
+      'published_at' => strtotime('-7 seconds'),
+    ]);
+
+    $this->correctOrderUuids = [
+      $first_entity->uuid(),
+      $second_entity->uuid(),
+      $third_entity->uuid(),
+      $fourth_entity->uuid(),
+    ];
+  }
+
+  /**
+   * Test the resource returns the correct entities, in the correct order.
+   */
+  public function testRecentlyAddedCorrectSorting() {
+    $this->assertJsonResponse($this->correctOrderUuids);
+  }
+
+  /**
+   * Test that new content is immediately updated on the resource.
+   */
+  public function testRecentlyAddedCacheClear() {
+    $request_options = [];
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    $this->request('GET', $this->jsonApiUrl, $request_options);
+
+    // Ensure we get a cache HIT on the second time we make a request.
+    $response = $this->request('GET', $this->jsonApiUrl, $request_options);
+    $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'HIT');
+    $new_entity = $this->createNode([
+      'field_not_in_series' => 1,
+      'published_at' => strtotime('+1 second'),
+    ]);
+    $this->correctOrderUuids = array_merge([$new_entity->uuid()], array_slice($this->correctOrderUuids, 0, 3));
+    $this->assertJsonResponse($this->correctOrderUuids);
+  }
+
+  /**
+   * Asserts the jsonapi response.
+   *
+   * @param array $correct_order_uuids
+   *   An array of uuids, in the correct order, to check for.
+   */
+  protected function assertJsonResponse(array $correct_order_uuids) {
+    $request_options = [];
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    $response = $this->request('GET', $this->jsonApiUrl, $request_options);
+    $this->assertSame(200, $response->getStatusCode());
+    $response_document = Json::decode((string) $response->getBody());
+    foreach ($response_document['data'] as $item) {
+      $this->assertEquals($correct_order_uuids, array_map(static function (array $data) {
+        return $data['id'];
+      }, $response_document['data']));
+    }
+  }
+}

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -361,3 +361,12 @@ function prisoner_content_hub_profile_deploy_copy_secondary_tag_field_data() {
   \Drupal::database()->query('INSERT INTO node__field_topics SELECT * FROM node__field_moj_secondary_tags');
   \Drupal::database()->query('INSERT INTO node_revision__field_topics SELECT * FROM node_revision__field_moj_secondary_tags');
 }
+
+/**
+ * Copy over field data for taxonomy image field.
+ */
+function prisoner_content_hub_profile_deploy_copy_thumbnail_image_field_data() {
+  // Do this with a direct db query so we don't need to update 3k+ items of
+  // content (resulting in a large cache flush).
+  \Drupal::database()->query('INSERT INTO taxonomy_term__field_moj_thumbnail_image SELECT * FROM taxonomy_term__field_featured_image');
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/LjGu2N1C/920-allow-users-to-see-all-recently-added-content-on-the-homepage

### Intent

Adds a new custom jsonapi resource:
`/jsonapi/recently-added`.

This displays the most recently published content.
If content is in a series, it displays the series instead (and removes duplicates of the same series).
If content is not in a series, it displays the content.

Note this resource doesn't fully support pagination.  However, it does support a limit, so you should use it like:
`/jsonapi/prison/wayland/recently-added?page[limit]=4`

### Considerations

The `field_featured_image` on taxonomy terms has been renamed to `field_moj_thumbnail_image`.
This will allow us to add this as an include to the resource, i.e.
`/jsonapi/prison/wayland/recently-added?page[limit]=4&include=field_moj_thumbnail_image`

Otherwise if the field isn't present on both nodes and taxonomy terms you get an error.

This means that all references to `field_featured_image in the f/e code will need to be updated.  When this PR is deployed the old field will still exist (and should be removed in a separate PR).  But any new updates to an image on a taxonomy term will go to the new field.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
