### PR TITLE
Use new s3 bucket for dev staging overnight sync

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -158,7 +158,7 @@ env:
   - name: S3_SOURCE_BUCKET
     valueFrom:
       secretKeyRef:
-        name: drupal-s3-output
+        name: drupal-s3-output-new
         key: bucket_name
   - name: S3_SOURCE_REGION
     value: {{ .Values.s3Sync.source_region }}

--- a/helm_deploy/prisoner-content-hub-backend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.production.yaml
@@ -12,10 +12,8 @@ ingress:
       - host: jsonapi-cms-prisoner-content-hub-production.apps.live.cloud-platform.service.justice.gov.uk
 
 application:
-  # The S3 bucket for production exists in Ireland,
-  # but the default is London
   s3:
-    region: eu-west-1
+    secretName: drupal-s3-2
   # Temporary setting for passing new S3 bucket details to cron jobs.
   s3temp:
     secretName: drupal-s3-2
@@ -29,5 +27,5 @@ s3Sync:
   enabled: false
 # Temporary switch for syncing new bucket from old production.
 s3SyncTemp:
-  enabled: true
+  enabled: false
   source_region: eu-west-1

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -102,7 +102,7 @@ dbRefresh:
 
 s3Sync:
   enabled: false
-  source_region: eu-west-1
+  source_region: eu-west-2
 
 # Temporary settings for syncing new buckets from staging.
 s3SyncTemp:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/IaJKTzZH/2128-move-prod-s3-bucket-from-ireland-to-london

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

This PR changes the source bucket for the overnight sync from prod to dev and staging, to use the new prod bucket in eu-west-2.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

This PR should not be deployed until after https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/534 has been deployed to prod and use of the new bucket in prod tested.

See deployment plan: https://docs.google.com/document/d/1NaLltCEmFHE0w748F3--UwgGCx306Wkuy1YtM98Wy8o/edit#



### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
