### PR TITLE
Improve performance by reducing unnecessary cache invalidations.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,6 +46,7 @@ module:
   jquery_ui_touch_punch: 0
   jsonapi: 0
   jsonapi_cross_bundles: 0
+  jsonapi_filter_cachetags: 0
   jsonapi_image_styles: 0
   jsonapi_menu_items: 0
   jsonapi_page_limit: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,7 +46,7 @@ module:
   jquery_ui_touch_punch: 0
   jsonapi: 0
   jsonapi_cross_bundles: 0
-  jsonapi_filter_cachetags: 0
+  jsonapi_filter_cache_tags: 0
   jsonapi_image_styles: 0
   jsonapi_menu_items: 0
   jsonapi_page_limit: 0

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/README.md
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/README.md
@@ -10,24 +10,22 @@ For example say you had two category taxonomy terms on your site, and you were r
 - /jsonapi/node/page?filter[field_category.id]=38f0565a-35d4-11ed-a261-0242ac120002
 - /jsonapi/node/page?filter[field_category.id]=20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3
 Both of these requests would get the `node_list` cache tag.  If you created or updated content in one category, it
-would invalidate both requests, when really it only needed to do one.
+would invalidate both requests.
 
 See https://www.drupal.org/node/3090131, which is an issue to provide per bundle specific cache tags.
 However, this module goes further than that.  Instead, providing cache tags based on filter values.
 
 This module removes the `node_list` cache tag, and provides a new one, which looks like:
 `jsonapi_filter:node:field_category:20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3`
-This module also then invalidates this cache tag, _only_ when content has a field_category reference to "20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3".
+This module also then invalidates this cache tag, _only_ when content has a field_category referencing that uuid.
 
-This means that there are much less invalidations, which results in much better performance.
+This means that there are much fewer invalidations, which results in much better performance.
 
 ## Limitations
-Currently, only entity reference field filters are supported.  I.e. the filter needs to look exactly like:
+Currently, only entity reference by uuid filters are supported.  I.e. the filter needs to look exactly like:
 `?filter[field_reference_field_name.id]=UUID`
 No other field types are currently supported.
 Also only the "=" operator is supported.  All other operators (e.g. "!=", "IN" or "NOT IN") are not supported.
+Condition groups are not supported, the filter needs to be outside a group.
 For all unsupported filters, it will revert to the default cache tag handling functionality, i.e. it will get the
 `node_list` cache tag.
