### PR TITLE
Enable readonly on deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ COPY docroot/profiles docroot/profiles
 COPY ./apache/ /etc/apache2/
 COPY docroot/sites/ docroot/sites/
 COPY config/ config/
+COPY Makefile Makefile
 
 # Remove write permissions for added security
 RUN chmod u-w docroot/sites/default/settings.php \

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-post-install-hook.yaml
@@ -22,7 +22,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["drush", "deploy"]
+          command: ["make", "deploy"]
 {{ include "drupal-deployment.envs" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/wqt78xna/1008-allow-dcms-and-studio-admins-to-continue-using-drupal-during-deployments

### Intent

The previous PR https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/410 added in this functionality, this PR enables the deployment.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
