### PR TITLE
Improve homepage fields

### DIFF
--- a/config/sync/core.entity_form_display.node.homepage.default.yml
+++ b/config/sync/core.entity_form_display.node.homepage.default.yml
@@ -27,7 +27,7 @@ third_party_settings:
       label: 'Where would you like this content to appear?'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 8
       format_type: fieldset
       format_settings:
         classes: ''
@@ -66,18 +66,31 @@ third_party_settings:
     group_updates_section:
       children:
         - field_large_update_tile
-        - field_featured_update
         - field_key_info_tiles
-      label: 'Updates section'
+      label: 'Row 1 - Updates'
       region: content
       parent_name: ''
       weight: 2
-      format_type: details
+      format_type: fieldset
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
+        description: ''
+        required_fields: true
         open: true
+    group_featured_tiles:
+      children:
+        - field_featured_tiles
+      label: 'Row 2 - Featured'
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
         description: ''
         required_fields: true
 id: node.homepage.default
@@ -87,7 +100,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -110,7 +123,7 @@ content:
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 40
+      size: 36
       placeholder: ''
     third_party_settings: {  }
   field_key_info_tiles:
@@ -120,7 +133,7 @@ content:
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 40
+      size: 35
       placeholder: ''
     third_party_settings: {  }
   field_large_update_tile:
@@ -157,19 +170,19 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -180,7 +193,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -195,7 +208,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -205,7 +218,7 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/field.field.node.homepage.field_featured_tiles.yml
+++ b/config/sync/field.field.node.homepage.field_featured_tiles.yml
@@ -20,7 +20,7 @@ field_name: field_featured_tiles
 entity_type: node
 bundle: homepage
 label: 'Featured tiles'
-description: 'Feature either content, series, categories or topics as a tile on the homepage.'
+description: 'Feature either content, series, subcategories or topics as a tile on the homepage.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.homepage.field_key_info_tiles.yml
+++ b/config/sync/field.field.node.homepage.field_key_info_tiles.yml
@@ -11,7 +11,6 @@ dependencies:
     - node.type.page
     - taxonomy.vocabulary.moj_categories
     - taxonomy.vocabulary.series
-    - taxonomy.vocabulary.topics
   module:
     - dynamic_entity_reference
 id: node.homepage.field_key_info_tiles
@@ -19,7 +18,7 @@ field_name: field_key_info_tiles
 entity_type: node
 bundle: homepage
 label: 'Key info tiles'
-description: 'Select upto 4 tiles to appear on the right-hand side of the <strong>Updates</strong> section.'
+description: "<strong>When to use?</strong><br>\r\nUse these tiles for key information about your prison that is frequently asked for - eg TV Guide, Facilities and Catalogues, Laptop guide, Guide to Prison."
 required: false
 translatable: false
 default_value: {  }
@@ -44,7 +43,6 @@ settings:
       target_bundles:
         moj_categories: moj_categories
         series: series
-        topics: topics
       sort:
         field: name
         direction: asc

--- a/config/sync/field.field.node.homepage.field_large_update_tile.yml
+++ b/config/sync/field.field.node.homepage.field_large_update_tile.yml
@@ -15,7 +15,7 @@ field_name: field_large_update_tile
 entity_type: node
 bundle: homepage
 label: 'Large update tile'
-description: '<a href="/content/10221" target="_blank">How does this work?</a>'
+description: "<strong>When to use?</strong><br>\r\nUse this tile to highlight the most important newsworthy information of the day/week for your prison"
 required: false
 translatable: false
 default_value: {  }

--- a/docroot/modules/custom/prisoner_hub_cms_help/prisoner_hub_cms_help.module
+++ b/docroot/modules/custom/prisoner_hub_cms_help/prisoner_hub_cms_help.module
@@ -63,3 +63,32 @@ function prisoner_hub_cms_help_preprocess_page_title(&$vars) {
     $vars['title'] = new HtmlEscapedText('');
   }
 }
