### PR TITLE
Switch from using drupal-s3-output-temp to drupal-s3-output to point temporary sync.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -186,7 +186,7 @@ env:
   - name: S3_SOURCE_BUCKET_TEMP
     valueFrom:
       secretKeyRef:
-        name: drupal-s3-output-temp
+        name: drupal-s3-output
         key: bucket_name
   - name: S3_SOURCE_REGION_TEMP
     value: {{ .Values.s3SyncTemp.source_region }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

We were previously editing drupal-s3-output-temp to point to the same location as drupal-s3-output when we wanted to change the sync source from staging to old prod. However this secret was overwritten by subsequent terraform applications. 

Since https://github.com/ministryofjustice/cloud-platform-environments/pull/13199, drupal-s3-output is now available in prod, so we can just change the  envs to use that instead.

> Would this PR benefit from screenshots?

No.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

Verify https://github.com/ministryofjustice/cloud-platform-environments/pull/13199 has applied cleanly before deploying this to production.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
