### PR TITLE
Increase replica count to 5

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: ""
 fullnameOverride: ""
 
-replicaCount: 3
+replicaCount: 5
 maxReplicaCount: 6
 
 image:

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -2,7 +2,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 replicaCount: 5
-maxReplicaCount: 6
 
 image:
   repository: quay.io/hmpps/prisoner-content-hub-backend


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/q0qy0xKe/814-fix-apache-error-in-logs-related-to-performance

### Intent

By increasing the number of pods in the service, we increase the amount of available processes Apache can handle.  The default is 256 per Apache server (so we'd be increasing from 768 simultaneous connections to 1280).

I looked at increasing the number of MaxRequestWorkers, but the method for working this out is:
```
total available memory / average process size
```

So in our case it would be:
```
2000 / 73 = 27
```
This therefore suggests decreasing the number, which would make the problem worse.

See related google doc: https://docs.google.com/document/d/1d0lkte2tgEuPjRW5VjQfZRtRqsP4yTkmjmUU0wMdUcg/edit#

### Considerations
We're also removing `maxReplicaCount`, as this isn't being used.  We're not using autoscaling, and even if we were the value to use is actually `maxReplicas`.
See https://mojdt.slack.com/archives/C57UPMZLY/p1657706855779549
> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
