### PR TITLE
Update/remove incorrect taxonomy data in the db.

### DIFF
--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.install
@@ -320,3 +320,49 @@ function prisoner_content_hub_profile_update_8021(&$sandbox) {
   $definition = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node')['published_at'];
   \Drupal::service('field_storage_definition.listener')->onFieldStorageDefinitionCreate($definition);
 }
+
+/**
+ * Delete old "left-over" tables.
+ *
+ * These db tables have not been used for a long time.  Someone previously must
+ * have either manually created them (i.e. the "old_*" tables), or deleted a
+ * field directly in the db.
+ */
+function prisoner_content_hub_profile_update_8022() {
+  \Drupal::database()->delete('old_453ca8taxonomy_term__0c5d518a58');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__4b0f937144');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__6be009d48c');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_content_summary');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_featured_audio');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_featured_image');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_featured_video');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_moj_promoted');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__field_promoted_feature');
+  \Drupal::database()->delete('old_453ca8taxonomy_term__parent');
+  \Drupal::database()->delete('old_453ca8taxonomy_term_data');
+  \Drupal::database()->delete('old_453ca8taxonomy_term_field_data');
+  \Drupal::database()->delete('taxonomy_term__field_channel_landing_page_video');
+  \Drupal::database()->delete('taxonomy_term__field_info');
+  \Drupal::database()->delete('taxonomy_term__field_landing_page_exists');
+  \Drupal::database()->delete('taxonomy_term__field_moj_back_link_url');
+  \Drupal::database()->delete('taxonomy_term__field_moj_left_tab_text');
+  \Drupal::database()->delete('taxonomy_term__field_moj_pdf_additional_desc');
+  \Drupal::database()->delete('taxonomy_term__field_moj_pdf_cat_description');
+  \Drupal::database()->delete('taxonomy_term__field_moj_right_tab_text');
+  \Drupal::database()->delete('taxonomy_term__field_pdf_category_banner');
+  \Drupal::database()->delete('taxonomy_term__field_radio_category_banner');
+  \Drupal::database()->delete('taxonomy_term__field_radio_category_profile');
+  \Drupal::database()->delete('taxonomy_term__field_video_channel_thumbnail');
+}
+
+/**
+ * Update bundle column on secondary tags fields, to ensure no data loss when switching to topics.
+ */
+function prisoner_content_hub_profile_update_8023() {
+  \Drupal::database()->query("UPDATE taxonomy_term__field_prisons SET bundle = 'topics' WHERE bundle = 'tags'");
+  \Drupal::database()->query("UPDATE taxonomy_term_revision__field_prisons SET bundle = 'topics' WHERE bundle = 'tags'");
+  \Drupal::database()->query("UPDATE taxonomy_term__field_exclude_feedback SET bundle = 'topics' WHERE bundle = 'tags'");
+  \Drupal::database()->query("UPDATE taxonomy_term_revision__field_exclude_feedback SET bundle = 'topics' WHERE bundle = 'tags'");
+  \Drupal::database()->query("UPDATE taxonomy_term__field_featured_image SET bundle = 'topics' WHERE bundle = 'tags'");
+  \Drupal::database()->query("UPDATE taxonomy_term_revision__field_featured_image SET bundle = 'topics' WHERE bundle = 'tags'");
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Currently the main branch has https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/395 ready to be released.  However this is leading to data loss due to incorrect data in the db.

### Intent

A previously deployed update set all secondary tags as topics:
https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/379/files#diff-b37e71fa6362842ef896c7076b00111f0965002dbcd125b843347f84d92e030bR346-R351

Although this worked, it did not update some of the field data in the db, to mark it with the new taxonomy type.
This incorrect db data was not causing any issues, however by removing the secondary tags taxonomy completely, it meant Drupal "tidied up" it's data, and cleared out the field data.

This PR updates the field data by running some manual db queries.
It also cleans up a load of unused db data, that's been leftover from a previous iteration of the Hub.  Lots of db tables that are not being used.  Makes sense to clean everything up in one go.

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
