### PR TITLE
Add additional cache rebuild before maintenance mode is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ run-tests:
 	vendor/bin/phpunit --testsuite=existing-site --log-junit ~/phpunit/junit-existing-site.xml --verbose
 
 deploy:
+	drush cache:rebuild
 	echo "Enabling maintenance and readonly mode"
 	drush state-set readonlymode_active 1
 	drush state-set system.maintenance_mode 1


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Fix issue deploying https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/495

### Intent

An additional cache rebuild is required, to pick up new module locations.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
