### PR TITLE
🔧  switch temp sync region to be Ireland, so we can sync new dev bucket from old prod. 

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -18,6 +18,7 @@ s3Sync:
 # Temporary switch for syncing new bucket from staging.
 s3SyncTemp:
   enabled: true
+  source_region: eu-west-1
 
 application:
   s3:


### PR DESCRIPTION
This will keep the new dev bucket in sync with changes made by content editors until we switch to the new bucket.

### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

There is a temporary sync cron job that was used to sync the new dev bucket from the existing staging bucket. Now this sync is complete, we want to stay up to date with any further changes made by content editors, which are still using the original Irish S3 prod bucket. This PR changes the region from which we run the temporary sync to Ireland.

> Would this PR benefit from screenshots?

No.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

Yes - the k8s secret drupal-s3-output-temp needs to be updated to point to the original prod s3 bucket at the same time. It currently points at the original staging bucket.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
