### PR TITLE
Sync new development s3 bucket from existing staging data 

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
+++ b/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ue
+
+mkdir ~/.aws/
+echo "[default]" > ~/.aws/credentials
+echo "aws_access_key_id=${S3_DESTINATION_KEY_TEMP}" >> ~/.aws/credentials
+echo "aws_secret_access_key=${S3_DESTINATION_SECRET_TEMP}" >> ~/.aws/credentials
+
+aws s3 sync  \
+  s3://"${S3_SOURCE_BUCKET_TEMP}" \
+  s3://"${S3_DESTINATION_BUCKET_TEMP}" \
+  --source-region "${S3_SOURCE_REGION_TEMP}" \
+  --region "${S3_DESTINATION_REGION_TEMP}" \

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -158,3 +158,31 @@ env:
   - name: S3_SOURCE_REGION
     value: {{ .Values.s3Sync.source_region }}
 {{- end -}}
+
+{{- define "s3-sync-temp.envs" }}
+env:
+  - name: S3_DESTINATION_KEY_TEMP
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.application.s3-2.secretName }}
+        key: access_key_id
+  - name: S3_DESTINATION_SECRET_TEMP
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.application.s3-2.secretName }}
+        key: secret_access_key
+  - name: S3_DESTINATION_REGION_TEMP
+    value: {{ .Values.application.s3-2.region }}
+  - name: S3_DESTINATION_BUCKET_TEMP
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.application.s3-2.secretName }}
+        key: bucket_name
+  - name: S3_SOURCE_BUCKET_TEMP
+    valueFrom:
+      secretKeyRef:
+        name: drupal-s3-output-temp
+        key: bucket_name
+  - name: S3_SOURCE_REGION_TEMP
+    value: {{ .Values.s3SyncTemp.source_region }}
+{{- end -}}

--- a/helm_deploy/prisoner-content-hub-backend/templates/s3-sync-temp.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/s3-sync-temp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.s3SyncTemp.enabled -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s3-sync-script-temp
+  labels:
+    {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
+data:
+  entrypoint.sh: |-
+{{ .Files.Get "s3-sync-temp.sh" | indent 4 }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "prisoner-content-hub-backend.fullname" . }}-s3-sync-temp-cronjob
+  labels:
+    {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      # Tidy up all jobs after 4 days
+      ttlSecondsAfterFinished: 345600
+      backoffLimit: 0
+      activeDeadlineSeconds: 2400
+      template:
+        spec:
+          containers:
+          - name: s3-sync-temp-cronjob
+            image: "ghcr.io/ministryofjustice/hmpps-mysql-tools:latest"
+            command:
+              - /bin/entrypoint.sh
+            volumeMounts:
+              - name: s3-sync-script
+                mountPath: /bin/entrypoint.sh
+                readOnly: true
+                subPath: entrypoint.sh
+{{ include "s3-sync-temp.envs" . | nindent 12 }}
+          restartPolicy: Never
+          volumes:
+            - name: s3-sync-script
+              configMap:
+                name: s3-sync-script
+                defaultMode: 0755
+  {{- end }}

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -15,8 +15,16 @@ dbRefresh:
   enabled: true
 s3Sync:
   enabled: true
+# Temporary switch for syncing new bucket from staging.
+s3SyncTemp:
+  enabled: true
 
-# Uncomment this section to switch development to use the new S3 bucket.
+# Uncomment this section to switch Drupal to use the new S3 bucket.
 #application:
 #  s3:
 #    secretName: drupal-s3-2
+
+# Temporary setting for passing new S3 bucket details to cron jobs.
+application:
+  s3-2:
+    secretName: drupal-s3-2

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -15,3 +15,7 @@ dbRefresh:
   enabled: true
 s3Sync:
   enabled: true
+
+application:
+  s3:
+    secretName: drupal-s3-2

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -16,6 +16,7 @@ dbRefresh:
 s3Sync:
   enabled: true
 
-application:
-  s3:
-    secretName: drupal-s3-2
+# Uncomment this section to switch development to use the new S3 bucket.
+#application:
+#  s3:
+#    secretName: drupal-s3-2

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -103,3 +103,7 @@ s3Sync:
   enabled: false
   source_region: eu-west-1
 
+# Temporary settings for syncing new buckets from staging.
+s3SyncTemp:
+  enabled: false
+  source_region: eu-west-1


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/LgNVXNpA/2113-spike-investigate-how-to-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

🔧  Add new s3-sync-temp.envs section to values.yaml to contain environment variables used by sync jobs to identify s3 bucket to sync to and from.

🔧  Enable syncing to the new bucket in development environment only. Default to off in all other environments.

🔧  Switch development environment Drupal instance to use original bucket so that that environment is usable for front end development.

🔨  New s3-sync-temp.sh script for syncing staging to new s3 buckets. This is a copy of the existing s3-sync.sh script used for overnight syncing of production s3 to other environments, but uses a different set of environment variables.

🔨  New s3-sync-temp.yaml file to define a new Kubernetes job for synchronising staging to new s3 buckets.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
