### PR TITLE
🔧  turn off temporary synchronisation of old prod to new dev s3 buckets every 15 minutes.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -15,15 +15,6 @@ dbRefresh:
   enabled: true
 s3Sync:
   enabled: true
-# Temporary switch for syncing new bucket from staging.
-s3SyncTemp:
-  enabled: true
-  source_region: eu-west-1
-
 application:
   s3:
     secretName: drupal-s3-2
-  # Temporary setting for passing new S3 bucket details to cron jobs.
-  s3temp:
-    secretName: drupal-s3-2
-    region: eu-west-2


### PR DESCRIPTION
 This can now return to just updating every night. 

### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

We introduced a new job for sync'ing dev s3 first from staging, then from the old prod bucket, so that the bulk of the content didn't have to be copied across regions. This has now been proven, has been replicated on prod, and is hence no longer required in dev.

This PR removes this temporary sync'ing mechanism on dev.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

The drupal-s3-output-temp k8s secret can be deleted in dev namespace after this has been deployed to dev.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
