### PR TITLE
Adding patch for per-bundle type cache.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,8 @@
                 "Issue #3228329 - Fix cache dependencies not set for files uploaded through text editor.": "patches/drupal-3228329-files-uploaded-through-text-editor-cache-dependency-2.patch",
                 "Issue #3057545 - ResourceTypeRepository wrongly assumes that all entity reference fields have the setting \"target_type\".": "patches/drupal-3057545-40.patch",
                 "Issue #2352009 - Bubbling of elements' max-age to the page's headers and the page cache": "patches/drupal-2352009-max-age-bubbling-9.1.x.patch",
-                "Issue #3114365 - Vocabulary name not shown in View for Anonymous Users": "patches/drupal-3114365-17.patch"
+                "Issue #3114365 - Vocabulary name not shown in View for Anonymous Users": "patches/drupal-3114365-17.patch",
+                "Issue #3090131 - Use per-bundle entity list cache tags to potentially increase caching and performance": "patches/drupal-3090131-16.patch"
             },
             "drupal/jsonapi_page_limit": {
                 "Add option to set a global limit, see https://gitlab.com/drupalspoons/jsonapi_page_limit/-/issues/1": "patches/jsonapi_page_limit-add-option-to-set-global-limit-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "965b380fd17005d42f940c56bbe6c817",
+    "content-hash": "82989ab4a49292cdfa66e09102e0e54a",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal-3090131-16.patch
+++ b/patches/drupal-3090131-16.patch
@@ -1,0 +1,24 @@
+diff --git a/core/modules/jsonapi/src/Controller/EntityResource.php b/core/modules/jsonapi/src/Controller/EntityResource.php
+index 9ce8a725ce..b17a59ae90 100644
+--- a/core/modules/jsonapi/src/Controller/EntityResource.php
++++ b/core/modules/jsonapi/src/Controller/EntityResource.php
+@@ -1062,9 +1062,16 @@ protected function respondWithCollection(ResourceObjectData $primary_data, Data
+     $response = $this->buildWrappedResponse($primary_data, $request, $includes, 200, [], $collection_links, $meta);
+
+     // When a new change to any entity in the resource happens, we cannot ensure
+-    // the validity of this cached list. Add the list tag to deal with that.
+-    $list_tag = $this->entityTypeManager->getDefinition($resource_type->getEntityTypeId())
+-      ->getListCacheTags();
++    // the validity of this cached list.
++    if ($resource_type->getBundle() && $resource_type->getBundle() !== $resource_type->getEntityTypeId()) {
++      // Add the list tag per bundle to deal with that.
++      $list_tag = [$resource_type->getEntityTypeId() . '_list:' . $resource_type->getBundle()];
++    }
++    else {
++      // Add the list tag to deal with that.
++      $list_tag = $this->entityTypeManager->getDefinition($resource_type->getEntityTypeId())
++        ->getListCacheTags();
++    }
+     $response->getCacheableMetadata()->addCacheTags($list_tag);
+     foreach ($primary_data as $entity) {
+       $response->addCacheableDependency($entity);


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Related to help with releasing https://trello.com/c/d1vzZdpJ/1150-prepare-to-release-new-homepage

### Intent

Currently, any JSON:API requests where multiple items of content are brought back gets a `node_list` or a `taxonomy_term_list` cachetag.

E.g.
`/jsonapi/node/page`
`/jsonapi/node`
`/jsonapi/taxonomy_term/topics`

The issue with the `node_list` cachetag, is that it gets cleared on _every_ CRUD node operation (i.e. any node create/update/delete, regardless of content type or prison).  Which causes lots of unnecessary invalidations and rebuilds.

This PR adds a patch from https://www.drupal.org/project/drupal/issues/3090131 to split this per content type.

This means requests such as `/jsonapi/node/page` will get a `node_list:page` tag instead, which only gets invalidated on CRUD operations with a page content type.

### Considerations

This PR will help, but only for a small amount of requests.  Any cross-bundle requests, i.e. `/jsonapi/node` and `/jsonapi/taxonomy_term` will still have the same issue.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
