### PR TITLE
Reducing cache tag invalidations on category pages.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_sub_terms/README.md
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/README.md
@@ -12,21 +12,23 @@ The results will be a paginated list of series and sub-categories.
 - Any sub category of the {uuid} (only direct sub-categories are included, not further levels)
 - Any series assigned to the {uuid} category (series assigned to sub-categories are not included).
 
-The results will be ordered by the most recently updated content within each sub term.
+The results will be ordered by the most recently created content within each sub term.
 When checking for the most recently updated content, we look at all levels of the taxonomy.  So changes to content that
-is in a sub-category multiple levels down, will affect the sorting order of it's parent sub-category.
+are in a sub-category multiple levels down, will affect the sorting order of it's parent sub-category (although this
+can take up to 24 hours to appear, see the cache tags info below).
 
 Note that if using a prison context, this again will be applied to the results.  So only content available in the
 current prison will be used for sorting.
 
-## Custom cachetags
-This module uses custom cachetags to invalidate the response when content has been updated or created.
-The cachetag looks like:
+## Custom cache tags
+This module uses custom cache tags to invalidate the response when content has been created.
+The cache tag looks like:
 `'prisoner_hub_sub_terms:123`
 (Where 123 is the taxonomy term id of the category).
 
-When content is updated or created, the cachetags for it's associated category and parent categories will be invalidated.
+When content is created, the cache tags for it's associated parent category will be invalidated.
+If the content is in a series, the category of the series will be invalidated.
+If the content is not in a series, then the category it is associated with will have its parent category invalidated.
 
-The reason for using a custom cachetag instead of the `taxonomy_term:123` tag that comes with Drupal, is that clearing
-the more generic Drupal cachetag will affect multiple parts of the site, whereas our custom cachetag can be specific
-to sub_terms JSON:API resource.
+There is also a 24 hour max-age set, which means that the sorting for parent categories higher up the hierarchy will
+eventually be updated with the new sorting order.

--- a/docroot/modules/custom/prisoner_hub_sub_terms/README.md
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/README.md
@@ -12,7 +12,7 @@ The results will be a paginated list of series and sub-categories.
 - Any sub category of the {uuid} (only direct sub-categories are included, not further levels)
 - Any series assigned to the {uuid} category (series assigned to sub-categories are not included).
 
-The results will be ordered by the most recently created content within each sub term.
+The results will be ordered by the most recently published content within each sub term.
 When checking for the most recently updated content, we look at all levels of the taxonomy.  So changes to content that
 are in a sub-category multiple levels down, will affect the sorting order of it's parent sub-category (although this
 can take up to 24 hours to appear, see the cache tags info below).
@@ -21,12 +21,12 @@ Note that if using a prison context, this again will be applied to the results. 
 current prison will be used for sorting.
 
 ## Custom cache tags
-This module uses custom cache tags to invalidate the response when content has been created.
+This module uses custom cache tags to invalidate the response when content has been published.
 The cache tag looks like:
 `'prisoner_hub_sub_terms:123`
 (Where 123 is the taxonomy term id of the category).
 
