### PR TITLE
Ensure homepage content does not appear on the content listing page.

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.node.field_topics
     - node.type.featured_articles
     - node.type.help_page
+    - node.type.homepage
     - node.type.link
     - node.type.moj_pdf_item
     - node.type.moj_radio_item
@@ -1440,6 +1441,48 @@ display:
           hierarchy: true
           limit: true
           error_message: true
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: 'not in'
+          value:
+            homepage: homepage
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/lnMF9FXd/925-create-new-homepage-content-type-in-drupal

### Intent
The previous PR https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/402 added the new homepage content type, and restricted it as a filter on the /admin/content page (so that DCM's are not shown the new type as it could be confusing).  However, homepage nodes were still being shown as they were not properly filtered out.  This PR fixes that.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
