### PR TITLE
Fix mariadb not working on circleci

### DIFF
--- a/docker-compose.circleci.yml
+++ b/docker-compose.circleci.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   prisoner-content-hub-backend-db:
-    image: mariadb
+    image: mariadb:10.4
     env_file:
       - prisoner-content-hub-backend-db.circleci.env
     ports:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

Fixes issue with mariadb not working, resulting in test runner not being able to run on other PRs.

The solution was to fix to a version of mariadb, the same version as used on prod.

This was the error from the latest version:
```
circleci@0b2e180760bc:~/workspace$ docker-compose -f docker-compose.circleci.yml logs prisoner-content-hub-backend-db
Attaching to workspace_prisoner-content-hub-backend-db_1
prisoner-content-hub-backend-db_1     | 2022-05-25 10:01:16+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.8.3+maria~jammy started.
prisoner-content-hub-backend-db_1     | 2022-05-25 10:01:16+00:00 [ERROR] [Entrypoint]: mariadbd failed while attempting to check config
prisoner-content-hub-backend-db_1     | 	command was: mariadbd --verbose --help --log-bin-index=/tmp/tmp.SST7sObzJU
prisoner-content-hub-backend-db_1     | 	Can't initialize timers
```

### Considerations

We should also do fix version on local environment.
### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
