### PR TITLE
Decrease timeout to 30 seconds, to match the timeout on the frontend.

### DIFF
--- a/apache/apache2.conf
+++ b/apache/apache2.conf
@@ -89,7 +89,7 @@ PidFile ${APACHE_PID_FILE}
 #
 # Timeout: The number of seconds before receives and sends time out.
 #
-Timeout 300
+Timeout 30
 
 #
 # KeepAlive: Whether or not to allow persistent connections (more than

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -182,3 +182,9 @@ if (PHP_SAPI !== 'cli') {
   // Setting the trusted reverse proxy header, to further prevent IP spoofing.
   $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_FOR | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_HOST | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PORT | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PROTO | \Symfony\Component\HttpFoundation\Request::HEADER_FORWARDED;
 }
+
+// Set max_execution_time to 30 seconds, as this is the same timeout as on the
+// frontend.  Note this does not apply to cli commands.
+if (PHP_SAPI !== 'cli') {
+  ini_set('max_execution_time', 30);
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.  Not 100% sure we want do this yet, up for discussion.

### Intent

The Apache timeout directive has a default of 60 seconds https://httpd.apache.org/docs/2.4/mod/core.html#timeout
For some reason ours is set to 5 minutes (not sure why it was increased).

This PR sets it to 30 seconds, to match the timeout from the frontend.

### Considerations

Are there any requests that take longer than 30 seconds?

There shouldn't be, at least not from the frontend.
There are some cli requests that do, but these do not run through Apache, so won't be subject to this timeout.

Possibly there are some long running processes in the CMS?  But anything that takes over 30 seconds should really be split into a batch.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
