### PR TITLE
Feature/linkit suggestions for front end urls

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3582,29 +3582,30 @@
         },
         {
             "name": "drupal/linkit",
-            "version": "6.0.0-beta3",
+            "version": "6.0.0-beta4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/linkit.git",
-                "reference": "6.0.0-beta3"
+                "reference": "6.0.0-beta4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta3.zip",
-                "reference": "6.0.0-beta3",
-                "shasum": "39a5bf54cbc88324d788a573df7b3fecf7622065"
+                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta4.zip",
+                "reference": "6.0.0-beta4",
+                "shasum": "94274f0af2315ca91d9be8fc4e5103c9566860f0"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9"
+                "drupal/core": "^9.4 || ^10"
             },
             "require-dev": {
+                "drupal/ckeditor": "*",
                 "drupal/imce": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.0.0-beta3",
-                    "datestamp": "1632946984",
+                    "version": "6.0.0-beta4",
+                    "datestamp": "1678030708",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -3625,6 +3626,10 @@
                 {
                     "name": "johnwebdev",
                     "homepage": "https://www.drupal.org/user/3331569"
+                },
+                {
+                    "name": "mark_fullmer",
+                    "homepage": "https://www.drupal.org/user/2612816"
                 }
             ],
             "description": "Linkit - Enriched linking experience",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -71,6 +71,7 @@ module:
   prisoner_hub_content_suggestions: 0
   prisoner_hub_edit_only: 0
   prisoner_hub_explore: 0
+  prisoner_hub_linkit_matcher: 0
   prisoner_hub_primary_nav: 0
   prisoner_hub_prison_access: 0
   prisoner_hub_prison_access_cms: 0

--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - node
+    - prisoner_hub_linkit_matcher
     - taxonomy
 _core:
   default_config_hash: Tt8DtxZ3Nooo0PoWPpJvszA3R_5d8MmpUW7LM_R-BzY
@@ -26,7 +27,7 @@ matchers:
       substitution_type: canonical
       limit: 100
       include_unpublished: false
-    weight: 0
+    weight: -9
   83f16b85-c553-402e-8cdc-1d58265b0216:
     id: 'entity:taxonomy_term'
     uuid: 83f16b85-c553-402e-8cdc-1d58265b0216
@@ -39,4 +40,9 @@ matchers:
       group_by_bundle: false
       substitution_type: canonical
       limit: 100
-    weight: 0
+    weight: -8
+  91b234df-d6ee-44b9-b73b-6c6ee2f6b200:
+    id: 'prisoner_hub:front_end'
+    uuid: 91b234df-d6ee-44b9-b73b-6c6ee2f6b200
+    settings: {  }
+    weight: -10

--- a/docroot/modules/custom/prisoner_hub_linkit_matcher/prisoner_hub_linkit_matcher.info.yml
+++ b/docroot/modules/custom/prisoner_hub_linkit_matcher/prisoner_hub_linkit_matcher.info.yml
@@ -1,0 +1,7 @@
+name: Prisoner Hub Linkit Matcher
+type: module
+description: Provides a custom Linkit Matcher for the content hub.
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - linkit:linkit

