### PR TITLE
Fix for undefined variable.  That is often appearing in the logs.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_cms_help/prisoner_hub_cms_help.module
+++ b/docroot/modules/custom/prisoner_hub_cms_help/prisoner_hub_cms_help.module
@@ -72,7 +72,7 @@ function prisoner_hub_cms_help_preprocess_page_title(&$vars) {
  * @see prisconhub_preprocess_form_element().
  */
 function prisoner_hub_cms_help_preprocess_form_element(&$variables) {
-  if ($variables['element']['#name'] == 'field_large_update_tile[0][target_id]') {
+  if (isset($variables['element']['#name']) && $variables['element']['#name'] == 'field_large_update_tile[0][target_id]') {
     $variables['#help_page_url'] = Url::fromUserInput('/content/16897', ['fragment' => 'large-update-tile']);
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

Clean up the logs by removing a common PHP warning about an undefined variable.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
