### PR TITLE
Adding make sync command to copy db down from s3 backups.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,9 @@ RUN composer install \
   --prefer-dist
 
 FROM test as local
+
+COPY scripts/ scripts/
+
 USER root
 RUN pecl install xdebug-3.1.5 \
   && docker-php-ext-enable xdebug

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,13 @@ deploy:
 	echo "Disabling maintenance and readonly mode"
 	drush state-set readonlymode_active 0
 	drush state-set system.maintenance_mode 0
+
+sync:
+	# Downloading latest db backup from S3
+	./scripts/downloadDBFromBackup.sh
+	# Download complete
+	# Clearing Drupal db of existing data
+	docker-compose -f ../prisoner-content-hub/docker-compose.yml exec -it prisoner-content-hub-backend drush sql-drop -y
+	# Importing db backup to Drupal DB
+	docker-compose -f ../prisoner-content-hub/docker-compose.yml exec prisoner-content-hub-backend scripts/importDBFromBackup.sh
+	# Import complete

--- a/scripts/downloadDBFromBackup.sh
+++ b/scripts/downloadDBFromBackup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -ue
+
+aws configure set aws_access_key_id $(kubectl -n prisoner-content-hub-development get secret db-backups-s3 --template={{.data.access_key_id}} | base64 --decode) --profile drupal-db-backups
+aws configure set aws_secret_access_key $(kubectl -n prisoner-content-hub-development get secret db-backups-s3 --template={{.data.secret_access_key}} | base64 --decode) --profile drupal-db-backups
+aws configure set region "eu-west-2" --profile drupal-db-backups
+
+# Find the most recent file in the S3 bucket.
+filename="$(aws s3 ls $(kubectl -n prisoner-content-hub-development get secret db-backups-s3 --template={{.data.bucket_name}} | base64 --decode) --profile=drupal-db-backups --recursive | grep '.sql' | sort | tail -n 1 | awk '{print $4}')"
+if [ -z "$filename" ]
+then
+  echo "No database backup files found.  Unable to perform database refresh."
+  # Exit with error.
+  exit 1
+fi
+
+# If file doesn't exist, download it.
+if [ ! -f "db-backups/$filename" ]
+then
+  # Clear out any old db dumps
+  rm -rf db-backups/
+  mkdir -p db-backups
+  aws s3 cp --profile=drupal-db-backups s3://$(kubectl -n prisoner-content-hub-development get secret db-backups-s3 --template={{.data.bucket_name}} | base64 --decode)/$filename db-backups/$filename
+
+else
+  echo "Latest backup already downloaded"
+fi
+
+

--- a/scripts/importDBFromBackup.sh
+++ b/scripts/importDBFromBackup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ue
+files=( db-backups/*.sql )
+drush sql-cli < ${files[0]}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/66Bk2qCz/1716-spike-improve-local-environment-setup

### Intent

Adds a `make sync` command for copying the latest db (from the s3 backups) and importing into the local db environment.

TODO: Add some documentation about this.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
