### PR TITLE
🗃️  start using the new s3 bucket in prod, and stop syncing old bucket to the new one.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -12,10 +12,8 @@ ingress:
       - host: jsonapi-cms-prisoner-content-hub-production.apps.live.cloud-platform.service.justice.gov.uk
 
 application:
-  # The S3 bucket for production exists in Ireland,
-  # but the default is London
   s3:
-    region: eu-west-1
+    secretName: drupal-s3-2
   # Temporary setting for passing new S3 bucket details to cron jobs.
   s3temp:
     secretName: drupal-s3-2
@@ -29,5 +27,5 @@ s3Sync:
   enabled: false
 # Temporary switch for syncing new bucket from old production.
 s3SyncTemp:
-  enabled: true
+  enabled: false
   source_region: eu-west-1


### PR DESCRIPTION

### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

This bucket switches the s3 bucket used by the production system from the old one to the new one.
This also disables the regular job that sync'd the contents of the old bucket to the new.

> Would this PR benefit from screenshots?

No.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

See deployment plan: https://docs.google.com/document/d/1NaLltCEmFHE0w748F3--UwgGCx306Wkuy1YtM98Wy8o/edit#

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
