### PR TITLE
Bugfix/taxonomy overview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,8 @@
                 "Issue #1149078 - States API doesn't work with multiple select fields": "patches/drupal_states-multiselect-1149078-109.patch",
                 "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
                 "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-40.patch",
-                "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch"
+                "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch",
+                "Issue #3114365 - Vocabulary name not shown in View for Anonymous Users": "patches/drupal-3114365-17.patch"
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch",

--- a/config/sync/views.view.taxonomy_overview.yml
+++ b/config/sync/views.view.taxonomy_overview.yml
@@ -351,7 +351,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: custom
-          label: 'Parent categories'
+          label: 'Parent category'
           exclude: false
           alter:
             alter_text: true
@@ -526,16 +526,16 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        edit_taxonomy_term:
-          id: edit_taxonomy_term
+        operations:
+          id: operations
           table: taxonomy_term_data
-          field: edit_taxonomy_term
+          field: operations
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
-          plugin_id: entity_link_edit
-          label: Edit
+          plugin_id: entity_operations
+          label: Operations
           exclude: false
           alter:
             alter_text: false
@@ -576,9 +576,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          text: edit
-          output_url_as_text: false
-          absolute: false
+          destination: false
       pager:
         type: full
         options:
@@ -1206,9 +1204,10 @@ display:
             name_1: name_1
             vid: vid
             nothing: nothing
-            changed: changed
-            edit_taxonomy_term: edit_taxonomy_term
             status: status
+            changed: changed
+            operations: operations
+            edit_taxonomy_term: edit_taxonomy_term
           default: name
           info:
             parent_target_id:
@@ -1247,6 +1246,13 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             changed:
               sortable: true
               default_sort_order: asc
@@ -1254,19 +1260,17 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
             edit_taxonomy_term:
               sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
+              empty_column: true
               responsive: ''
           override: true
           sticky: false

--- a/docroot/modules/custom/prisoner_hub_prison_access_cms/prisoner_hub_prison_access_cms.module
+++ b/docroot/modules/custom/prisoner_hub_prison_access_cms/prisoner_hub_prison_access_cms.module
@@ -31,7 +31,14 @@ function prisoner_hub_prison_access_cms_field_widget_form_alter(&$element, \Drup
     // setting this message on a different page, if the form redirects to
     // another url after submit.
     if (empty($form_state->getUserInput())) {
-      \Drupal::messenger()->addWarning(t('You cannot make changes to this content, as it is owned by another prison.  However, you <strong>can</strong> set your own prison to be <a href="#edit-group-exclude-from-prison">excluded from the content.</a>'));
+      // Set a different message when using views_entity_form_field.
+      if (substr($form_state->getFormObject()->getFormId(), 0, strlen('views_form')) == 'views_form') {
+        \Drupal::messenger()->addWarning(t('You cannot update values for some of the content on this page, as they are owned by another prison.'));
+      }
+      else {
+        \Drupal::messenger()->addWarning(t('You cannot make changes to this content, as it is owned by another prison.  However, you <strong>can</strong> set your own prison to be <a href="#edit-group-exclude-from-prison">excluded from the content.</a>'));
+      }
+
     }
   }
 

