### PR TITLE
Bugfix/sub terms cache not clearing

### DIFF
--- a/docroot/modules/custom/prisoner_hub_sub_terms/README.md
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/README.md
@@ -9,9 +9,24 @@ Note that the above url will work with a prison context.  E.g.
 `/jsonapi/prison/{prison name}}/taxonomy_term/moj_categories/{uuid}/sub_terms`
 
 The results will be a paginated list of series and sub-categories.
-- Any sub category of the {uuid} (including multiple levels, so sub-sub-sub-categories will also work)
-- Any series assigned to either the {uuid} category, or any of it's sub-categories (again on multiple levels).
+- Any sub category of the {uuid} (only direct sub-categories are included, not further levels)
+- Any series assigned to the {uuid} category (series assigned to sub-categories are not included).
 
 The results will be ordered by the most recently updated content within each sub term.
-Note that if using a prison context, this again will be applied to the results.
-So only content available in the current prison will be used for sorting.
+When checking for the most recently updated content, we look at all levels of the taxonomy.  So changes to content that
+is in a sub-category multiple levels down, will affect the sorting order of it's parent sub-category.
+
+Note that if using a prison context, this again will be applied to the results.  So only content available in the
+current prison will be used for sorting.
+
+## Custom cachetags
+This module uses custom cachetags to invalidate the response when content has been updated or created.
+The cachetag looks like:
+`'prisoner_hub_sub_terms:123`
+(Where 123 is the taxonomy term id of the category).
+
+When content is updated or created, the cachetags for it's associated category and parent categories will be invalidated.
+
+The reason for using a custom cachetag instead of the `taxonomy_term:123` tag that comes with Drupal, is that clearing
+the more generic Drupal cachetag will affect multiple parts of the site, whereas our custom cachetag can be specific
+to sub_terms JSON:API resource.

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Primary hook implementations for Prisoner hub sub terms module.
+ */
+
+/**
+ * Implements hook_entity_update().
+ */
+function prisoner_hub_sub_terms_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
+  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity, FALSE);
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function prisoner_hub_sub_terms_entity_insert(\Drupal\Core\Entity\EntityInterface $entity) {
+  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity, TRUE);
+}

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.services.yml
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.services.yml
@@ -1,0 +1,4 @@
+services:
+  prisoner_hub_sub_terms.cachetag_invalidator:
+    class: Drupal\prisoner_hub_sub_terms\SubTermsCacheTagInvalidator
+    arguments: ['@cache_tags.invalidator', '@entity_type.manager']

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -49,6 +49,12 @@ class SubTerms extends EntityResourceBase {
     $cacheability = new CacheableMetadata();
     $cacheability->addCacheContexts(['url.path']);
 
+    // Add the current term (i.e parent category) as a cache dependency.
+    // As this term won't be loaded in the response, so it won't get
+    // automatically added.
+    // Without this, new categories will not automatically appear in the
+    // response.
+    $cacheability->addCacheableDependency($taxonomy_term);
     $tids = [$taxonomy_term->id()];
 
     // Check content also assigned to any sub-category (multiple levels) of the

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -4,13 +4,11 @@ namespace Drupal\prisoner_hub_sub_terms\Resource;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\Query\QueryInterface;
-use Drupal\Core\Entity\RevisionableStorageInterface;
 use Drupal\Core\Http\Exception\CacheableBadRequestHttpException;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Url;
 use Drupal\jsonapi\JsonApiResource\Link;
 use Drupal\jsonapi\JsonApiResource\LinkCollection;
-use Drupal\jsonapi\JsonApiResource\ResourceObjectData;
 use Drupal\jsonapi\Query\OffsetPage;
 use Drupal\jsonapi\ResourceResponse;
 use Drupal\jsonapi_resources\Resource\EntityResourceBase;
@@ -19,7 +17,6 @@ use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
-
 
 /**
  * Processes a request for sub terms.
@@ -49,12 +46,9 @@ class SubTerms extends EntityResourceBase {
     $cacheability = new CacheableMetadata();
     $cacheability->addCacheContexts(['url.path']);
 
-    // Add the current term (i.e parent category) as a cache dependency.
-    // As this term won't be loaded in the response, so it won't get
-    // automatically added.
-    // Without this, new categories will not automatically appear in the
-    // response.
-    $cacheability->addCacheableDependency($taxonomy_term);
+    // Add our own custom cache tag that is cleared whenever content is updated.
+    $cacheability->addCacheTags(['prisoner_hub_sub_terms:' . $taxonomy_term->id()]);
+
     $tids = [$taxonomy_term->id()];
 
     // Check content also assigned to any sub-category (multiple levels) of the

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\prisoner_hub_sub_terms;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+class SubTermsCacheTagInvalidator {
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * SubTermsCacheTagInvalidator constructor.
+   *
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tag_invalidator
+   *   The cache tag invalidator service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(CacheTagsInvalidatorInterface $cache_tag_invalidator, EntityTypeManagerInterface $entity_type_manager) {
+    $this->cacheTagsInvalidator = $cache_tag_invalidator;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Invalidate appropriate cachetag(s) based on $entity.
+   *
+   * @param $entity
+   *   The $entity being inserted or updated.
+   * @param bool $insert
+   *  TRUE if $entity is being inserted, otherwise FALSE.
+   */
+  public function invalidate($entity, bool $insert) {
+    if ($entity instanceof NodeInterface) {
+      $this->invalidateNode($entity, $insert);
+    }
+    if ($entity instanceof TermInterface) {
+      $this->invalidateTaxonomyTerm($entity, $insert);
+    }
+  }
+
+  /**
+   * Check whether the $entity is published.
+   *
+   * If the $entity is being updated, then we check whether either the previous
+   * version was published, _or_ the current version.
+   *
+   * @param \Drupal\Core\Entity\EntityPublishedInterface $entity
+   *   The $entity to check.
+   * @param bool $insert
+   *   TRUE if $entity is being inserted, otherwise FALSE.
+   *
+   * @return bool
+   *   TRUE if $entity is published, otherwise FALSE.
+   */
+  protected function checkEntityIsPublished(EntityPublishedInterface $entity, bool $insert) {
+    // Ignore if we are inserting an unpublished entity.
+    if ($insert && !$entity->isPublished()) {
+      return FALSE;
+    }
+    // Ignore if we are updating an unpublished entity.
+    if (isset($entity->original) && ($entity->original->isPublished() || $entity->isPublished())) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Invalidate cachetags based on node updates/inserts.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The node $entity.
+   * @param bool $insert
+   *   TRUE if $entity is being inserted, otherwise FALSE.
+   */
+  protected function invalidateNode(NodeInterface $entity, bool $insert) {
+    if (!$this->checkEntityIsPublished($entity, $insert)) {
+      return;
+    }
+    $category_id = NULL;
+    if ($entity->hasField('field_moj_top_level_categories') && !$entity->get('field_moj_top_level_categories')->isEmpty()) {
+      $category_id = $entity->get('field_moj_top_level_categories')->target_id;
+    }
+    if ($entity->hasField('field_moj_series') && !$entity->get('field_moj_series')->isEmpty()) {
+      $series_entities = $entity->get('field_moj_series')->referencedEntities();
+      if (!empty($series_entities)) {
+        $category_id = $series_entities[0]->get('field_category')->target_id;
+      }
+    }
+    if ($category_id) {
+      $this->invalidateCategoryAndParents($category_id);
+    }
+  }
+
+  /**
+   * Invalidate cachetags based on taxonomy term updates/inserts.
+   *
+   * @param \Drupal\taxonomy\TermInterface $entity
+   *   The taxonomy terms $entity.
+   * @param bool $insert
+   *   TRUE if $entity is being inserted, otherwise FALSE.
+   */
+  protected function invalidateTaxonomyTerm(TermInterface $entity, bool $insert) {
+    if (!$this->checkEntityIsPublished($entity, $insert)) {
+      return;
+    }
+    $category_id = NULL;
+    if ($entity->bundle() == 'series') {
+      $category_id = $entity->get('field_category')->target_id;
+    }
+    if ($entity->bundle() == 'moj_categories') {
+      if ($insert) {
+        // If this is a new category, then it wont have a cache entry yet.
+        // So just clear it's parents.
+        $category_id = $entity->get('parent')->target_id;
+      }
+      else {
+        $category_id = $entity->id();
+      }
+    }
+    if ($category_id) {
+      $this->invalidateCategoryAndParents($category_id);
+    }
+  }
+
+  /**
+   * Invalidate cachetags for category id, and all parents of that category.
+   *
+   * @param int $category_id
+   *   The taxonomy term id for the category.
+   */
+  protected function invalidateCategoryAndParents(int $category_id) {
+    $tags = ['prisoner_hub_sub_terms:' . $category_id];
+
+    $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category_id);
+    foreach ($terms as $term) {
+      // Exclude the current category id, which is also returned by
+      // loadAllParents(), as this has already been added.
+      if ($term->id() != $category_id) {
+        $tags[] =  'prisoner_hub_sub_terms:' . $term->id();
+      }
+    }
+    $this->cacheTagsInvalidator->invalidateTags($tags);
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
@@ -57,8 +57,8 @@ class SubTermsCacheTagInvalidator {
   /**
    * Check whether the $entity is published.
    *
-   * If the $entity is being updated, then we check whether either the previous
-   * version was published, _or_ the current version.
+   * If the $entity is being updated, then we check both the previous and
+   * current versions (if one of those is published then we return TRUE).
    *
    * @param \Drupal\Core\Entity\EntityPublishedInterface $entity
    *   The $entity to check.
@@ -66,7 +66,8 @@ class SubTermsCacheTagInvalidator {
    *   TRUE if $entity is being inserted, otherwise FALSE.
    *
    * @return bool
-   *   TRUE if $entity is published, otherwise FALSE.
+   *   TRUE if $entity (either current or previous version) is published,
+   *   otherwise FALSE.
    */
   protected function checkEntityIsPublished(EntityPublishedInterface $entity, bool $insert) {
     // Ignore if we are inserting an unpublished entity.
@@ -74,7 +75,7 @@ class SubTermsCacheTagInvalidator {
       return FALSE;
     }
     // Ignore if we are updating an unpublished entity.
-    if (isset($entity->original) && ($entity->original->isPublished() || $entity->isPublished())) {
+    if (isset($entity->original) && !$entity->original->isPublished() && !$entity->isPublished()) {
       return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Ar0dte1r/820-change-sorting-of-subcats-series-to-show-relevant-order-in-specific-prisons

### Intent

A bug that has been occurring with the new sub terms resource, is that new series/sub-categories are not immediately appearing.

This PR fixes the issue by implementing custom cachetags, to invalidate responses when content is updated.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
