### PR TITLE
🗃️  move db_refresh cron job to run at 0630 rather than 0430.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/db-refresh.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/db-refresh.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
-  schedule: "30 4 * * *"
+  schedule: "30 6 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/bzfsOjsr/2124-fix-dev-cms-database-refresh

> If this is an issue, do we have steps to reproduce?

Go to sleep. The next day, the prod database will not have refreshed to the development environment.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Changes the time the db_refresh cron runs to 0630, when the development database is actually running again after new nightly shut down.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