-When content is created, the cache tags for it's associated parent category will be invalidated.
+When content is published, the cache tags for it's associated parent category will be invalidated.
 If the content is in a series, the category of the series will be invalidated.
 If the content is not in a series, then the category it is associated with will have its parent category invalidated.
 

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.info.yml
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.info.yml
@@ -5,3 +5,4 @@ core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - jsonapi_resources:jsonapi_resources
+  - publication_date:publication_date

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
@@ -9,17 +9,10 @@ use Drupal\taxonomy\TermInterface;
 use Drupal\views\ViewExecutable;
 
 /**
- * Implements hook_entity_update().
- */
-function prisoner_hub_sub_terms_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
-  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity, FALSE);
-}
-
-/**
  * Implements hook_entity_insert().
  */
 function prisoner_hub_sub_terms_entity_insert(\Drupal\Core\Entity\EntityInterface $entity) {
-  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity, TRUE);
+  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity);
 }
 
 /**

--- a/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/prisoner_hub_sub_terms.module
@@ -16,6 +16,13 @@ function prisoner_hub_sub_terms_entity_insert(\Drupal\Core\Entity\EntityInterfac
 }
 
 /**
+ * Implements hook_entity_update().
+ */
+function prisoner_hub_sub_terms_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
+  \Drupal::service('prisoner_hub_sub_terms.cachetag_invalidator')->invalidate($entity);
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Modify the options for the Subcategory exposed filter, to only include

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -49,6 +49,12 @@ class SubTerms extends EntityResourceBase {
     // Add our own custom cache tag that is cleared whenever content is updated.
     $cacheability->addCacheTags(['prisoner_hub_sub_terms:' . $taxonomy_term->id()]);
 
+    // Set cache to 24 hours.  We do this because we only invalidate the
+    // directly associated subcategory, and not parent categories.  So parent
+    // categories will have their cache rebuilt after 24 hours with the new
+    // order of subcategories and series.
+    $cacheability->setCacheMaxAge(86400);
+
     $tids = [$taxonomy_term->id()];
 
     // Check content also assigned to any sub-category (multiple levels) of the
@@ -91,7 +97,7 @@ class SubTerms extends EntityResourceBase {
     $query->groupBy('field_moj_series');
 
     // Aggregate the groupings by the most recently created, and sort by that.
-    $query->sortAggregate('changed', 'MAX', 'DESC');
+    $query->sortAggregate('created', 'MAX', 'DESC');
 
     $pagination = $this->getPagination($request);
     if ($pagination->getSize() <= 0) {

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -96,8 +96,8 @@ class SubTerms extends EntityResourceBase {
     $query->groupBy('field_moj_top_level_categories');
     $query->groupBy('field_moj_series');
 
-    // Aggregate the groupings by the most recently created, and sort by that.
-    $query->sortAggregate('created', 'MAX', 'DESC');
+    // Aggregate the groupings by the most recently published, and sort by that.
+    $query->sortAggregate('published_at', 'MAX', 'DESC');
 
     $pagination = $this->getPagination($request);
     if ($pagination->getSize() <= 0) {

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
@@ -42,120 +42,66 @@ class SubTermsCacheTagInvalidator {
    *
    * @param $entity
    *   The $entity being inserted or updated.
-   * @param bool $insert
-   *  TRUE if $entity is being inserted, otherwise FALSE.
    */
-  public function invalidate($entity, bool $insert) {
+  public function invalidate($entity) {
     if ($entity instanceof NodeInterface) {
-      $this->invalidateNode($entity, $insert);
-    }
-    if ($entity instanceof TermInterface) {
-      $this->invalidateTaxonomyTerm($entity, $insert);
+      $this->invalidateNode($entity);
     }
   }
 
   /**
-   * Check whether the $entity is published.
-   *
-   * If the $entity is being updated, then we check both the previous and
-   * current versions (if one of those is published then we return TRUE).
-   *
-   * @param \Drupal\Core\Entity\EntityPublishedInterface $entity
-   *   The $entity to check.
-   * @param bool $insert
-   *   TRUE if $entity is being inserted, otherwise FALSE.
-   *
-   * @return bool
-   *   TRUE if $entity (either current or previous version) is published,
-   *   otherwise FALSE.
-   */
-  protected function checkEntityIsPublished(EntityPublishedInterface $entity, bool $insert) {
-    // Ignore if we are inserting an unpublished entity.
-    if ($insert && !$entity->isPublished()) {
-      return FALSE;
-    }
-    // Ignore if we are updating an unpublished entity.
-    if (isset($entity->original) && !$entity->original->isPublished() && !$entity->isPublished()) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * Invalidate cachetags based on node updates/inserts.
+   * Invalidate cache tags based on node updates/inserts.
    *
    * @param \Drupal\node\NodeInterface $entity
    *   The node $entity.
-   * @param bool $insert
-   *   TRUE if $entity is being inserted, otherwise FALSE.
    */
-  protected function invalidateNode(NodeInterface $entity, bool $insert) {
-    if (!$this->checkEntityIsPublished($entity, $insert)) {
+  protected function invalidateNode(NodeInterface $entity) {
+    if (!$entity->isPublished()) {
       return;
     }
-    $category_id = NULL;
+    $term = NULL;
     if ($entity->hasField('field_moj_top_level_categories') && !$entity->get('field_moj_top_level_categories')->isEmpty()) {
-      $category_id = $entity->get('field_moj_top_level_categories')->target_id;
+      $entities = $entity->get('field_moj_top_level_categories')->referencedEntities();
+      if (!empty($entities)) {
+        $term = $entities[0];
+      }
     }
     if ($entity->hasField('field_moj_series') && !$entity->get('field_moj_series')->isEmpty()) {
-      $series_entities = $entity->get('field_moj_series')->referencedEntities();
-      if (!empty($series_entities)) {
-        $category_id = $series_entities[0]->get('field_category')->target_id;
+      $entities = $entity->get('field_moj_series')->referencedEntities();
+      if (!empty($entities)) {
+        $term = $entities[0];
       }
     }
-    if ($category_id) {
-      $this->invalidateCategoryAndParents($category_id);
+    if ($term) {
+      $this->invalidateTermParent($term);
     }
   }
 
   /**
-   * Invalidate cachetags based on taxonomy term updates/inserts.
+   * Invalidate cache tags for the immediate parent category.
    *
-   * @param \Drupal\taxonomy\TermInterface $entity
-   *   The taxonomy terms $entity.
-   * @param bool $insert
-   *   TRUE if $entity is being inserted, otherwise FALSE.
-   */
-  protected function invalidateTaxonomyTerm(TermInterface $entity, bool $insert) {
-    if (!$this->checkEntityIsPublished($entity, $insert)) {
-      return;
-    }
-    $category_id = NULL;
-    if ($entity->bundle() == 'series') {
-      $category_id = $entity->get('field_category')->target_id;
-    }
-    if ($entity->bundle() == 'moj_categories') {
-      if ($insert) {
-        // If this is a new category, then it wont have a cache entry yet.
-        // So just clear it's parents.
-        $category_id = $entity->get('parent')->target_id;
-      }
-      else {
-        $category_id = $entity->id();
-      }
-    }
-    if ($category_id) {
-      $this->invalidateCategoryAndParents($category_id);
-    }
-  }
-
-  /**
-   * Invalidate cachetags for category id, and all parents of that category.
+   * Note we do not invalidate grandfather (and beyond) categories. Even though
+   * content updates do still "bubble up" to the highest level in the hierarchy.
+   * But due to performance reasons, we only clear the most immediate parent and
+   * instead allow the others caches to reach their max-age.
+   * Note we did use to expire grandfather categories, so if this is required
+   * again please look in the git history.
    *
-   * @param int $category_id
-   *   The taxonomy term id for the category.
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The taxonomy term, either a series or a category.
    */
-  protected function invalidateCategoryAndParents(int $category_id) {
-    $tags = ['prisoner_hub_sub_terms:' . $category_id];
-
-    $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadAllParents($category_id);
-    foreach ($terms as $term) {
-      // Exclude the current category id, which is also returned by
-      // loadAllParents(), as this has already been added.
-      if ($term->id() != $category_id) {
-        $tags[] =  'prisoner_hub_sub_terms:' . $term->id();
+  protected function invalidateTermParent(TermInterface $term) {
+    $cache_tags = [];
+    if ($term->bundle() == 'series') {
+      $cache_tags[] = 'prisoner_hub_sub_terms:' . $term->get('field_category')->target_id;
+    }
+    else if ($term->bundle() == 'moj_categories') {
+      foreach ($term->get('parent') as $parent) {
+        if ($parent->target_id != 0) {
+          $cache_tags = ['prisoner_hub_sub_terms:' . $parent->target_id];
+        }
       }
     }
-    $this->cacheTagsInvalidator->invalidateTags($tags);
+    $this->cacheTagsInvalidator->invalidateTags($cache_tags);
   }
 }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -88,7 +88,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $first_term->id()]],
       'field_not_in_series' => 1,
-      'created' => time(),
+      'published_at' => time(),
     ]);
 
     // Create another subcategory, and create content that is _very old_,
@@ -101,7 +101,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
       'field_not_in_series' => 1,
-      'created' => strtotime('-2 years'),
+      'published_at' => strtotime('-2 years'),
     ]);
 
     // Create some unpublished content to ensure this doesn't effect
@@ -109,7 +109,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
       'field_not_in_series' => 1,
-      'created' => time(),
+      'published_at' => time(),
       'status' => 0,
     ]);
 
@@ -127,7 +127,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     ]);
     $this->createNode([
       'field_moj_series' => [['target_id' => $second_series->id()]],
-      'created' => strtotime('-10 minutes'),
+      'published_at' => strtotime('-10 minutes'),
     ]);
 
     // Create a subcategory with some content, and ensure it's displayed
@@ -140,7 +140,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $third_term->id()]],
       'field_not_in_series' => 1,
-      'created' => strtotime('-1 week'),
+      'published_at' => strtotime('-1 week'),
     ]);
 
     // Create a series inside the current category, with some content in it.
