### PR TITLE
Set the default value for new series to be release date

### DIFF
--- a/config/sync/field.field.taxonomy_term.series.field_sort_by.yml
+++ b/config/sync/field.field.taxonomy_term.series.field_sort_by.yml
@@ -17,7 +17,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: season_and_episode_desc
+    value: release_date_desc
 default_value_callback: ''
 settings: {  }
 field_type: list_string


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/qBzmYtwt/1100-bulk-update-series-to-use-release-date-sorting
### Intent

Small change that will effect new series created in Drupal. 

The default value for how a series is sorted will now be using release dates.  As release date sorting is more appropriate for most series.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
