### PR TITLE
Giving access to the new homepage.

### DIFF
--- a/config/sync/node.type.homepage.yml
+++ b/config/sync/node.type.homepage.yml
@@ -22,7 +22,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-name: Homepage
+name: 'New homepage'
 type: homepage
 description: 'Use the <em>Homepage</em> content type to control certain components on a prisons homepage.  There is normally one <em>Homepage</em> per prison, and these are created when the prison is first added to Drupal.'
 help: ''

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -6,6 +6,7 @@ dependencies:
     - filter.format.full_html
     - node.type.featured_articles
     - node.type.help_page
+    - node.type.homepage
     - node.type.link
     - node.type.moj_pdf_item
     - node.type.moj_radio_item
@@ -58,6 +59,7 @@ permissions:
   - 'clone taxonomy_term entity'
   - 'create featured_articles content'
   - 'create help_page content'
+  - 'create homepage content'
   - 'create link content'
   - 'create moj_pdf_item content'
   - 'create moj_radio_item content'
@@ -76,6 +78,7 @@ permissions:
   - 'delete terms in series'
   - 'edit any featured_articles content'
   - 'edit any help_page content'
+  - 'edit any homepage content'
   - 'edit any link content'
   - 'edit any moj_pdf_item content'
   - 'edit any moj_radio_item content'
@@ -83,6 +86,7 @@ permissions:
   - 'edit any page content'
   - 'edit own featured_articles content'
   - 'edit own help_page content'
+  - 'edit own homepage content'
   - 'edit own link content'
   - 'edit own moj_pdf_item content'
   - 'edit own moj_radio_item content'
@@ -107,6 +111,7 @@ permissions:
   - 'execute views_bulk_edit all'
   - 'revert featured_articles revisions'
   - 'revert help_page revisions'
+  - 'revert homepage revisions'
   - 'revert link revisions'
   - 'revert moj_pdf_item revisions'
   - 'revert moj_radio_item revisions'

--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.full_html
     - node.type.featured_articles
+    - node.type.homepage
     - node.type.moj_pdf_item
     - node.type.moj_radio_item
     - node.type.moj_video_item
@@ -31,11 +32,13 @@ permissions:
   - 'create moj_video_item content'
   - 'create page content'
   - 'edit any featured_articles content'
+  - 'edit any homepage content'
   - 'edit any moj_pdf_item content'
   - 'edit any moj_radio_item content'
   - 'edit any moj_video_item content'
   - 'edit any page content'
   - 'edit own featured_articles content'
+  - 'edit own homepage content'
   - 'edit own moj_pdf_item content'
   - 'edit own moj_radio_item content'
   - 'edit own moj_video_item content'
@@ -44,12 +47,14 @@ permissions:
   - 'send javascript errors to sentry'
   - 'use text format full_html'
   - 'view any unpublished featured_articles content'
+  - 'view any unpublished homepage content'
   - 'view any unpublished link content'
   - 'view any unpublished moj_pdf_item content'
   - 'view any unpublished moj_radio_item content'
   - 'view any unpublished moj_video_item content'
   - 'view any unpublished page content'
   - 'view featured_articles revisions'
+  - 'view homepage revisions'
   - 'view moj_pdf_item revisions'
   - 'view moj_radio_item revisions'
   - 'view moj_video_item revisions'

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -957,6 +957,7 @@ display:
             featured_articles: featured_articles
             help_page: help_page
             link: link
+            homepage: homepage
             moj_pdf_item: moj_pdf_item
             moj_video_item: moj_video_item
           group: 1

--- a/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
@@ -43,12 +43,6 @@ class PrisonerHubPrisonAccessCmsTest extends ExistingSiteBase {
     $this->userPrisonFieldName = $this->container->getParameter('prisoner_hub_prison_access_cms.user_prison_field_name');
     $this->contentTypes = $this->getBundlesWithField('node', $this->prisonOwnerFieldName);
 
-    // Temporarily remove homepage content type, as this is not yet accessible
-    // local content managers.
-    // TODO: Remove these lines (re-instate tests) for homepage content type.
-    $key = array_search('homepage', $this->contentTypes);
-    unset($this->contentTypes[$key]);
-
     // Temporarily remove urgent banner content type, as this is not yet
     // accessible local content managers.
     // TODO: Remove these lines (re-instate tests) for urgent banner content type.


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/d1vzZdpJ/1150-prepare-to-release-new-homepage

### Intent

This PR gives DCMS and studio admins access to the new homepage content type, so that content population can start in preparation for the launch.

The content type has temporarily been renamed to "New homepage", once we go live we should rename it back to "Homepage".  Note this is just the label, the internal machine name, ie what you use from JSON:API is still `homepage`.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
