### PR TITLE
Fix for intermittent DNS issue with cronjob

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/db-backup.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-backup.sh
@@ -7,6 +7,24 @@ echo "password=${HUB_DB_ENV_MYSQL_PASSWORD}" >> ~/.my.cnf
 echo "host=${HUB_DB_PORT_3306_TCP_ADDR}" >> ~/.my.cnf
 echo "column-statistics=0" >> ~/.my.cnf
 
+echo "[client]" >> ~/.my.cnf
+echo "user=${HUB_DB_ENV_MYSQL_USER}" >> ~/.my.cnf
+echo "password=${HUB_DB_ENV_MYSQL_PASSWORD}" >> ~/.my.cnf
+echo "host=${HUB_DB_PORT_3306_TCP_ADDR}" >> ~/.my.cnf
+
+# Make 2 attempts to connect to the database.  This mitigates intermittent DNS issues.
+# See https://mojdt.slack.com/archives/C57UPMZLY/p1664264969450269
+attempts=2
+while [ $attempts -gt 0 ] && ! mysql ${HUB_DB_ENV_MYSQL_DATABASE} -e "SELECT 1" &> /dev/null
+do
+  ((attempts--))
+  if [ $attempts -eq 0 ]
+  then
+    echo "Error establishing connection to database, aborting."
+    exit 1
+  fi
+done
+
 filename="db_backup_$(date +"%F-%H%M%S").sql"
 mysqldump ${HUB_DB_ENV_MYSQL_DATABASE} > ~/${filename}
 
@@ -17,4 +35,4 @@ echo "aws_secret_access_key=${DB_BACKUP_S3_SECRET}" >> ~/.aws/credentials
 
 aws s3 mv ~/${filename} s3://${DB_BACKUP_S3_BUCKET}/${filename} --region=${DB_BACKUP_S3_REGION}
 
-echo "Successfuly backed up database ${filename}"
+echo "Successfully backed up database ${filename}"

--- a/helm_deploy/prisoner-content-hub-backend/db-backup.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-backup.sh
@@ -15,7 +15,7 @@ echo "host=${HUB_DB_PORT_3306_TCP_ADDR}" >> ~/.my.cnf
 # Make 2 attempts to connect to the database.  This mitigates intermittent DNS issues.
 # See https://mojdt.slack.com/archives/C57UPMZLY/p1664264969450269
 attempts=2
-while [ $attempts -gt 0 ] && ! mysql ${HUB_DB_ENV_MYSQL_DATABASE} -e "SELECT 1" &> /dev/null
+while ! mysql ${HUB_DB_ENV_MYSQL_DATABASE} -e "SELECT 1" &> /dev/null
 do
   ((attempts--))
   if [ $attempts -eq 0 ]


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/JnaHKTyN/758-improve-drupal-database-backups

### Intent

We found that there are intermittent DNS issues with this cronjob.  Other services have reported similar.  The fix is to retry the connection.
https://mojdt.slack.com/archives/C57UPMZLY/p1664264969450269

Because mysqldump doesn't have a `--retry` option (like curl does), we do this manually by running a simple 'SELECT 1' command, twice, before the mysqldump command.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