--- a/docroot/modules/custom/prisoner_hub_linkit_matcher/src/Plugin/Linkit/Matcher/FrontEndMatcher.php
+++ b/docroot/modules/custom/prisoner_hub_linkit_matcher/src/Plugin/Linkit/Matcher/FrontEndMatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\prisoner_hub_linkit_matcher\Plugin\Linkit\Matcher;
+
+use Drupal\linkit\MatcherBase;
+use Drupal\linkit\MatcherInterface;
+use Drupal\linkit\Suggestion\DescriptionSuggestion;
+use Drupal\linkit\Suggestion\SuggestionCollection;
+
+/**
+ * Matcher for front end urls.
+ *
+ * @Matcher(
+ *   id = "prisoner_hub:front_end",
+ *   label = @Translation("Profile links")
+ * )
+ */
+class FrontEndMatcher extends MatcherBase implements MatcherInterface {
+
+  /**
+   * Gets all suggestions potentially relevant to this matcher.
+   *
+   * @return \Drupal\linkit\Suggestion\SuggestionCollection
+   *   Collection of all suggestions against which this matcher could match.
+   */
+  protected function searchSuggestions(): SuggestionCollection {
+    $suggestionCollection = new SuggestionCollection();
+
+    $suggestion = new DescriptionSuggestion();
+    $suggestion->setLabel($this->t('Profile'));
+    $suggestion->setPath('/profile');
+    $suggestion->setDescription('Prisoner profile');
+    $suggestion->setGroup('Profile links');
+    $suggestionCollection->addSuggestion($suggestion);
+
+    $suggestion = new DescriptionSuggestion();
+    $suggestion->setLabel($this->t('Timetable'));
+    $suggestion->setPath('/timetable');
+    $suggestion->setDescription('Prisoner timetable');
+    $suggestion->setGroup('Profile links');
+    $suggestionCollection->addSuggestion($suggestion);
+
+    $suggestion = new DescriptionSuggestion();
+    $suggestion->setLabel($this->t('Transactions'));
+    $suggestion->setPath('/money/transactions');
+    $suggestion->setDescription('Prisoner transactions within profile');
+    $suggestion->setGroup('Profile links');
+    $suggestionCollection->addSuggestion($suggestion);
+
+    $suggestion = new DescriptionSuggestion();
+    $suggestion->setLabel($this->t('Approved Visitors'));
+    $suggestion->setPath('/approved-visitors');
+    $suggestion->setDescription('Prisoner approved visitors within profile');
+    $suggestion->setGroup('Profile links');
+    $suggestionCollection->addSuggestion($suggestion);
+
+    return $suggestionCollection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($string): SuggestionCollection {
+    // Get all possible suggestions.
+    $suggestions = $this->searchSuggestions()->getSuggestions();
+    $matchedSuggestions = new SuggestionCollection();
+
+    // Add any suggestions whose label or path match the user input.
+    foreach ($suggestions as $suggestion) {
+      if (str_contains(strtoupper($suggestion->getLabel()), strtoupper($string))
+        || str_contains(strtoupper($suggestion->getPath()), strtoupper($string))) {
+        $matchedSuggestions->addSuggestion($suggestion);
+      }
+    }
+
+    return $matchedSuggestions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSummary(): array {
+    return [$this->t('Matches known prisoner profile links')];
+  }
+
+}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/8M9EFLQK/2083-add-non-drupal-suggestions-to-linkit

> If this is an issue, do we have steps to reproduce?

- Start creating a basic page. 
- Add a link into the main body content
- Start typing a link for a front end URL that doesn't exist within Drupal, for example /profile

Before this change the UI would not acknowledge this as a valid link. This could confuse users.

### Intent

> What changes are introduced by this PR that correspond to the above card?

A new custom module is added, that contains a custom Linkit matcher plugin to match against the following paths
- /profile
- /timetable
- /money/transactions
- /approved-visitors

A partial case insensitive match against any of these paths or their descriptions will trigger a linkit suggestion in a new group 'Profile links'. This group is positioned above the suggestions from Drupal's own content, to make sure it doesn't get buried.

The new module is enabled in config, and the new plugin added to the default linkit configuration.

This change also updates the version of the linkit module we are using. This isn't strictly necessary for this change, but we do need to update this module for Drupal 10 compatibility, and this is a convenient time to do so.


> Would this PR benefit from screenshots?

Yes! Here are some.

Before this change

<img width="727" alt="image" src="https://user-images.githubusercontent.com/440637/227283311-11368f14-9bf5-4eb9-827b-5b6e92b23c7d.png">


After the change

<img width="772" alt="image" src="https://user-images.githubusercontent.com/440637/227282872-af5cf413-8586-4f78-a64b-d40f4facf46c.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
