### PR TITLE
Update s3 temp sync region in prod

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
+++ b/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
@@ -11,3 +11,5 @@ aws s3 sync  \
   s3://"${S3_DESTINATION_BUCKET_TEMP}" \
   --source-region "${S3_SOURCE_REGION_TEMP}" \
   --region "${S3_DESTINATION_REGION_TEMP}" \
+
+sleep 600;

--- a/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
+++ b/helm_deploy/prisoner-content-hub-backend/s3-sync-temp.sh
@@ -11,5 +11,3 @@ aws s3 sync  \
   s3://"${S3_DESTINATION_BUCKET_TEMP}" \
   --source-region "${S3_SOURCE_REGION_TEMP}" \
   --region "${S3_DESTINATION_REGION_TEMP}" \
-
-sleep 600;

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -27,6 +27,7 @@ dbRefresh:
   enabled: false
 s3Sync:
   enabled: false
-# Temporary switch for syncing new bucket from staging.
+# Temporary switch for syncing new bucket from old production.
 s3SyncTemp:
   enabled: true
+  source_region: eu-west-1


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

There is a temporary sync job. This previously sync'd the new prod s3 bucket in London with the staging bucket, to get the majority of the contents from the same region. Now that has been completed, we now want to sync the new prod bucket from the old one which is still use by the prod application. Then when we want to cut over to the new prod bucket it will already be up to date.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

Yes - the drupal-s3-output-temp secret in the prod namespace will need updating to reflect the old prod bucket.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
