### PR TITLE
Re-exporting config that Drupal seems to want to always re-order.

### DIFF
--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -39,23 +39,6 @@ filters:
     status: true
     weight: -47
     settings: {  }
-  linkit:
-    id: linkit
-    provider: linkit
-    status: true
-    weight: -46
-    settings:
-      title: true
-  filter_pathologic:
-    id: filter_pathologic
-    provider: pathologic
-    status: true
-    weight: -45
-    settings:
-      settings_source: global
-      local_settings:
-        protocol_style: full
-        local_paths: ''
   filter_autop:
     id: filter_autop
     provider: filter
@@ -87,3 +70,20 @@ filters:
     weight: -42
     settings:
       filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -46
+    settings:
+      title: true
+  filter_pathologic:
+    id: filter_pathologic
+    provider: pathologic
+    status: true
+    weight: -45
+    settings:
+      settings_source: global
+      local_settings:
+        protocol_style: full
+        local_paths: ''

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -45,16 +45,6 @@ filters:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre> <a href hreflang href data-entity-substitution data-entity-type data-entity-uuid title>'
       filter_html_help: true
       filter_html_nofollow: false
-  filter_pathologic:
-    id: filter_pathologic
-    provider: pathologic
-    status: true
-    weight: -41
-    settings:
-      settings_source: global
-      local_settings:
-        protocol_style: full
-        local_paths: ''
   filter_autop:
     id: filter_autop
     provider: filter
@@ -87,3 +77,13 @@ filters:
     weight: -42
     settings:
       title: true
+  filter_pathologic:
+    id: filter_pathologic
+    provider: pathologic
+    status: true
+    weight: -41
+    settings:
+      settings_source: global
+      local_settings:
+        protocol_style: full
+        local_paths: ''


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

For some reason Drupal wants to re-order this config, so it's re-importing it on every deployment.

This PR adds it in the correct format, so that it doesn't get picked up as a new config change.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
