### PR TITLE
🔧 Add audio description to search index

### DIFF
--- a/config/sync/search_api.index.content_for_search.yml
+++ b/config/sync/search_api.index.content_for_search.yml
@@ -3,18 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_moj_top_level_categories
+    - field.storage.node.field_description
     - field.storage.node.field_exclude_from_prison
+    - field.storage.node.field_prisons
     - field.storage.node.field_moj_series
     - field.storage.node.field_moj_stand_first
-    - field.storage.node.field_prisons
     - field.storage.node.field_summary
-    - field.storage.node.field_moj_top_level_categories
     - search_api.server.elasticsearch
   module:
     - elasticsearch_connector
     - taxonomy
-    - taxonomy_machine_name
     - node
+    - taxonomy_machine_name
     - search_api
 third_party_settings:
   elasticsearch_connector:
@@ -28,6 +29,14 @@ name: 'Content for search'
 description: ''
 read_only: false
 field_settings:
+  field_description:
+    label: Description
+    datasource_id: 'entity:node'
+    property_path: field_description
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_description
   field_exclude_from_prison:
     label: 'Exclude from prison » Taxonomy term » Term ID'
     datasource_id: 'entity:node'
@@ -150,6 +159,7 @@ processor_settings:
       preprocess_query: -48
     all_fields: true
     fields:
+      - field_description
       - field_exclude_from_prison_name
       - field_moj_series
       - field_moj_stand_first
@@ -166,6 +176,7 @@ processor_settings:
       preprocess_query: -42
     all_fields: true
     fields:
+      - field_description
       - field_moj_series
       - field_moj_stand_first
       - field_summary

--- a/config/sync/search_api.index.content_for_search.yml
+++ b/config/sync/search_api.index.content_for_search.yml
@@ -5,8 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_moj_top_level_categories
     - field.storage.node.field_description
-    - field.storage.node.field_exclude_from_prison
-    - field.storage.node.field_prisons
     - field.storage.node.field_moj_series
     - field.storage.node.field_moj_stand_first
     - field.storage.node.field_summary
@@ -15,7 +13,6 @@ dependencies:
     - elasticsearch_connector
     - taxonomy
     - node
-    - taxonomy_machine_name
     - search_api
 third_party_settings:
   elasticsearch_connector:
@@ -37,27 +34,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_description
-  field_exclude_from_prison:
-    label: 'Exclude from prison » Taxonomy term » Term ID'
-    datasource_id: 'entity:node'
-    property_path: 'field_exclude_from_prison:entity:tid'
-    type: integer
-    dependencies:
-      config:
-        - field.storage.node.field_exclude_from_prison
-      module:
-        - taxonomy
-  field_exclude_from_prison_name:
-    label: 'Exclude from prison » Taxonomy term » Machine name'
-    datasource_id: 'entity:node'
-    property_path: 'field_exclude_from_prison:entity:machine_name'
-    type: string
-    dependencies:
-      config:
-        - field.storage.node.field_exclude_from_prison
-      module:
-        - taxonomy
-        - taxonomy_machine_name
   field_moj_series:
     label: 'Series » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -78,27 +54,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_moj_stand_first
-  field_prisons:
-    label: 'Prisons » Taxonomy term » Term ID'
-    datasource_id: 'entity:node'
-    property_path: 'field_prisons:entity:tid'
-    type: integer
-    dependencies:
-      config:
-        - field.storage.node.field_prisons
-      module:
-        - taxonomy
-  field_prisons_name:
-    label: 'Prisons » Taxonomy term » Machine name'
-    datasource_id: 'entity:node'
-    property_path: 'field_prisons:entity:machine_name'
-    type: string
-    dependencies:
-      config:
-        - field.storage.node.field_prisons
-      module:
-        - taxonomy
-        - taxonomy_machine_name
   field_summary:
     label: Summary
     datasource_id: 'entity:node'
@@ -160,10 +115,8 @@ processor_settings:
     all_fields: true
     fields:
       - field_description
-      - field_exclude_from_prison_name
       - field_moj_series
       - field_moj_stand_first
-      - field_prisons_name
       - field_summary
       - name
       - title


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/WomQXMef/2041-search-via-front-end-does-not-appear-to-be-looking-at-the-description-field

> If this is an issue, do we have steps to reproduce?

- Create a piece of audio content.
- Add a distinctive word to its description field.
- Search via the front end for the distinctive word.
- The piece of audio content will not be found. 

### Intent

> What changes are introduced by this PR that correspond to the above card?

This change adds the description to the search index held in Elastic so that the steps outlined above will result in the description being searchable.

This change also removes some fields from the search index that add no value.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No, but note the content will be automatically reindexed in the background using the new configuration.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
