### PR TITLE
🔧 disable alt-text on thumbnail images for all content types and taxonomy vocabularies with a thumbnail.

### DIFF
--- a/config/sync/field.field.node.link.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.link.field_moj_thumbnail_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.node.moj_pdf_item.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_moj_thumbnail_image.yml
@@ -27,7 +27,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.node.moj_radio_item.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_moj_thumbnail_image.yml
@@ -27,7 +27,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.node.moj_video_item.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.moj_video_item.field_moj_thumbnail_image.yml
@@ -27,7 +27,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.node.page.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.node.page.field_moj_thumbnail_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.moj_categories.field_moj_thumbnail_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.taxonomy_term.series.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.series.field_moj_thumbnail_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/config/sync/field.field.taxonomy_term.topics.field_moj_thumbnail_image.yml
+++ b/config/sync/field.field.taxonomy_term.topics.field_moj_thumbnail_image.yml
@@ -25,7 +25,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: true
+  alt_field: false
   alt_field_required: true
   title_field: false
   title_field_required: false


### PR DESCRIPTION
…
### Context

> Does this issue have a Trello card?
https://trello.com/c/Sb2D4Zgh/950-remove-alt-text-from-thumbnail-field-for-all-content-types-and-taxonomies

> If this is an issue, do we have steps to reproduce?
Create any content type or taxonomy that has a thumbnail image field. Upload an image. Before this change, after uploading an image, an edit control would appear for mandatory alt text. The content would not be saveable without alt text.

With this change, the alt text edit box is not presented, and the content can still be saved without filling it in.

### Intent

> What changes are introduced by this PR that correspond to the above card?
This removes the prompt to add mandatory alt-text when uploading an image.

> Would this PR benefit from screenshots?
No

### Considerations

> Is there any additional information that would help when reviewing this PR?
No

> Are there any steps required when merging/deploying this PR?
No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
