### PR TITLE
Fix absolute urls being used in the text editor.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/jsonapi_page_limit": "^1.0@beta",
         "drupal/jsonapi_search_api": "^1.0@RC",
+        "drupal/linkit": "^6.0",
         "drupal/maintenance_exempt": "1.x-dev",
         "drupal/memcache": "^2.0",
         "drupal/migrate_tools": "^5.0",
@@ -44,6 +45,7 @@
         "drupal/node_edit_protection": "^1.0",
         "drupal/optgroup_taxonomy_select": "^1.2",
         "drupal/pathauto": "^1.8",
+        "drupal/pathologic": "^1.0@alpha",
         "drupal/profile_switcher": "1.0-alpha5",
         "drupal/publication_date": "^2.0@beta",
         "drupal/raven": "^3.2",
@@ -185,6 +187,9 @@
             },
             "drupal/publication_date": {
                 "Issue #2983348: Published on empty for existing nodes.": "patches/publication_date-fill_published_at-2983348-60-for-composer.patch"
+            },
+            "drupal/pathologic": {
+                "Issue #758118: wild card for Additional paths.": "patches/pathologic-758118-wildcard-for-additional-paths-18.patch"
             }
         },
         "patches-ignore": {

--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,9 @@
             },
             "drupal/pathologic": {
                 "Issue #758118: wild card for Additional paths.": "patches/pathologic-758118-wildcard-for-additional-paths-18.patch"
+            },
+            "drupal/linkit": {
+                "Issue #2877535: Link shown after the autocomplete selection is the bare node/xxx link, not the alias": "patches/linkit-2877535-link-shown-after-autocomplete-is-bare-41.patch"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82989ab4a49292cdfa66e09102e0e54a",
+    "content-hash": "75ee1480f28a7a8015826442676e43ee",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4051,6 +4051,60 @@
             }
         },
         {
+            "name": "drupal/linkit",
+            "version": "6.0.0-beta3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/linkit.git",
+                "reference": "6.0.0-beta3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta3.zip",
+                "reference": "6.0.0-beta3",
+                "shasum": "39a5bf54cbc88324d788a573df7b3fecf7622065"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "require-dev": {
+                "drupal/imce": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "6.0.0-beta3",
+                    "datestamp": "1632946984",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Emil Stjerneman",
+                    "homepage": "https://stjerneman.com",
+                    "email": "emil@stjerneman.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "johnwebdev",
+                    "homepage": "https://www.drupal.org/user/3331569"
+                }
+            ],
+            "description": "Linkit - Enriched linking experience",
+            "homepage": "http://drupal.org/project/linkit",
+            "support": {
+                "source": "http://cgit.drupalcode.org/linkit",
+                "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
             "name": "drupal/maintenance_exempt",
             "version": "dev-1.x",
             "source": {
@@ -4546,6 +4600,58 @@
                 "source": "https://cgit.drupalcode.org/pathauto",
                 "issues": "https://www.drupal.org/project/issues/pathauto",
                 "documentation": "https://www.drupal.org/docs/8/modules/pathauto"
+            }
+        },
+        {
+            "name": "drupal/pathologic",
+            "version": "1.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/pathologic.git",
+                "reference": "8.x-1.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/pathologic-8.x-1.0-alpha3.zip",
+                "reference": "8.x-1.0-alpha3",
+                "shasum": "efcbbaccc24168e2fb30eb441e99ce330bde3321"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-alpha3",
+                    "datestamp": "1646804076",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Garrett Albright",
+                    "homepage": "https://www.drupal.org/user/191212"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                }
+            ],
+            "description": "Helps avoid broken links and incorrect paths in content.",
+            "homepage": "https://www.drupal.org/project/pathologic",
+            "support": {
+                "source": "https://git.drupalcode.org/project/pathologic"
             }
         },
         {
@@ -18094,6 +18200,7 @@
         "drupal/jsonapi_page_limit": 10,
         "drupal/jsonapi_search_api": 5,
         "drupal/maintenance_exempt": 20,
+        "drupal/pathologic": 15,
         "drupal/publication_date": 10,
         "drupal/readonlymode": 20,
         "drupal/taxonomy_machine_name": 20,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -54,6 +54,7 @@ module:
   layout_builder: 0
   layout_discovery: 0
   link: 0
+  linkit: 0
   maintenance_exempt: 0
   menu_ui: 0
   monolog: 0
@@ -66,6 +67,7 @@ module:
   page_cache_persist: 0
   path: 0
   path_alias: 0
+  pathologic: 0
   prisoner_hub_breadcrumbs: 0
   prisoner_hub_cms_help: 0
   prisoner_hub_content_suggestions: 0

--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -43,6 +43,9 @@ settings:
           items:
             - Source
   plugins:
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
     language:
       language_list: un
     stylescombo:

--- a/config/sync/editor.editor.full_html.yml
+++ b/config/sync/editor.editor.full_html.yml
@@ -51,10 +51,13 @@ settings:
             - ShowBlocks
             - Source
   plugins:
-    stylescombo:
-      styles: ''
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
     language:
       language_list: un
+    stylescombo:
+      styles: ''
 image_upload:
   status: true
   scheme: s3

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -16,7 +16,7 @@ filters:
     id: filter_html
     provider: filter
     status: true
-    weight: -10
+    weight: -50
     settings:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <panel> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title>'
       filter_html_help: false
@@ -25,34 +25,65 @@ filters:
     id: filter_align
     provider: filter
     status: true
-    weight: 7
+    weight: -49
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: true
-    weight: 8
+    weight: -48
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: 11
+    weight: -47
     settings: {  }
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: 0
+    weight: -46
     settings:
       title: true
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
     status: true
-    weight: 50
+    weight: -45
     settings:
       settings_source: global
       local_settings:
         protocol_style: full
         local_paths: ''
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: false
+    weight: -40
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -41
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -42
+    settings:
+      filter_url_length: 72

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - editor
     - linkit
+    - pathologic
 _core:
   default_config_hash: P8ddpAIKtawJDi5SzOwCzVnnNYqONewSTJ6Xn0dW_aQ
 name: 'Basic HTML'
@@ -17,7 +18,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <panel> <a href hreflang href data-entity-substitution data-entity-type data-entity-uuid title>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <panel> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
@@ -45,3 +46,13 @@ filters:
     weight: 0
     settings:
       title: true
+  filter_pathologic:
+    id: filter_pathologic
+    provider: pathologic
+    status: true
+    weight: 50
+    settings:
+      settings_source: global
+      local_settings:
+        protocol_style: full
+        local_paths: ''

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - editor
+    - linkit
 _core:
   default_config_hash: P8ddpAIKtawJDi5SzOwCzVnnNYqONewSTJ6Xn0dW_aQ
 name: 'Basic HTML'
@@ -16,7 +17,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <panel>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <panel> <a href hreflang href data-entity-substitution data-entity-type data-entity-uuid title>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
@@ -37,3 +38,10 @@ filters:
     status: true
     weight: 11
     settings: {  }
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: 0
+    settings:
+      title: true

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - editor
+    - linkit
     - pathologic
 _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
@@ -15,42 +16,74 @@ filters:
     id: filter_align
     provider: filter
     status: true
-    weight: 8
+    weight: -50
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: true
-    weight: 9
+    weight: -49
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: 10
+    weight: -48
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: 11
+    weight: -47
     settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: false
-    weight: -10
+    weight: -46
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre> <a href hreflang href data-entity-substitution data-entity-type data-entity-uuid title>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
     status: true
-    weight: 50
+    weight: -41
     settings:
       settings_source: global
       local_settings:
         protocol_style: full
         local_paths: ''
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -40
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -43
+    settings:
+      filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -42
+    settings:
+      title: true

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - editor
+    - pathologic
 _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
 name: 'Full HTML'
@@ -43,3 +44,13 @@ filters:
       allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre>'
       filter_html_help: true
       filter_html_nofollow: false
+  filter_pathologic:
+    id: filter_pathologic
+    provider: pathologic
+    status: true
+    weight: 50
+    settings:
+      settings_source: global
+      local_settings:
+        protocol_style: full
+        local_paths: ''

--- a/config/sync/image.style.linkit_result_thumbnail.yml
+++ b/config/sync/image.style.linkit_result_thumbnail.yml
@@ -1,0 +1,17 @@
+uuid: 7046d8c9-3664-4334-8e96-1ce71f4ab0e0
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: CMuvuRCfGZ5k3XgsXmkEc54rI8etDY1Qz2JP7JzKL-g
+name: linkit_result_thumbnail
+label: 'Linkit result thumbnail'
+effects:
+  2943df29-38ea-459c-ba1d-290489bb1807:
+    uuid: 2943df29-38ea-459c-ba1d-290489bb1807
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 50
+      height: 50
+      anchor: center-center

--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -4,20 +4,39 @@ status: true
 dependencies:
   module:
     - node
+    - taxonomy
 _core:
   default_config_hash: Tt8DtxZ3Nooo0PoWPpJvszA3R_5d8MmpUW7LM_R-BzY
-id: default
 label: Default
+id: default
 description: 'A default Linkit profile'
 matchers:
   556010a3-e317-48b3-b4ed-854c10f4b950:
-    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     id: 'entity:node'
-    weight: 0
+    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     settings:
-      metadata: 'by [node:author] | [node:created:medium]'
-      bundles: {  }
+      metadata: 'Published to [node:field_prisons] | In [node:field_moj_series] [node:field_moj_top_level_categories]'
+      bundles:
+        link: link
+        moj_pdf_item: moj_pdf_item
+        moj_radio_item: moj_radio_item
+        moj_video_item: moj_video_item
+        page: page
       group_by_bundle: false
-      include_unpublished: false
       substitution_type: canonical
       limit: 100
+      include_unpublished: false
+    weight: 0
+  83f16b85-c553-402e-8cdc-1d58265b0216:
+    id: 'entity:taxonomy_term'
+    uuid: 83f16b85-c553-402e-8cdc-1d58265b0216
+    settings:
+      metadata: 'type: [term:vocabulary]'
+      bundles:
+        moj_categories: moj_categories
+        series: series
+        topics: topics
+      group_by_bundle: false
+      substitution_type: canonical
+      limit: 100
+    weight: 0

--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -1,0 +1,23 @@
+uuid: be70c9fc-f42b-4858-86ce-7ebbbeb1dade
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+_core:
+  default_config_hash: Tt8DtxZ3Nooo0PoWPpJvszA3R_5d8MmpUW7LM_R-BzY
+id: default
+label: Default
+description: 'A default Linkit profile'
+matchers:
+  556010a3-e317-48b3-b4ed-854c10f4b950:
+    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
+    id: 'entity:node'
+    weight: 0
+    settings:
+      metadata: 'by [node:author] | [node:created:medium]'
+      bundles: {  }
+      group_by_bundle: false
+      include_unpublished: false
+      substitution_type: canonical
+      limit: 100

--- a/config/sync/pathologic.settings.yml
+++ b/config/sync/pathologic.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: EKYCulG-Y3pcObfUpVbl-D9T5DDX6d4hpQ-BVlSBAmw
+scheme_whitelist:
+  - http
+  - https
+  - files
+  - internal
+protocol_style: path
+local_paths: 'https://*content-hub.prisoner.service.justice.gov.uk'

--- a/patches/linkit-2877535-link-shown-after-autocomplete-is-bare-41.patch
+++ b/patches/linkit-2877535-link-shown-after-autocomplete-is-bare-41.patch
@@ -1,0 +1,129 @@
+diff --git a/js/linkit.autocomplete.js b/js/linkit.autocomplete.js
+index 558278d..6f14ea7 100644
+--- a/js/linkit.autocomplete.js
++++ b/js/linkit.autocomplete.js
+@@ -80,7 +80,7 @@
+       $('input[name="attributes[data-entity-substitution]"]', $form).val(ui.item.substitution_id);
+     }
+ 
+-    event.target.value = ui.item.path;
++    event.target.value = ui.item.alias ? ui.item.alias : ui.item.path;
+ 
+     return false;
+   }
+diff --git a/src/Element/Linkit.php b/src/Element/Linkit.php
+index 2bb7963..1184c1e 100644
+--- a/src/Element/Linkit.php
++++ b/src/Element/Linkit.php
+@@ -41,6 +41,16 @@ class Linkit extends FormElement {
+    * {@inheritdoc}
+    */
+   public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
++    if (!empty($input) && \Drupal::moduleHandler()->moduleExists('path_alias')) {
++      /** @var \Drupal\path_alias\AliasManagerInterface $aliasManager */
++      $aliasManager = \Drupal::service('path_alias.manager');
++
++      $path = $aliasManager->getPathByAlias($input);
++      if ($path !== $input) {
++        $input = $path;
++      }
++    }
++
+     return Textfield::valueCallback($element, $input, $form_state);
+   }
+ 
+@@ -86,6 +96,25 @@ class Linkit extends FormElement {
+    * {@inheritdoc}
+    */
+   public static function preRenderLinkitElement($element) {
++    if (empty($element['#default_value']) || empty($element['#value'])) {
++      return Textfield::preRenderTextfield($element);
++    }
++
++    if ($element['#value'][0] !== '/') {
++      return Textfield::preRenderTextfield($element);
++    }
++
++    if (\Drupal::moduleHandler()->moduleExists('path_alias')) {
++      /** @var \Drupal\path_alias\AliasManagerInterface $aliasManager */
++      $aliasManager = \Drupal::service('path_alias.manager');
++
++      $alias = $aliasManager->getAliasByPath($element['#value']);
++      if ($alias !== $element['#value']) {
++        $element['#default_value'] = $alias;
++        $element['#value'] = $alias;
++      }
++    }
++
+     return Textfield::preRenderTextfield($element);
+   }
+ 
+diff --git a/src/Plugin/Linkit/Matcher/EntityMatcher.php b/src/Plugin/Linkit/Matcher/EntityMatcher.php
+index e5a9413..99edf8c 100644
+--- a/src/Plugin/Linkit/Matcher/EntityMatcher.php
++++ b/src/Plugin/Linkit/Matcher/EntityMatcher.php
+@@ -426,7 +426,8 @@ class EntityMatcher extends ConfigurableMatcherBase {
+       ->setEntityUuid($entity->uuid())
+       ->setEntityTypeId($entity->getEntityTypeId())
+       ->setSubstitutionId($this->configuration['substitution_type'])
+-      ->setPath($this->buildPath($entity));
++      ->setPath($this->buildPath($entity))
++      ->setAlias($this->buildPath($entity));
+ 
+     return $suggestion;
+   }
+@@ -491,7 +492,7 @@ class EntityMatcher extends ConfigurableMatcherBase {
+    *   The path for this entity.
+    */
+   protected function buildPath(EntityInterface $entity) {
+-    $path = $entity->toUrl('canonical', ['path_processing' => FALSE])->toString();
++    $path = $entity->toUrl('canonical')->toString();
+     // For media entities, check if standalone URLs are allowed. If not, then
+     // strip '/edit' from the end of the canonical URL returned
+     // by $entity->toUrl().
+diff --git a/src/Suggestion/EntitySuggestion.php b/src/Suggestion/EntitySuggestion.php
+index bd55db3..618a84b 100644
+--- a/src/Suggestion/EntitySuggestion.php
++++ b/src/Suggestion/EntitySuggestion.php
+@@ -28,6 +28,13 @@ class EntitySuggestion extends DescriptionSuggestion {
+    */
+   protected $substitutionId;
+ 
++  /**
++   * The entity's path alias.
++   *
++   * @var string
++   */
++  protected $alias;
++
+   /**
+    * Sets the entity uuid.
+    *
+@@ -67,6 +74,19 @@ class EntitySuggestion extends DescriptionSuggestion {
+     return $this;
+   }
+ 
++  /**
++   * Sets the path alias.
++   *
++   * @param string $alias
++   *   The path alias.
++   *
++   * @return $this
++   */
++  public function setAlias($alias) {
++    $this->alias = $alias;
++    return $this;
++  }
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -76,6 +96,7 @@ class EntitySuggestion extends DescriptionSuggestion {
+       'entity_uuid' => $this->entityUuid,
+       'entity_type_id' => $this->entityTypeId,
+       'substitution_id' => $this->substitutionId,
++      'alias' => $this->alias,
+     ];
+   }
+ 

--- a/patches/pathologic-758118-wildcard-for-additional-paths-18.patch
+++ b/patches/pathologic-758118-wildcard-for-additional-paths-18.patch
@@ -1,0 +1,35 @@
+diff --git a/pathologic.module b/pathologic.module
+index b7e145c..63c057f 100644
+--- a/pathologic.module
++++ b/pathologic.module
+@@ -210,7 +210,7 @@ function _pathologic_replace($matches) {
+       && strpos($parts['path'], $exploded['path']) === 0
+       // And either they have the same host, or both have no host…
+       && (
+-        (isset($exploded['host']) && isset($parts['host']) && $exploded['host'] === $parts['host'])
++        (isset($exploded['host']) && isset($parts['host']) && fnmatch($exploded['host'], $parts['host']))
+         || (!isset($exploded['host']) && !isset($parts['host']))
+       )
+     ) {
+@@ -227,7 +227,7 @@ function _pathologic_replace($matches) {
+     // Okay, we didn't match on path alone, or host and path together. Can we
+     // match on just host? Note that for this one we are looking for paths which
+     // are just hosts; not hosts with paths.
+-    elseif ((isset($parts['host']) && !isset($exploded['path']) && isset($exploded['host']) && $exploded['host'] === $parts['host'])) {
++    elseif ((isset($parts['host']) && !isset($exploded['path']) && isset($exploded['host']) && fnmatch($exploded['host'], $parts['host']))) {
+       // No further editing; just continue
+       $found = TRUE;
+       // Break out of foreach loop
+diff --git a/src/PathologicSettingsCommon.php b/src/PathologicSettingsCommon.php
+index d279188..a55abdc 100644
+--- a/src/PathologicSettingsCommon.php
++++ b/src/PathologicSettingsCommon.php
+@@ -37,7 +37,7 @@ class PathologicSettingsCommon {
+         '#type' => 'textarea',
+         '#title' =>  $this->t('All base paths for this site'),
+         '#default_value' => $defaults['local_paths'],
+-          '#description' => $this->t('If this site is or was available at more than one base path or URL, enter them here, separated by line breaks. For example, if this site is live at <code>http://example.com/</code> but has a staging version at <code>http://dev.example.org/staging/</code>, you would enter both those URLs here. If confused, please read <a href=":docs" target="_blank">Pathologic&rsquo;s documentation</a> for more information about this option and what it affects.', [':docs' => 'https://www.drupal.org/node/257026']),
++        '#description' => $this->t('If this site is or was available at more than one base path or URL, enter them here, separated by line breaks. For example, if this site is live at <code>http://example.com/</code> but has a staging version at <code>http://dev.example.org/staging/</code>, you would enter both those URLs here.  Note that wildcards are also supported, e.g. <code>http://*example.com/</code> would match any subdomain for example.com.  If confused, please read <a href=":docs" target="_blank">Pathologic&rsquo;s documentation</a> for more information about this option and what it affects.', [':docs' => 'https://www.drupal.org/node/257026']),
+         '#weight' => 20,
+       ],
+     ];


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ZTW15U4f/1387-prevent-urls-that-wont-work-from-being-used-in-the-texteditor

### Intent

Installs a module called `pathologic` which adds a text filter to update urls.  The configuration has been setup to convert urls to be relative.  Therefore urls like `https://wayland.content-hub.prisoner.service.justice.gov.uk/tags/1282` will become `/tags/1282`.

Also enables a module called `linkit` which allows the user to search for the title of content/taxonomy instead of copy pasting the url.

<img width="613" alt="Screenshot 2022-08-16 at 11 22 49" src="https://user-images.githubusercontent.com/436483/184857164-d0b200fc-b04a-4c68-96f4-966514ec8c99.png">
<img width="698" alt="Screenshot 2022-08-16 at 11 20 10" src="https://user-images.githubusercontent.com/436483/184857199-f5f90ff4-5ca7-4119-916a-4a6e5ab642a5.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
