### PR TITLE
Increase MaxSpareServers from default of 10 to 18.

### DIFF
--- a/apache/apache2.conf
+++ b/apache/apache2.conf
@@ -226,3 +226,6 @@ IncludeOptional conf-enabled/*.conf
 IncludeOptional sites-enabled/*.conf
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+
+# Increase max idle servers to avoid "AH00162: server seems busy" errors
+MaxSpareServers 18


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/q0qy0xKe/814-fix-apache-error-in-logs-related-to-performance

### Intent

This change is based on recommendation here https://serverfault.com/questions/693708/how-to-resolve-info-server-seems-busy-from-apache-server-logs

Because we have limited visibility on the issue (we don't have great monitoring tools, we don't have a devops/sysadmin type expert).  We are going to increase this setting in small amounts, to see if there are any improvements.

### Considerations

There's not a huge amount of documentation on this setting.  But the Apache docs says _"Setting this parameter to a large number is almost always a bad idea."_. Although without specifying what the consequences are.
https://httpd.apache.org/docs/2.4/mod/prefork.html#maxspareservers

It's likely that increasing idle servers results in wasted memory, as each process reserves memory.  

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