-
-
-

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/README.md
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/README.md
@@ -1,0 +1,33 @@
+# JSON:API Filter Cache Tags
+
+## Background
+This module adds cache tags based on JSON:API filter values.
+
+By default, JSON:API places _very generic_ `node_list` cache tags on all collection resources.
+This approach leads to lots of unnecessary invalidations, as the `node_list` cache tag is invalidated on _any_ node
+CRUD operation.
+For example say you had two category taxonomy terms on your site, and you were retrieving content for them separately:
+- /jsonapi/node/page?filter[field_category.id]=38f0565a-35d4-11ed-a261-0242ac120002
+- /jsonapi/node/page?filter[field_category.id]=20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3
+Both of these requests would get the `node_list` cache tag.  If you created or updated content in one category, it
+would invalidate both requests, when really it only needed to do one.
+
+See https://www.drupal.org/node/3090131, which is an issue to provide per bundle specific cache tags.
+However, this module goes further than that.  Instead, providing cache tags based on filter values.
+
+This module removes the `node_list` cache tag, and provides a new one, which looks like:
+`jsonapi_filter:node:field_category:20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3`
+This module also then invalidates this cache tag, _only_ when content has a field_category reference to "20bf54fa-b239-4b3a-bf4c-b7fd2db5ce3".
+
+This means that there are much less invalidations, which results in much better performance.
+
+## Limitations
+Currently, only entity reference field filters are supported.  I.e. the filter needs to look exactly like:
+`?filter[field_reference_field_name.id]=UUID`
+No other field types are currently supported.
+Also only the "=" operator is supported.  All other operators (e.g. "!=", "IN" or "NOT IN") are not supported.
+For all unsupported filters, it will revert to the default cache tag handling functionality, i.e. it will get the
+`node_list` cache tag.
+
+
+

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.info.yml
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.info.yml
@@ -1,0 +1,7 @@
+name: 'JSON:API Filter Cachetags'
+type: module
+description: 'Provides custom cachetag integration based on jsonapi filters.'
+core_version_requirement: ^9
+package: 'Custom'
+dependencies:
+  - drupal:jsonapi

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.install
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.install
@@ -1,0 +1,15 @@
+<?php
+
+use Drupal\Core\Entity\ContentEntityType;
+
+/**
+ * Implements hook_uninstall().
+ */
+function jsonapi_filter_cache_tags_uninstall($is_syncing) {
+  $entity_types = \Drupal::entityTypeManager()->getDefinitions();
+  foreach ($entity_types as $entity_type) {
+    if ($entity_type instanceof ContentEntityType) {
+      \Drupal::state()->delete('jsonapi_filter_cache_tags:' . $entity_type->id());
+    }
+  }
+}

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.install
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.install
@@ -9,7 +9,7 @@ function jsonapi_filter_cache_tags_uninstall($is_syncing) {
   $entity_types = \Drupal::entityTypeManager()->getDefinitions();
   foreach ($entity_types as $entity_type) {
     if ($entity_type instanceof ContentEntityType) {
-      \Drupal::state()->delete('jsonapi_filter_cache_tags:' . $entity_type->id());
+      \Drupal::state()->delete(\Drupal::service('jsonapi_filter_cache_tags.cache_tags_builder')->getStateKey($entity_type->id()));
     }
   }
 }

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.module
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Contains jsonapi_filter_cache_tags.module.
+ */
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Implements hook_entity_insert().
+ */
+function jsonapi_filter_cache_tags_entity_insert(\Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity instanceof ContentEntityInterface) {
+    \Drupal::service('jsonapi_filter_cache_tags.cache_tags_builder')->invalidateForEntity($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function jsonapi_filter_cache_tags_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity instanceof ContentEntityInterface) {
+    \Drupal::service('jsonapi_filter_cache_tags.cache_tags_builder')->invalidateForEntity($entity);
+  }
+}

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.services.yml
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/jsonapi_filter_cache_tags.services.yml
@@ -1,0 +1,8 @@
+services:
+  jsonapi_filter_cache_tags.cache_tags_builder:
+    class: Drupal\jsonapi_filter_cache_tags\CacheTagsBuilder
+  jsonapi_filter_cache_tags.subscriber:
+    class: Drupal\jsonapi_filter_cache_tags\EventSubscriber\ResponseSubscriber
+    arguments: ['@jsonapi_filter_cache_tags.cache_tags_builder', '@jsonapi.field_resolver']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
@@ -54,9 +54,9 @@ class CacheTagsBuilder {
   /**
    * Store the field used as filters in Drupal's state system.
    *
-   * We do this so that we can retrieve them later and know which ones to
-   * invalidate.  We'd otherwise need to invalidate every field, which would
-   * be wasteful.
+   * We do this so that we can retrieve them later and know which fields to
+   * use as cache tags for invalidation.  We'd otherwise need to invalidate
+   * every field, which would be wasteful.
    *
    * @param string $entity_type
    *   The entity type name, e.g. "node".
@@ -75,7 +75,7 @@ class CacheTagsBuilder {
   }
 
   /**
-   * Invalidate cache tags based for $entity, based on what is already stored.
+   * Invalidate cache tags for $entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity that has been created/updated.

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
@@ -39,6 +39,14 @@ class CacheTagsBuilder {
     return self::CACHE_TAG_PREFIX . ':' . $entity_type . ':' . $field_name . ':' . $field_value;
   }
 
+  /**
+   * Get the state key to be used based on $entity_type.
+   *
+   * @param string $entity_type
+   *   The entity type name, e.g. "node"
+   *
+   * @return string
+   */
   public function getStateKey(string $entity_type) {
     return self::STATE_KEY_PREFIX . '.' . $entity_type;
   }

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/CacheTagsBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\jsonapi_filter_cache_tags;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * The CacheTagsBuilder service.
+ *
+ * Provide common functionality between the creating and storing the cache tags
+ * (via the ResponseSubcriber) and invalidating them on entity save.
+ */
+class CacheTagsBuilder {
+
+  /**
+   * Build the cache tag string.
+   *
+   * @param string $entity_type
+   *   The entity type name, e.g. "node".
+   * @param string $field_name
+   *   The field name, e.g. "field_category".
+   * @param string $field_value
+   *   The value of the field.
+   *
+   * @return string
+   */
+  public function buildCacheTag(string $entity_type, string $field_name, string $field_value) {
+    return 'jsonapi_filter:' . $entity_type . ':' . $field_name . ':' . $field_value;
+  }
+
+  /**
+   * Store the cache tags in Drupal's state system.
+   *
+   * We do this so that we can retrieve them later and know which ones to
+   * invalidate.  We'd otherwise need to invalidate every theoretical cache tag
+   * (for every field on the entity), which would be wasteful.
+   *
+   * @param string $entity_type
+   *   The entity type name, e.g. "node".
+   * @param array $cache_tags
+   *   A list of cache tags to be stored.
+   *
+   * @return void
+   */
+  public function storeCacheTags(string $entity_type, array $cache_tags) {
+    $state_key = 'jsonapi_filter_cache_tags:' . $entity_type;
+    $existing_cache_tags = \Drupal::state()->get($state_key, []);
+    \Drupal::state()->set($state_key, array_merge($cache_tags, $existing_cache_tags));
+  }
+
+  /**
+   * Invalidate cache tags based for $entity, based on what is already stored.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity that has been created/updated.
+   *
+   * @return void
+   */
+  public function invalidateForEntity(ContentEntityInterface $entity) {
+    $existing_cache_tags = \Drupal::state()->get('jsonapi_filter_cache_tags:' . $entity->getEntityTypeId(), []);
+    foreach($existing_cache_tags as $cache_tag) {
+      $parts = explode(':', $cache_tag);
+      if ($entity->hasField($parts[2]) && $entity->{$parts[2]}->entity && $entity->{$parts[2]}->entity->uuid() == $parts[3]) {
+        Cache::invalidateTags([$cache_tag]);
+      }
+    }
+  }
+}

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\jsonapi_filter_cache_tags\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\CacheableResponse;
+use Drupal\jsonapi\CacheableResourceResponse;
+use Drupal\jsonapi\Context\FieldResolver;
+use Drupal\jsonapi\Query\EntityCondition;
+use Drupal\jsonapi\Query\Filter;
+use Drupal\jsonapi\ResourceType\ResourceType;
+use Drupal\jsonapi\Routing\Routes;
+use Drupal\jsonapi_filter_cache_tags\CacheTagsBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Class ResponseSubscriber.
+ */
+class ResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var \Drupal\jsonapi_filter_cache_tags\CacheTagsBuilder
+   *
+   * The cache tags builder service.
+   */
+  protected $cacheTagsBuilder;
+
+  /**
+   * @var \Drupal\jsonapi\Context\FieldResolver
+   *
+   * The field resolver service.
+   */
+  protected $fieldResolver;
+
+  /**
+   * Constructs a new ResponseSubscriber object.
+   */
+  public function __construct(CacheTagsBuilder $cache_tags_builder, FieldResolver $field_resolver) {
+    $this->cacheTagsBuilder = $cache_tags_builder;
+    $this->fieldResolver = $field_resolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE] = ['onResponse', 999];
+
+    return $events;
+  }
+
+  /**
+   * This method is called when the kernel.response is dispatched.
+   *
+   * @param \Symfony\Component\EventDispatcher\Event $event
+   *   The dispatched event.
+   */
+  public function onResponse(ResponseEvent $event) {
+    $response = $event->getResponse();
+    $request = $event->getRequest();
+    if ($response instanceof CacheableResourceResponse && $request->query->has('filter')) {
+      $resource_type = $request->attributes->get('resource_type');
+      if ($resource_type instanceof ResourceType) {
+        $cache_tags = [];
+        $filter = Filter::createFromQueryParameter($request->query->get('filter'), $resource_type, $this->fieldResolver);
+        foreach ($filter->root()->members() as $member) {
+          // We currently don't support group conditions, or any operator other
+          // than =.
+          if ($member instanceof EntityCondition && $member->operator() == '=') {
+            $parts = explode('.', $member->field());
+            // We are looking for an entity reference field, in the format of:
+            // field_reference_name.entity:entity_type.uuid
+            if (isset($parts[2]) && $parts[2] == 'uuid') {
+              $cache_tags[] = $this->cacheTagsBuilder->buildCacheTag($resource_type->getEntityTypeId(), $parts[0], $member->value());
+            }
+          }
+        }
+        if (!empty($cache_tags)) {
+          $this->cacheTagsBuilder->storeCacheTags($resource_type->getEntityTypeId(), $cache_tags);
+          $response->getCacheableMetadata()->setCacheTags($cache_tags);
+        }
+      }
+    }
+  }
+
+
+}

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
@@ -2,24 +2,15 @@
 
 namespace Drupal\jsonapi_filter_cache_tags\EventSubscriber;
 
