### PR TITLE
⬆️  update taxonomy_machine_name to 2.0.0 for Drupal 10 compatibility…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/search_api": "^1.17",
         "drupal/select2": "^1.13",
         "drupal/string_field_formatter": "^2.0",
-        "drupal/taxonomy_machine_name": "1.x-dev",
+        "drupal/taxonomy_machine_name": "^2.0",
         "drupal/term_reference_tree": "^1.1",
         "drupal/token": "^1.5",
         "drupal/upgrade_status": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e75a5bd2d259c652c99c4bcb88b2b993",
-    "content-hash": "92cbc9d099a67d6492c1656f9defe145",
+    "content-hash": "7177e41f134c7dd48be4e0c791993345",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -5036,29 +5035,32 @@
         },
         {
             "name": "drupal/taxonomy_machine_name",
-            "version": "dev-1.x",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/taxonomy_machine_name.git",
-                "reference": "0df34b70df1a303da3406bcbcb505e5398f8e79b"
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/taxonomy_machine_name-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "c12912804d5c00032cf33df20a14b014efda1aa4"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^9.4 || ^10"
             },
             "require-dev": {
                 "drupal/search_api": "*"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.0-beta6+6-dev",
-                    "datestamp": "1650813805",
+                    "version": "2.0.0",
+                    "datestamp": "1688572816",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -5078,8 +5080,8 @@
                     "role": "Co-Maintainer"
                 },
                 {
-                    "name": "sdstyles",
-                    "homepage": "https://www.drupal.org/user/1420228"
+                    "name": "Sebastien M.",
+                    "homepage": "https://www.drupal.org/user/380104"
                 }
             ],
             "description": "This module create a new property named machine_name.",
@@ -18772,7 +18774,6 @@
         "drupal/jsonapi_search_api": 5,
         "drupal/publication_date": 10,
         "drupal/readonlymode": 20,
-        "drupal/taxonomy_machine_name": 20,
         "drupal/views_entity_form_field": 10,
         "drupal/views_tree": 15
     },


### PR DESCRIPTION
…. This also moves us to a stable and secured release.

### Context

> Does this issue have a Trello card?

https://trello.com/c/nN4o2rNB/44-taxonomy-machine-name

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Updates taxonomy_machine_name from a specific named commit on a dev branch to full release 2.0.0.

> Would this PR benefit from screenshots?

Yes. Here is a screenshot that shows a side effect of this update; 

<img width="1651" alt="Pasted Graphic 1" src="https://github.com/ministryofjustice/prisoner-content-hub-backend/assets/440637/ec1808d3-07f3-49d3-975d-f3b657a79055">

The machine name column highlighted in red in this taxonomy overview screen will be removed from non-admin users.

This is beneficial - these machine names have no use for non-admin users, and the target of their links is duplicated on the full names in the column to the left. If this wasn't an improvement, it could be circumvented by granting the `'view machine name overview page'` permission to the relevant roles.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [X] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
