### PR TITLE
✉️  Integrate with GovUK Notify service to enable password resets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "drupal/flysystem": "^2.0",
         "drupal/flysystem_s3": "^2.0-rc5",
         "drupal/form_state_empty": "^1.0@alpha",
+        "drupal/govuk_notify": "^2.1",
         "drupal/health_check": "^3.0",
         "drupal/image_style_warmer": "^1.1",
         "drupal/jsonapi_cross_bundles": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,61 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2943c0ff6e7d18c07812f4de74ddd742",
+    "content-hash": "98949b123fce64dc190ae0f908ba22ef",
     "packages": [
+        {
+            "name": "alphagov/notifications-php-client",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alphagov/notifications-php-client.git",
+                "reference": "5bc25ece4261983bbb504fe065df2bfd38e86632"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alphagov/notifications-php-client/zipball/5bc25ece4261983bbb504fe065df2bfd38e86632",
+                "reference": "5bc25ece4261983bbb504fe065df2bfd38e86632",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^v6.1.0",
+                "guzzlehttp/psr7": "^1.2",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "php-http/guzzle6-adapter": "*",
+                "php-http/message": "^1.1",
+                "php-http/mock-client": "*",
+                "php-http/socket-client": "^2.1.0",
+                "phpspec/phpspec": "^5.0|^7.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Alphagov\\Notifications\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "GOV UK Notify",
+                    "email": "notify@digital-cabinet-office.gov.uk"
+                },
+                {
+                    "name": "Neil Smith",
+                    "email": "neil@nsmith.net"
+                }
+            ],
+            "description": "PHP client for GOV.UK Notifications",
+            "support": {
+                "issues": "https://github.com/alphagov/notifications-php-client/issues",
+                "source": "https://github.com/alphagov/notifications-php-client/tree/4.2.0"
+            },
+            "time": "2022-10-06T13:35:15+00:00"
+        },
         {
             "name": "asm89/stack-cors",
             "version": "1.3.0",
@@ -3093,6 +3146,56 @@
             }
         },
         {
+            "name": "drupal/govuk_notify",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/govuk_notify.git",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/govuk_notify-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "1fb88a66e0805956880739e8ad89a8804d9956dc"
+            },
+            "require": {
+                "alphagov/notifications-php-client": "*",
+                "drupal/core": "^8 || ^9",
+                "php-http/guzzle6-adapter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1582551058",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Andrew Larcombe (alarcombe)",
+                    "homepage": "https://www.drupal.org/u/alarcombe",
+                    "role": "Maintainer",
+                    "email": "andrew@andrewl.net"
+                }
+            ],
+            "description": "govuk_notify",
+            "homepage": "https://drupal.org/project/govuk_notify",
+            "support": {
+                "source": "https://cgit.drupalcode.org/govuk_notify",
+                "issues": "https://drupal.org/project/issues/govuk_notify",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/health_check",
             "version": "3.0.0",
             "source": {
@@ -6013,6 +6116,69 @@
             "time": "2022-09-18T07:06:19+00:00"
         },
         {
+            "name": "firebase/php-jwt",
+            "version": "v6.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1||^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^1.1",
+                "phpunit/phpunit": "^7.5||^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.4.0"
+            },
+            "time": "2023-02-09T21:01:23+00:00"
+        },
+        {
             "name": "grasmash/expander",
             "version": "2.0.3",
             "source": {
@@ -8514,6 +8680,73 @@
                 "source": "https://github.com/php-http/discovery/tree/1.14.3"
             },
             "time": "2022-07-11T14:04:40+00:00"
+        },
+        {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "9d1a45eb1c59f12574552e81fb295e9e53430a56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/9d1a45eb1c59f12574552e81fb295e9e53430a56",
+                "reference": "9d1a45eb1c59f12574552e81fb295e9e53430a56",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": "^7.1 || ^8.0",
+                "php-http/httplug": "^2.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0",
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^2.0 || ^3.0",
+                "phpunit/phpunit": "^7.4 || ^8.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/guzzle6-adapter/issues",
+                "source": "https://github.com/php-http/guzzle6-adapter/tree/v2.0.2"
+            },
+            "time": "2021-03-02T10:52:33+00:00"
         },
         {
             "name": "php-http/httplug",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   flysystem: 0
   flysystem_s3: 0
   form_state_empty: 0
+  govuk_notify: 0
   health_check: 0
   image: 0
   image_style_warmer: 0

--- a/config/sync/govuk_notify.settings.yml
+++ b/config/sync/govuk_notify.settings.yml
@@ -1,0 +1,6 @@
+notification_service: uk
+api_key: ''
+default_template_id: f6cf7d37-7a5c-4a26-a758-ef902bb7f7ab
+default_sms_template_id: ''
+force_temporary_failure: 0
+force_permanent_failure: 0

--- a/config/sync/system.mail.yml
+++ b/config/sync/system.mail.yml
@@ -1,4 +1,5 @@
 _core:
   default_config_hash: rYgt7uhPafP2ngaN_ZUPFuyI4KdE0zU868zLNSlzKoE
 interface:
-  default: php_mail
+  default: govuk_notify_mail
+  govuk_notify: govuk_notify_mail

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -3,7 +3,7 @@ _core:
 langcode: en
 uuid: a760ecec-2369-499e-9591-3fad01b7f592
 name: 'Digital Hub'
-mail: admin@example.com
+mail: thehub@digital.justice.gov.uk
 slogan: ''
 page:
   403: ''

--- a/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
+++ b/docroot/profiles/prisoner_content_hub_profile/prisoner_content_hub_profile.profile
@@ -10,7 +10,6 @@
  * don't belong to a particular module, and are global to the site.
  */
 
-use Drupal\dynamic_entity_reference\Plugin\Field\FieldType\DynamicEntityReferenceFieldItemList;
 use Drupal\dynamic_entity_reference\Plugin\Field\FieldWidget\DynamicEntityReferenceWidget;
 use Drupal\taxonomy\Entity\Vocabulary;
 
@@ -24,17 +23,6 @@ function prisoner_content_hub_profile_toolbar_alter(&$items) {
   // prison that the user is associated with (if we were to start assigning
   // users to prisons).
   unset($items['home']);
-}
-
-
-/**
- * Implements hook_mail_alter().
- *
- * Disable all email messages from being sent, as they just result in an error
- * in the logs.
- */
-function prisoner_content_hub_profile_mail_alter(&$message) {
-  $message['send'] = FALSE;
 }
 
 /**

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -161,6 +161,9 @@ if (!InstallerKernel::installationAttempted() && extension_loaded('redis')) {
 
 }
 
+// Set API key for govuk_notify for sending emails.
+$config['govuk_notify.settings']['api_key'] = getenv('GOVUK_NOTIFY_API_KEY', TRUE);
+
 $settings['config_sync_directory'] = '../config/sync';
 
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -87,6 +87,11 @@ env:
         key: auth_token
   - name: REDIS_TLS_ENABLED
     value: "true"
+  - name:GOVUK_NOTIFY_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: govuknotify
+        key: access_key
 
 {{- end -}}
 

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -34,6 +34,7 @@ application:
     cname: ''
     cnameIsBucket: true
   redisSecretName: drupal-redis
+  govUkSecretName: govuknotify
 
 volumes:
   - name: apache-cache


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/usArwmtf/2132-allow-drupal-users-to-reset-their-passwords

> If this is an issue, do we have steps to reproduce?

* Go to the login page
* Click link to reset your password
* Enter your email address and submit the form
* Password reset email is never received

### Intent

> What changes are introduced by this PR that correspond to the above card?

* Adds the existing govuk_notify Drupal module
* Enables that module and sets up configuration to use
* Passes API keys securely through environment using k8s secrets implemented before this PR was raised
* Removes some custom code that explicitly prevented emails from being sent
* Sets the site's email address to match that configured with GovUK Notify

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

k8s secret not yet created for prod - this will need to happen before this is deployed to production. 

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
