### PR TITLE
Fix for errors relating to missing image field.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_explore/src/Resource/Explore.php
+++ b/docroot/modules/custom/prisoner_hub_explore/src/Resource/Explore.php
@@ -48,8 +48,10 @@ class Explore extends EntityQueryResourceBase {
     // See https://drupal.stackexchange.com/a/249153/4831
     $query->addTag('prisoner_hub_explore_sort_by_random');
 
-    // Exclude homepage content types.
-    $query->condition('type', ['featured_articles', 'homepage'], 'NOT IN');
+    // We only want to include certain content types that can be shown as tiles.
+    // TODO: Is there a better way to determine this other than checking they
+    // have the image field?
+    $query->exists('field_moj_thumbnail_image');
 
     $data = $this->loadResourceObjectDataFromEntityQuery($query, $cacheability);
 

--- a/docroot/modules/custom/prisoner_hub_explore/src/Resource/Explore.php
+++ b/docroot/modules/custom/prisoner_hub_explore/src/Resource/Explore.php
@@ -21,6 +21,13 @@ use Symfony\Component\Routing\Route;
 class Explore extends EntityQueryResourceBase {
 
   /**
+   * Array of content types to use in the resource.
+   *
+   * @var array|string[]
+   */
+  static array $content_types = ['moj_radio_item', 'page', 'link', 'moj_pdf_item', 'moj_video_item'];
+
+  /**
    * Process the resource request.
    *
    * @param \Symfony\Component\HttpFoundation\Request $request
@@ -48,10 +55,7 @@ class Explore extends EntityQueryResourceBase {
     // See https://drupal.stackexchange.com/a/249153/4831
     $query->addTag('prisoner_hub_explore_sort_by_random');
 
-    // We only want to include certain content types that can be shown as tiles.
-    // TODO: Is there a better way to determine this other than checking they
-    // have the image field?
-    $query->exists('field_moj_thumbnail_image');
+    $query->condition('type', self::$content_types, 'IN');
 
     $data = $this->loadResourceObjectDataFromEntityQuery($query, $cacheability);
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Fix for https://sentry.io/organizations/ministryofjustice/issues/3451881467/?referrer=slack

### Intent

The explore the hub query (to get random content) was not excluding certain content types such as the help_page and urgent_banner.  These cause an error when used with `?include=field_moj_thumbnail_image` as the field does not exist on these types.

The fix was to add a check that this image field exists.  

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
