### PR TITLE
Update String Field Formatter module for Drupal 10 compatibility.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4910,26 +4910,26 @@
         },
         {
             "name": "drupal/string_field_formatter",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/string_field_formatter.git",
-                "reference": "2.0.0"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/string_field_formatter-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "deac34befbe9bc13977223da31058cbc66251a81"
+                "url": "https://ftp.drupal.org/files/projects/string_field_formatter-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "22055a38ffaa0de12802be186bf348c1aeb1a52f"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8 || ^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1604697749",
+                    "version": "2.0.2",
+                    "datestamp": "1687527067",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/vO5BiuwU/43-string-field-formatter

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Updates String Field Formatter from 2.0.0 to 2.0.2 for Drupal 10 compatibility.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
