### PR TITLE
Feature/readonly mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,5 @@
-build-deps:
-	composer clear-cache
-	composer install --no-dev --no-ansi --no-scripts --prefer-dist --ignore-platform-reqs --no-interaction --no-autoloader
-
 build:
 	docker build -t prisoner-content-hub-backend .
-
-clean:
-	rm -rf modules/contrib
 
 push:
 	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
@@ -28,3 +21,13 @@ run-tests:
 	vendor/bin/phpunit --testsuite=existing-site --log-junit ~/phpunit/junit-existing-site.xml --verbose
 	echo "Running Javascript tests on existing site"
 	vendor/bin/phpunit --testsuite=existing-site-javascript --log-junit ~/phpunit/junit-existing-site-javascript.xml --verbose
+
+deploy:
+  echo "Enabling maintenance and readonly mode"
+  drush state-set readonlymode_active 1
+  drush state-set system.maintenance_mode 1
+  echo "Running deploy commands"
+  drush deploy
+  echo "Disabling maintenance and readonly mode"
+  drush state-set readonlymode_active 0
+  drush state-set system.maintenance_mode 0

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ run-tests:
 	vendor/bin/phpunit --testsuite=existing-site-javascript --log-junit ~/phpunit/junit-existing-site-javascript.xml --verbose
 
 deploy:
-  echo "Enabling maintenance and readonly mode"
-  drush state-set readonlymode_active 1
-  drush state-set system.maintenance_mode 1
-  echo "Running deploy commands"
-  drush deploy
-  echo "Disabling maintenance and readonly mode"
-  drush state-set readonlymode_active 0
-  drush state-set system.maintenance_mode 0
+	echo "Enabling maintenance and readonly mode"
+	drush state-set readonlymode_active 1
+	drush state-set system.maintenance_mode 1
+	echo "Running deploy commands"
+	drush deploy
+	echo "Disabling maintenance and readonly mode"
+	drush state-set readonlymode_active 0
+	drush state-set system.maintenance_mode 0

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "drupal/profile_switcher": "1.0-alpha5",
         "drupal/publication_date": "^2.0@beta",
         "drupal/raven": "^3.2",
+        "drupal/readonlymode": "2.0.x-dev",
         "drupal/redis": "^1.5",
         "drupal/rest_menu_items": "^2.6",
         "drupal/restui": "^1.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2ada5020cf9978f21465d3aff079ce6",
+    "content-hash": "d9129e240084aef52c703018ddef11f1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4433,6 +4433,75 @@
                     "url": "https://www.patreon.com/mfb"
                 }
             ]
+        },
+        {
+            "name": "drupal/readonlymode",
+            "version": "dev-2.0.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/readonlymode.git",
+                "reference": "45d9e9e6293cbe9d12642861cdb515e7236a0a28"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "conflict": {
+                "drush/drush": "<10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0.x": "2.0.x-dev"
+                },
+                "drupal": {
+                    "version": "2.0.x-dev",
+                    "datestamp": "1616593505",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Sharique Farooqui",
+                    "homepage": "https://www.drupal.org/u/sharique",
+                    "email": "safknw@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "email": "opensource@fabianbircher.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "bircher",
+                    "homepage": "https://www.drupal.org/user/1344166"
+                },
+                {
+                    "name": "petew",
+                    "homepage": "https://www.drupal.org/user/1009366"
+                }
+            ],
+            "description": "Read Only Mode provides an alternate to the built in Maintenance Mode in Drupal.",
+            "homepage": "https://www.drupal.org/project/readonlymode",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/readonlymode",
+                "issues": "https://www.drupal.org/project/issues/readonlymode"
+            }
         },
         {
             "name": "drupal/redis",
@@ -17665,6 +17734,7 @@
         "drupal/jsonapi_search_api": 5,
         "drupal/maintenance_exempt": 20,
         "drupal/publication_date": 10,
+        "drupal/readonlymode": 20,
         "drupal/taxonomy_machine_name": 20,
         "drupal/views_entity_form_field": 10
     },

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -75,6 +75,7 @@ module:
   prisoner_hub_taxonomy_sorting: 0
   raven: 0
   rdf: 0
+  readonlymode: 0
   redis: 0
   role_delegation: 0
   scheduler: 0

--- a/config/sync/readonlymode.settings.yml
+++ b/config/sync/readonlymode.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: hqSQdVJi4YZZ3d8diPQZeEhGvCoFqQuvDwL0LpOC4uI
+messages:
+  default: 'During this maintenance it is not possible to change site content.  The maintenance should take no longer than 10 mins.  Please look out for announcements on Microsoft Teams should there be any further issues.'
+  not_saved: 'Changes not saved. Please wait until after the current maintenance has completed and try again.'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -8,6 +8,7 @@ dependencies:
     - autocomplete_id
     - filter
     - flysystem_s3
+    - readonlymode
     - shortcut
     - system
 _core:
@@ -19,6 +20,7 @@ is_admin: false
 permissions:
   - 'access content'
   - 'access shortcuts'
+  - 'see readonlymode warning'
   - 'use S3 CORS upload'
   - 'use text format basic_html'
   - 'view entity autocomplete id results'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -37,6 +37,7 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access content overview'
+  - 'access site in maintenance mode'
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'add content to books'

--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -14,6 +14,7 @@ dependencies:
     - node
     - raven
     - scheduler
+    - system
     - toolbar
     - view_unpublished
 id: moj_local_content_manager
@@ -22,6 +23,7 @@ weight: -8
 is_admin: null
 permissions:
   - 'access content overview'
+  - 'access site in maintenance mode'
   - 'access toolbar'
   - 'administer nodes'
   - 'create moj_pdf_item content'

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
@@ -22,7 +22,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["drush", "deploy"]
+          command: ["make", "deploy"]
 {{ include "drupal-deployment.envs" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/wqt78xna/1008-allow-dcms-and-studio-admins-to-continue-using-drupal-during-deployments

### Intent

This PR adds a new module `readonlymode`, which, when enabled, ensures no content can be updated.
By using this new mode, we can allow DCMs and studio admins access to the site when in maintenance mode (i.e. during deployments).  As the reason Drupal is placed in maintenance mode is that updates to the database could be taking place, so any content saved during this time can cause issues.

The deployment is updated to explicitly enable both maintenance mode and readonly mode before the deployment starts, and disabled once it has finished (previously Drupal would enable maintenance mode automatically, but we want to ensure it's enabled at the same time as readonly mode, so we do it ourselves).

### Considerations

Version 2.x of the readonlymode module is being used, as version 1 had a method of hiding the entire content edit form.  Whereas with version 2 you can still see and edit the form, but get a validation error when saving.

Below are the messages displayed when the site is in a deployment:
<img width="1746" alt="Screenshot 2022-06-06 at 13 22 13" src="https://user-images.githubusercontent.com/436483/172192463-7c0818f0-2b27-4479-8336-591e2aa84329.png">

When attempting to save content:
<img width="1708" alt="Screenshot 2022-06-06 at 16 24 39" src="https://user-images.githubusercontent.com/436483/172192553-c99014f4-ac75-4cc0-bf52-1d01d0835794.png">

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
