### PR TITLE
Adding permissions to see and edit the publication date.

### DIFF
--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -22,6 +22,7 @@ dependencies:
     - filter
     - node
     - prisoner_hub_prison_access_cms
+    - publication_date
     - raven
     - role_delegation
     - scheduler
@@ -119,6 +120,7 @@ permissions:
   - 'revert page revisions'
   - 'schedule publishing of nodes'
   - 'send javascript errors to sentry'
+  - 'set any published on date'
   - 'take_ownership_on_clone file entity'
   - 'take_ownership_on_clone node entity'
   - 'use text format full_html'

--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -13,6 +13,7 @@ dependencies:
   module:
     - filter
     - node
+    - publication_date
     - raven
     - scheduler
     - system
@@ -45,6 +46,7 @@ permissions:
   - 'edit own page content'
   - 'schedule publishing of nodes'
   - 'send javascript errors to sentry'
+  - 'set any published on date'
   - 'use text format full_html'
   - 'view any unpublished featured_articles content'
   - 'view any unpublished homepage content'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

After releasing the homepage we noticed that studio admins (and DCMs) can't see or edit the publication date.  This makes it difficult to get content to appear on the "recently added" component (amongst other things).

The permissions have already been added on production, this PR updates the config as code, to prevent the change from being reverted on the next deploy.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