--- a/patches/drupal-3114365-17.patch
+++ b/patches/drupal-3114365-17.patch
@@ -1,0 +1,89 @@
+diff --git a/core/modules/taxonomy/src/VocabularyAccessControlHandler.php b/core/modules/taxonomy/src/VocabularyAccessControlHandler.php
+index 176691408a..19598097ef 100644
+--- a/core/modules/taxonomy/src/VocabularyAccessControlHandler.php
++++ b/core/modules/taxonomy/src/VocabularyAccessControlHandler.php
+@@ -20,9 +20,11 @@ class VocabularyAccessControlHandler extends EntityAccessControlHandler {
+   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+     switch ($operation) {
+       case 'access taxonomy overview':
+-      case 'view':
+         return AccessResult::allowedIfHasPermissions($account, ['access taxonomy overview', 'administer taxonomy'], 'OR');
+ 
++      case 'view':
++        return AccessResult::allowedIfHasPermissions($account, ['access taxonomy overview', 'administer taxonomy', 'access content'], 'OR');
++
+       default:
+         return parent::checkAccess($entity, $operation, $account);
+     }
+diff --git a/core/modules/taxonomy/tests/src/Kernel/Views/TaxonomyFieldVidTest.php b/core/modules/taxonomy/tests/src/Kernel/Views/TaxonomyFieldVidTest.php
+index 1b0c88b28a..d410092fc7 100644
+--- a/core/modules/taxonomy/tests/src/Kernel/Views/TaxonomyFieldVidTest.php
++++ b/core/modules/taxonomy/tests/src/Kernel/Views/TaxonomyFieldVidTest.php
+@@ -4,8 +4,8 @@
+ 
+ use Drupal\Core\Render\RenderContext;
+ use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
++use Drupal\Tests\user\Traits\UserCreationTrait;
+ use Drupal\Tests\views\Kernel\ViewsKernelTestBase;
+-use Drupal\user\Entity\User;
+ use Drupal\views\Tests\ViewTestData;
+ use Drupal\views\Views;
+ use Drupal\taxonomy\Entity\Vocabulary;
+@@ -18,6 +18,7 @@
+ class TaxonomyFieldVidTest extends ViewsKernelTestBase {
+ 
+   use TaxonomyTestTrait;
++  use UserCreationTrait;
+ 
+   /**
+    * Modules to enable.
+@@ -66,12 +67,6 @@ protected function setUp($import_test_views = TRUE): void {
+     $vocabulary = $this->createVocabulary();
+     $this->term1 = $this->createTerm($vocabulary);
+ 
+-    // Create user 1 and set is as the logged in user, so that the logged in
+-    // user has the correct permissions to view the vocabulary name.
+-    $this->adminUser = User::create(['name' => $this->randomString()]);
+-    $this->adminUser->save();
+-    $this->container->get('current_user')->setAccount($this->adminUser);
+-
+     ViewTestData::createTestViews(static::class, ['taxonomy_test_views']);
+   }
+ 
+@@ -85,6 +80,9 @@ public function testViewsHandlerVidField() {
+     $view = Views::getView('test_taxonomy_vid_field');
+     $this->executeView($view);
+ 
++    // Test with user who is an admin.
++    $this->setUpCurrentUser([], [], TRUE);
++
+     $actual = $renderer->executeInRenderContext(new RenderContext(), function () use ($view) {
+       return $view->field['vid']->advancedRender($view->result[0]);
+     });
+@@ -92,6 +90,26 @@ public function testViewsHandlerVidField() {
+     $expected = $vocabulary->get('name');
+ 
+     $this->assertEquals($expected, $actual);
++
++    // Test with user without 'access content' permission.
++    $this->setUpCurrentUser([], []);
++
++    $actual = $renderer->executeInRenderContext(new RenderContext(), function () use ($view) {
++      return $view->field['vid']->advancedRender($view->result[0]);
++    });
++    $expected = '';
++
++    $this->assertEquals($expected, $actual);
++
++    // Test with user with 'access content' permission.
++    $this->setUpCurrentUser([], ['access content']);
++
++    $actual = $renderer->executeInRenderContext(new RenderContext(), function () use ($view) {
++      return $view->field['vid']->advancedRender($view->result[0]);
++    });
++    $expected = $vocabulary->get('name');
++
++    $this->assertEquals($expected, $actual);
+   }
+ 
+ }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/qBzmYtwt/1100-bulk-update-series-to-use-release-date-sorting

### Intent

A few fixes that were spotted when testing the latest changes in main.
- DCMS saw an empty column on the taxonomy overview page, which would normally show links to editing the taxonomy.
- DCMS did not see anything under the "Type" column
- When viewing series or topics pages, the user can bulk update content in one go.  However they can only do this for content owned by their own prison.  The warning message they got about this was the same as when editing the content directly, which didn't really make sense in the context of bulk updating content.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
