### PR TITLE
🔧  use a real email address for update notifications. Only notify for security updates.

### DIFF
--- a/config/sync/update.settings.yml
+++ b/config/sync/update.settings.yml
@@ -9,5 +9,5 @@ fetch:
   timeout: 30
 notification:
   emails:
-    - admin@example.com
-  threshold: all
+    - elliot.ward@digital.justice.gov.uk
+  threshold: security


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/grIV143g/2134-configure-module-update-notification-email-address

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

The configuration for the update manager module is changed to 
* only send emails for security updates, rather than all available updates
* send such updates to a real email address rather than admin@example.com

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