@@ -152,7 +152,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     ]);
     $this->createNode([
       'field_moj_series' => [['target_id' => $fourth_term->id()]],
-      'created' => strtotime('-6 months'),
+      'published_at' => strtotime('-6 months'),
     ]);
 
     // Create a three new sub-categories (going three levels down), and ensure
@@ -175,7 +175,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $fifth_subsubcategory->id()]],
       'field_not_in_series' => 1,
-      'created' => strtotime('-7 months'),
+      'published_at' => strtotime('-7 months'),
     ]);
 
     $correct_order_sub_terms = [

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -246,11 +246,14 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     if (\Drupal::moduleHandler()->moduleExists('page_cache')) {
       $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'HIT');
     }
+    else {
+      $this->markTestSkipped('Page cache module not installed, test can be removed.');
+    }
 
-    // We should have one cachetag invalidation, as we created one peice of content.
-    $cachetag = 'prisoner_hub_sub_terms:' . $this->categoryTerm->id();
-    $invalidation_count = \Drupal::service('cache_tags.invalidator.checksum')->getCurrentChecksum([$cachetag]);
-    $this->assertSame(1, $invalidation_count, 'Cachetag has been cleared exactly one time.');
+    // We should have one cache tag invalidation, as we created one piece of content.
+    $cache_tag = 'prisoner_hub_sub_terms:' . $this->categoryTerm->id();
+    $invalidation_count = \Drupal::service('cache_tags.invalidator.checksum')->getCurrentChecksum([$cache_tag]);
+    $this->assertSame(1, $invalidation_count, 'Cache tag has been cleared exactly one time.');
 
     // Create a new node, and check for a MISS.
     $this->createNode([
@@ -261,8 +264,11 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     if (\Drupal::moduleHandler()->moduleExists('page_cache')) {
       $this->assertSame($response->getHeader('X-Drupal-Cache')[0], 'MISS');
     }
-    $invalidation_count = \Drupal::service('cache_tags.invalidator.checksum')->getCurrentChecksum([$cachetag]);
-    $this->assertSame(2, $invalidation_count, 'Cachetag has been cleared exactly two times.');
+    else {
+      $this->markTestSkipped('Page cache module not installed, test can be removed.');
+    }
+    $invalidation_count = \Drupal::service('cache_tags.invalidator.checksum')->getCurrentChecksum([$cache_tag]);
+    $this->assertSame(2, $invalidation_count, 'Cache tag has been cleared exactly two times.');
   }
 
   /**

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -88,7 +88,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $first_term->id()]],
       'field_not_in_series' => 1,
-      'changed' => time(),
+      'created' => time(),
     ]);
 
     // Create another subcategory, and create content that is _very old_,
@@ -101,7 +101,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
       'field_not_in_series' => 1,
-      'changed' => strtotime('-2 years'),
+      'created' => strtotime('-2 years'),
     ]);
 
     // Create some unpublished content to ensure this doesn't effect
@@ -109,7 +109,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $last_term->id()]],
       'field_not_in_series' => 1,
-      'changed' => time(),
+      'created' => time(),
       'status' => 0,
     ]);
 
@@ -127,7 +127,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     ]);
     $this->createNode([
       'field_moj_series' => [['target_id' => $second_series->id()]],
-      'changed' => strtotime('-10 minutes'),
+      'created' => strtotime('-10 minutes'),
     ]);
 
     // Create a subcategory with some content, and ensure it's displayed
@@ -140,7 +140,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $third_term->id()]],
       'field_not_in_series' => 1,
-      'changed' => strtotime('-1 week'),
+      'created' => strtotime('-1 week'),
     ]);
 
     // Create a series inside the current category, with some content in it.
@@ -152,7 +152,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     ]);
     $this->createNode([
       'field_moj_series' => [['target_id' => $fourth_term->id()]],
-      'changed' => strtotime('-6 months'),
+      'created' => strtotime('-6 months'),
     ]);
 
     // Create a three new sub-categories (going three levels down), and ensure
@@ -175,7 +175,7 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $this->createNode([
       'field_moj_top_level_categories' => [['target_id' => $fifth_subsubcategory->id()]],
       'field_not_in_series' => 1,
-      'changed' => strtotime('-7 months'),
+      'created' => strtotime('-7 months'),
     ]);
 
     $correct_order_sub_terms = [


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/g4cjHCyT/1585-prevent-certain-jsonapi-requests-from-having-their-cache-regularly-cleared

### Intent

This PR improves performance by reducing the number of cache invalidations for subcategory pages.

- Only the direct parent category will be invalidated, and not parents of that.  
- We only invalidate when content is published, not when existing published content is updated. 

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
