### PR TITLE
Disabling Sentry JS error reporting.

### DIFF
--- a/config/sync/raven.settings.yml
+++ b/config/sync/raven.settings.yml
@@ -18,7 +18,7 @@ message_limit: 2048
 trace: true
 fatal_error_handler: true
 fatal_error_handler_memory: 2560
-javascript_error_handler: true
+javascript_error_handler: false
 drush_error_handler: true
 public_dsn: 'https://7e038c55ab3547be95934595b77723f5@o345774.ingest.sentry.io/5377063'
 ssl: verify_ssl


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

I'm trying to reduce noise on the #hub_alerts_prod channel.  We get quite a few clientside js errors from Drupal.  They are normally related to third party code (either from Drupal or ckeditor) and is not possible to replicate on another environment.  I.e. they are not possible to fix, and often don't actually represent a real issue.

I looked into a way to stop these types of errors from making it through to Slack (whilst still retaining PHP errors) but couldn't see a way.  I therefore think it's easier to just disable them altogether.  We've had them enabled for over a year and have never found them to be useful.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
