### PR TITLE
Reduce max-age to 24 hours.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -48,7 +48,7 @@ $settings['flysystem'] = [
 
       'options' => [
         'ACL' => 'private',
-        'CacheControl' => 'max-age=7890000, public',
+        'CacheControl' => 'max-age=86400, public',
       ],
 
       // Directory prefix for all viewed files


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

See previous PR https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/478

We are reducing the max-age to 24 hours, as it is not necessary to store cache's any longer than this, due to our s3 url signatures.

### Intent

> What changes are introduced by this PR that correspond to the above card?

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