+
+/**
+ * Implements hook_preprocess_form_element().
+ *
+ * Set help page links for single value form elements.  These are rendered via
+ * the theme.
+ * @see prisconhub_preprocess_form_element().
+ */
+function prisoner_hub_cms_help_preprocess_form_element(&$variables) {
+  if ($variables['element']['#name'] == 'field_large_update_tile[0][target_id]') {
+    $variables['#help_page_url'] = Url::fromUserInput('/content/16897', ['fragment' => 'large-update-tile']);
+  }
+}
+
+/**
+ * Implements hook_preprocess_field_multiple_value_form().
+ *
+ * Set help page links for multiple value form elements.  These are rendered via
+ * the theme.
+ * @see prisconhub_preprocess_field_multiple_value_form().
+ */
+function prisoner_hub_cms_help_preprocess_field_multiple_value_form(&$variables) {
+  if ($variables['element']['#field_name'] == 'field_key_info_tiles') {
+    $variables['#help_page_url'] = Url::fromUserInput('/content/16897', ['fragment' => 'key-info-tiles']);
+  }
+  if ($variables['element']['#field_name'] == 'field_featured_tiles') {
+    $variables['#help_page_url'] = Url::fromUserInput('/content/16897', ['fragment' => 'featured-tiles']);
+  }
+}

--- a/docroot/themes/custom/prisconhub/css/styles.css
+++ b/docroot/themes/custom/prisconhub/css/styles.css
@@ -64,3 +64,16 @@ a[href="/admin/help"].toolbar-icon:before {
 .field-group-fieldset .form-wrapper legend {
   font-weight: bold;
 }
+
+.form-item__help-page-link {
+  font-weight: normal;
+  font-size: 0.79rem;
+  display: block;
+}
+
+/**
+ * Hide the "Show row heights" text
+ */
+.tabledrag-toggle-weight {
+  display: none;
+}

--- a/docroot/themes/custom/prisconhub/prisconhub.theme
+++ b/docroot/themes/custom/prisconhub/prisconhub.theme
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the Prisconhub custom theme.
+ */
+
+use Drupal\Core\Link;
+
+/**
+ * Implements hook_preprocess_form_element().
+ *
+ * Render #help_page_url attributes as links.
+ * @see prisoner_hub_cms_help_preprocess_form_element().
+ */
+function prisconhub_preprocess_form_element(&$variables) {
+  if (isset($variables['#help_page_url'])) {
+    $link = Link::fromTextAndUrl(t('How does this work?'), $variables['#help_page_url']);
+    $build = $link->toRenderable();
+    $build['#attributes']['target'] = '_blank';
+    $build['#attributes']['class'] = ['form-item__help-page-link'];
+    $variables['prefix'] = \Drupal::service('renderer')->render($build);
+  }
+}
+
+/**
+ * Implements hook_preprocess_field_multiple_value_form().
+ *
+ * Render #help_page_url attributes as links.
+ * @see prisoner_hub_cms_help_preprocess_field_multiple_value_form().
+ */
+function prisconhub_preprocess_field_multiple_value_form(&$variables) {
+  if (isset($variables['#help_page_url'])) {
+    $link = Link::fromTextAndUrl(t('How does this work?'), $variables['#help_page_url']);
+    $build = $link->toRenderable();
+    $build['#attributes']['target'] = '_blank';
+    $build['#attributes']['class'] = ['form-item__help-page-link'];
+    $variables['table']['#header'][0]['data']['#suffix'] = \Drupal::service('renderer')->render($build);
+  }
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/HK5LEtQ4/1029-help-dcms-understand-how-the-new-homepage-updates-section-works

### Intent

This PR updates the fields on the new homepage content type:
- Adds a "How does this work?" link
- Updates the descriptive text around the fields and places them into groups.
- For reference fields that support switching to the "Taxonomy Term" type (e.g. Key Info Tiles, and Featured Tiles).  The label "Taxonomy term" is changed to list out the types of taxonomy that can be selected.

<img width="895" alt="Screenshot 2022-07-04 at 15 07 44" src="https://user-images.githubusercontent.com/436483/177171439-2087dfd9-c2e3-4714-9ca9-53c1be5516c9.png">
<img width="536" alt="Screenshot 2022-07-04 at 15 07 52" src="https://user-images.githubusercontent.com/436483/177171454-00cd99b1-4389-4469-80b1-9ae2045f5ab9.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
