### PR TITLE
Remove h5 h6 from rich text editor

### DIFF
--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -33,8 +33,6 @@ settings:
         - heading2
         - heading3
         - heading4
-        - heading5
-        - heading6
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<cite>'
@@ -49,8 +47,6 @@ settings:
         - '<h2 id>'
         - '<h3 id>'
         - '<h4 id>'
-        - '<h5 id>'
-        - '<h6 id>'
         - '<a hreflang title>'
     ckeditor5_list:
       reversed: false

--- a/config/sync/editor.editor.full_html.yml
+++ b/config/sync/editor.editor.full_html.yml
@@ -38,8 +38,6 @@ settings:
         - heading2
         - heading3
         - heading4
-        - heading5
-        - heading6
     ckeditor5_sourceEditing:
       allowed_tags: {  }
     ckeditor5_list:

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -18,7 +18,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <span> <panel> <blockquote cite> <ul type> <ol type start> <a hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <strong> <em> <code> <li> <img src alt height width data-entity-uuid data-entity-type data-caption data-align>'
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <cite> <dl> <dt> <dd> <span> <panel> <blockquote cite> <ul type> <ol type start> <a hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <strong> <em> <code> <li> <img src alt height width data-entity-uuid data-entity-type data-caption data-align>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:

--- a/config/sync/filter.format.restricted_html.yml
+++ b/config/sync/filter.format.restricted_html.yml
@@ -14,7 +14,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id>'
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/oAlFYW7K/2117-dont-expose-options-in-the-rich-text-editor-that-have-no-effect-in-the-front-end

> If this is an issue, do we have steps to reproduce?

Create content using the Restricted HTML format that contains h5 and h6 elements.

### Intent

> What changes are introduced by this PR that correspond to the above card?

H5 and H6 elements also removed from Restricted HTML text format.

Note they were previously removed from Basic HTML and Full HTML formats to stop them being presented in CKEditor.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