-use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Cache\CacheableResponse;
 use Drupal\jsonapi\CacheableResourceResponse;
 use Drupal\jsonapi\Context\FieldResolver;
 use Drupal\jsonapi\Query\EntityCondition;
 use Drupal\jsonapi\Query\Filter;
 use Drupal\jsonapi\ResourceType\ResourceType;
-use Drupal\jsonapi\Routing\Routes;
 use Drupal\jsonapi_filter_cache_tags\CacheTagsBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\Event\ViewEvent;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ResponseSubscriber.
@@ -90,6 +81,4 @@ class ResponseSubscriber implements EventSubscriberInterface {
       }
     }
   }
-
-
 }

--- a/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
+++ b/docroot/modules/custom/jsonapi_filter_cache_tags/src/EventSubscriber/ResponseSubscriber.php
@@ -72,7 +72,7 @@ class ResponseSubscriber implements EventSubscriberInterface {
    * Create cache tag(s) from a JSON:API filter.
    *
    * @param \Drupal\jsonapi\Query\Filter $filter
-   *   The filter object, originating from the url quey.
+   *   The filter object, originating from the url query.
    * @param string $entity_type_id
    *   The entity type id, e.g. "node".
    *


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/g4cjHCyT/1585-prevent-certain-jsonapi-requests-from-having-their-cache-regularly-cleared

### Intent

Fix performance issues when content is updated during peak hours.  The issue we've been seeing is that due to Drupal's default use of the generic `node_list` cache tag, this results in any content updates invalidating all series/topics pages, the content component on category pages, and the updates section on the homepage.  When done during high traffic periods, Drupal has to rebuild the cache for all of these pages at the same time.

This PR adds a custom module that adds cache tags based on jsonapi filter values.  So we only end up invalidating the requests we need to.

For more info on cache tags see https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal (which also should be updated with details of this change).

### Considerations

- This module is designed to only alter the output of the cache tag in certain situations (see the limitations section of the module README.md).  So it won't apply everywhere, in particular the homepage updates component (as this uses a group filter).
- Only the `node_list` cache tag is removed, the individual node cache tags that are part of the response are still kept in, e.g. `node:17682`.  This is the correct functionality as we want any updates to these nodes to also invalidate the cache (it could be that they were changed to another category or series, so it wouldn't then trigger the cache tag invalidation from this module). 
- Tests still need to be written, will do that as part of the firebreak week.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
