### PR TITLE
Set cache control headers for all files in s3.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -48,7 +48,7 @@ $settings['flysystem'] = [
 
       'options' => [
         'ACL' => 'private',
-        'CacheControl' => 'max-age=290304000, public',
+        'CacheControl' => 'max-age=7890000, public',
       ],
 
       // Directory prefix for all viewed files

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -48,6 +48,7 @@ $settings['flysystem'] = [
 
       'options' => [
         'ACL' => 'private',
+        'CacheControl' => 'max-age=290304000, public',
       ],
 
       // Directory prefix for all viewed files


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/4tKSi5ng/1713-spike-video-transcoding

### Intent

Adds CacheControl headers to s3 files.  After this has been merged, all uploaded files will get the
`CacheControl' => 'max-age=7890000, public',` header (i.e. cache for 3 months).

For existing files, we can update the metadata using the aws cli:
```
aws s3 cp s3://my-bucket/ s3://my-bucket/ --recursive --metadata-directive REPLACE \
--cache-control "max-age=7890000, public" --acl private
```
Note that this command updates all of the files in the bucket.  I ran this on the dev bucket and it too approx 2 hours.  However, there would have been no downtime, as all it is doing is updating files within S3.


### Considerations
Although we are setting the max-age to 3 months, we will currently only get a maximum of 24 hours.  This is due to the url signatures (which are set to expire every morning at 3am). 
The 3 month max-age will come into effect if and when we remove the s3 signatures https://trello.com/c/tPOfeYia/685-remove-s3-signatures-and-use-ip-allowlist-instead

_Could there be issues if a filename is re-used?  Meaning users seeing a stale version from the cache?_

It's possible, but highly unlikely.

In Drupal, files are given unique filenames if one already exists (otherwise the original filename is used).
Files are also placed into YEAR-MONTH directories.  So if you uploaded a file called "my-filename.mp4" in November 2022, it would get the full filename of "2022-11/my-filename.mp4"
When a file is removed, it's not actually deleted for at least another 6 hours (Drupal cleans up files in a cronjob, and sets a minimum threshold of 6 hours before removing them).
So in theory, a user could delete a file, wait 6+ hours, and then upload a new file with the same filename, in the same month.

This can either be fixed by adding ensuring all file urls are unique (e.g. adding a timestamp or uuid to the filename).
However, as we currently have a max 24 hour cache, (due to the url signatures) this isn't required for now.  I will write a note in the card to remove s3 signatures, that this should be done when we that is picked up.


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
