### PR TITLE
Cloudfront Proof of Concept

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -44,15 +44,6 @@ $settings['flysystem'] = [
       'region' => getenv('FLYSYSTEM_S3_REGION', true),
       'bucket' => getenv('FLYSYSTEM_S3_BUCKET', true),
 
-      // Optional configuration settings.
-
-      'options' => [
-        'ACL' => 'private',
-        // Set max-age to be 24 hours.  This takes into account the url
-        // signatures (which have a max expiration of 24 hours).
-        'CacheControl' => 'max-age=86400, public',
-      ],
-
       // Directory prefix for all viewed files
       // 'prefix' => 'an/optional/prefix',
 

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -46,7 +46,7 @@ env:
         name: {{ .Values.application.s3.secretName }}
         key: cloudfront_url
   - name: FLYSYSTEM_S3_CNAME_IS_BUCKET
-    value: {{ true | quote }}
+    value: {{ .Values.application.s3.cnameIsBucket | quote }}
   - name: HASH_SALT
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -41,7 +41,10 @@ env:
         name: {{ .Values.application.s3.secretName }}
         key: bucket_name
   - name: FLYSYSTEM_S3_CNAME
-    value: {{ .Values.application.s3.cname }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.application.s3.secretName }}
+        key: cloudfront_url
   - name: FLYSYSTEM_S3_CNAME_IS_BUCKET
     value: {{ .Values.application.s3.cnameIsBucket | quote }}
   - name: HASH_SALT

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -46,7 +46,7 @@ env:
         name: {{ .Values.application.s3.secretName }}
         key: cloudfront_url
   - name: FLYSYSTEM_S3_CNAME_IS_BUCKET
-    value: {{ false | quote }}
+    value: {{ true | quote }}
   - name: HASH_SALT
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -46,7 +46,7 @@ env:
         name: {{ .Values.application.s3.secretName }}
         key: cloudfront_url
   - name: FLYSYSTEM_S3_CNAME_IS_BUCKET
-    value: {{ .Values.application.s3.cnameIsBucket | quote }}
+    value: {{ false | quote }}
   - name: HASH_SALT
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -14,8 +14,8 @@ ingress:
 dbRefresh:
   enabled: true
 s3Sync:
-  enabled: true
+  enabled: false
 application:
   s3:
-    secretName: drupal-s3-2
+    secretName: drupal-s3-cf
   analyticsSiteId: G-0RBPFCWD3X


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Od3P3oiw/869-use-cloudfront-with-s3

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?

* swaps the s3 bucket used in dev from drupal-s3-2 to drupal-s3-cf, and turns overnight syncing from prod off. This allows us to test Cloudfront in dev before allow-listing rules are in place without exposing S3 content from the prod environment. 
* removes the private setting and cache control from the s3 configuration; this is no longer required now we don't use short lived signatures to control access to s3 files.

These changes in tandem with https://github.com/ministryofjustice/cloud-platform-environments/pull/15137 and https://github.com/ministryofjustice/cloud-platform-environments/pull/15152 allow this branch to be deployed to dev where Drupal will then upload content to the new bucket and reference all S3 content either rendered in Drupal's UI or exported to the front end via JSON:API via its Cloudfront address.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

Don't merge this PR.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
