### PR TITLE
Invalidate cache when switching to a new category or series.

### DIFF
--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/SubTermsCacheTagInvalidator.php
@@ -111,7 +111,10 @@ class SubTermsCacheTagInvalidator {
     }
     $referenced_entity = $this->getCategoryFromEntity($entity) ?: $this->getSeriesFromEntity($entity);
     $previous_referenced_entity = $this->getCategoryFromEntity($entity->original) ?: $this->getSeriesFromEntity($entity->original);
-    return $referenced_entity->id() != $previous_referenced_entity->id();
+    
+    $previous_entity_id = $previous_referenced_entity ? $previous_referenced_entity->id() : NULL;
+    $current_entity_id = $referenced_entity ? $referenced_entity->id() : NULL;
+    return $previous_entity_id != $current_entity_id;
   }
 
   /**


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Fixes an issue introduced by https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/450

### Intent

The above PR changed how cache invalidations worked for the "In this section" component.
Now only new content being published in a category or series will trigger a cache invalidation.

This PR takes into account already published content, that is being switched from one category/series to another.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
