### PR TITLE
Update jsonapi image styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ info.php
 import
 db_dump/
 .idea/**
-.idea
 *.swp
 .vscode/**
 docroot/sites/default/settings.local.php
@@ -37,6 +36,12 @@ docroot/.eslintrc.json
 docroot/.ht.router.php
 docroot/.htaccess
 docroot/INSTALL.txt
+aws
+awscliv2.zip
+.phpunit.result.cache
+db-backups
+docroot/libraries
+docroot/sites/simpletest
 
 # Ignore override docker-compose files.
 # Even those these are in git, we want to allow local changes to them without being pushed up to git.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "drupal/image_style_warmer": "^1.1",
         "drupal/jsonapi_cross_bundles": "^1.0",
         "drupal/jsonapi_filter_cache_tags": "^1.0@beta",
-        "drupal/jsonapi_image_styles": "^2.0@beta",
+        "drupal/jsonapi_image_styles": "^3.0",
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/jsonapi_page_limit": "^1.0.0-beta2",
         "drupal/jsonapi_search_api": "^1.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aa6e46dde14cf339f71b0e2879d21f7",
+    "content-hash": "c800677c9ae84d1fcb37a50b53ef67c8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3294,29 +3294,30 @@
         },
         {
             "name": "drupal/jsonapi_image_styles",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/jsonapi_image_styles.git",
-                "reference": "2.0.1"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi_image_styles-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "fb723e06236fb84299020ce23fb77ca92fac0bea"
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_image_styles-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "9747a66d4da23d07e33768e77a07e86b1916f425"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^9 || ^10"
             },
             "require-dev": {
-                "drupal/coder": "^8.3"
+                "drupal/coder": "^8.3",
+                "phpcompatibility/php-compatibility": "10.x-dev"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1632412799",
+                    "version": "3.0.0",
+                    "datestamp": "1646861925",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -18192,7 +18193,6 @@
         "drupal/entity_clone": 10,
         "drupal/form_state_empty": 15,
         "drupal/jsonapi_filter_cache_tags": 10,
-        "drupal/jsonapi_image_styles": 10,
         "drupal/jsonapi_search_api": 5,
         "drupal/maintenance_exempt": 20,
         "drupal/pathologic": 15,


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/PjmirJ6p/2107-update-jsonapi-image-styles-module

> If this is an issue, do we have steps to reproduce?

View any page containing images.

### Intent

> What changes are introduced by this PR that correspond to the above card?

This PR updates the version constraint for the JSON:API Image Style modules from the 2.x to 3.x branch. It also updates the installed version of the module to 3.0.0. 

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

Yes. This must be deployed in conjunction with https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/635

### Checklist

- [X] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [X] Tested in Development
