### PR TITLE
Revert series field back to select2, accidentally updated.

### DIFF
--- a/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
@@ -205,10 +205,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_moj_series:
-    type: options_buttons
+    type: select2_entity_reference
     weight: 11
     region: content
-    settings: {  }
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_moj_thumbnail_image:
     type: image_image


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

A config change on local was accidentally exported and pushed up to prod.  This was displaying the series field on the audio content type as a long list of radio buttons.  This PR reverts it back to a select2 field.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
