### PR TITLE
Rename link summary field

### DIFF
--- a/config/sync/core.entity_form_display.node.link.default.yml
+++ b/config/sync/core.entity_form_display.node.link.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.link.field_display_url
     - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_link_summary
     - field.field.node.link.field_moj_episode
     - field.field.node.link.field_moj_season
     - field.field.node.link.field_moj_series
@@ -23,6 +24,7 @@ dependencies:
     - field_group
     - image
     - path
+    - publication_date
     - scheduler
     - select2
     - term_reference_tree
@@ -142,6 +144,14 @@ content:
       cascading_selection_enforce: false
       max_depth: 0
     third_party_settings: {  }
+  field_link_summary:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_moj_episode:
     type: number
     weight: 17
@@ -216,14 +226,6 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-  field_summary:
-    type: string_textfield
-    weight: 2
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_url:
     type: string_textfield
     weight: 3
@@ -241,6 +243,12 @@ content:
   publish_on:
     type: datetime_timestamp_no_default
     weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -266,7 +274,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -281,5 +289,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_summary: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
@@ -271,6 +271,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   scheduler_settings:
     weight: 12
     region: content

--- a/config/sync/core.entity_form_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_video_item.default.yml
@@ -287,6 +287,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   scheduler_settings:
     weight: 14
     region: content

--- a/config/sync/core.entity_view_display.node.link.default.yml
+++ b/config/sync/core.entity_view_display.node.link.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.link.field_display_url
     - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_link_summary
     - field.field.node.link.field_moj_episode
     - field.field.node.link.field_moj_season
     - field.field.node.link.field_moj_series
@@ -33,6 +34,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 104
+    region: content
+  field_link_summary:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 119
     region: content
   field_moj_episode:
     type: number_integer

--- a/config/sync/core.entity_view_display.node.link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.link.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.link.field_display_url
     - field.field.node.link.field_exclude_from_prison
+    - field.field.node.link.field_link_summary
     - field.field.node.link.field_moj_episode
     - field.field.node.link.field_moj_season
     - field.field.node.link.field_moj_series
@@ -34,6 +35,7 @@ hidden:
   breadcrumbs: true
   field_display_url: true
   field_exclude_from_prison: true
+  field_link_summary: true
   field_moj_episode: true
   field_moj_season: true
   field_moj_series: true
@@ -45,4 +47,5 @@ hidden:
   field_show_interstitial_page: true
   field_summary: true
   field_url: true
+  published_at: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.search_index.yml
+++ b/config/sync/core.entity_view_display.node.page.search_index.yml
@@ -47,4 +47,5 @@ hidden:
   field_release_date: true
   field_topics: true
   links: true
+  published_at: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -51,4 +51,5 @@ hidden:
   field_prisons: true
   field_release_date: true
   field_topics: true
+  published_at: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -51,4 +51,5 @@ hidden:
   field_prisons: true
   field_release_date: true
   field_topics: true
+  published_at: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.link.field_link_summary.yml
+++ b/config/sync/field.field.node.link.field_link_summary.yml
@@ -1,0 +1,19 @@
+uuid: 0df8fef4-da83-4791-8363-16faa8df4688
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link_summary
+    - node.type.link
+id: node.link.field_link_summary
+field_name: field_link_summary
+entity_type: node
+bundle: link
+label: Summary
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_link_summary.yml
+++ b/config/sync/field.storage.node.field_link_summary.yml
@@ -1,0 +1,21 @@
+uuid: 6610caaa-8cf3-4e0e-b2e5-4560c64c6343
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_link_summary
+field_name: field_link_summary
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.moj_radio_item
     - node.type.moj_video_item
     - node.type.page
+    - node.type.urgent_banner
     - taxonomy.vocabulary.moj_categories
     - taxonomy.vocabulary.prisons
     - taxonomy.vocabulary.series
@@ -951,12 +952,14 @@ display:
           plugin_id: bundle
           operator: in
           value:
+            all: all
             moj_radio_item: moj_radio_item
             page: page
             help_page: help_page
-            link: link
             homepage: homepage
+            link: link
             moj_pdf_item: moj_pdf_item
+            urgent_banner: urgent_banner
             moj_video_item: moj_video_item
           group: 1
           exposed: true
@@ -978,7 +981,7 @@ display:
               moj_local_content_manager: '0'
               local_administrator: '0'
               administrator: '0'
-            reduce: true
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.deploy.php
@@ -426,7 +426,8 @@ function prisoner_content_hub_profile_deploy_reimport_layout_builder_config() {
 /**
  * Update series to use release date sorting.
  *
- * For list of series, see https://docs.google.com/spreadsheets/d/1rpF-uYfU2pkTVKTWY6Un4jq9Y8NCNYPfl0_GFXRnUIQ
+ * For list of series, see
+ * https://docs.google.com/spreadsheets/d/1rpF-uYfU2pkTVKTWY6Un4jq9Y8NCNYPfl0_GFXRnUIQ
  */
 function prisoner_content_hub_profile_deploy_update_series_to_date_sorting() {
   $series_to_convert = [
@@ -558,7 +559,8 @@ function prisoner_content_hub_profile_deploy_update_series_to_date_sorting() {
 /**
  * Convert series to subcategories.
  *
- * For list of series, see https://docs.google.com/spreadsheets/d/1rpF-uYfU2pkTVKTWY6Un4jq9Y8NCNYPfl0_GFXRnUIQ
+ * For list of series, see
+ * https://docs.google.com/spreadsheets/d/1rpF-uYfU2pkTVKTWY6Un4jq9Y8NCNYPfl0_GFXRnUIQ
  */
 function prisoner_content_hub_profile_deploy_convert_series_to_subcats() {
   $series_to_convert = [
@@ -593,7 +595,7 @@ function prisoner_content_hub_profile_deploy_convert_series_to_subcats() {
     $nodes = Node::loadMultiple($result);
     foreach ($nodes as $node) {
       $node->set('field_moj_top_level_categories', [
-        ['target_id' => $new_category->id()]
+        ['target_id' => $new_category->id()],
       ]);
       $node->set('field_moj_series', NULL);
       $node->set('field_not_in_series', 1);
@@ -610,5 +612,24 @@ function prisoner_content_hub_profile_deploy_convert_series_to_subcats() {
     \Drupal::database()->query("UPDATE node__field_moj_description SET field_moj_description_value = REPLACE(field_moj_description_value, '" . $find . "', '" . $replace . "') WHERE field_moj_description_value LIKE '%" . $find . "%'");
     $term->delete();
 
+  }
+}
+
+/**
+ * The summary field on the link content type has changed name, copy over
+ * previous values.
+ */
+function prisoner_content_hub_profile_deploy_copy_link_summary() {
+  $result = \Drupal::entityQuery('node')
+    ->condition('type', 'link')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  $nodes = Node::loadMultiple($result);
+
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($nodes as $node) {
+    $node->set('field_link_summary', $node->get('field_summary')->getValue());
+    $node->save();
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/7cqZ8r3j/1710-separate-summary-and-description-in-drupal

### Intent
Prep for the card above.

We need to rename the existing `field_summary` to `field_link_summary`, as we want to create a new `field_summary` and use it on all content types with a description.

### Considerations

This will also need an update to the f/e to use the new field name.
EDIT: Looks like it's not actually in use on the f/e https://github.com/ministryofjustice/prisoner-content-hub-frontend/search?q=field_summary&type=code
I also looked at how Link tiles are displayed, and can't see the summary being outputted anywhere.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
