### PR TITLE
LNP-272: move from elasticsearch to opensearch

### DIFF
--- a/config/sync/elasticsearch_connector.cluster.opensearch.yml
+++ b/config/sync/elasticsearch_connector.cluster.opensearch.yml
@@ -1,12 +1,12 @@
-uuid: 57b5b06b-a960-4a2c-aa23-33f9e126af6a
+uuid: 74bee59b-96aa-43c3-b8fc-806228d6a5af
 langcode: en
-status: '0'
+status: '1'
 dependencies: {  }
-cluster_id: elasticsearch
-name: Elasticsearch
-url: 'http://hub-elasticsearch:9200'
+cluster_id: opensearch
+name: OpenSearch
+url: ''
 options:
-  multiple_nodes_connection: false
+  multiple_nodes_connection: true
   use_authentication: false
   authentication_type: Basic
   username: ''

--- a/config/sync/search_api.server.elasticsearch.yml
+++ b/config/sync/search_api.server.elasticsearch.yml
@@ -5,11 +5,11 @@ dependencies:
   module:
     - elasticsearch_connector
 id: elasticsearch
-name: Elasticsearch
-description: 'Elasticsearch server for Hub Content'
+name: OpenSearch
+description: 'OpenSearch server for Hub Content'
 backend: elasticsearch
 backend_config:
-  server_description: ''
   cluster_settings:
-    cluster: elasticsearch
+    cluster: opensearch
   fuzziness: '0'
+  server_description: ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,20 +24,24 @@ services:
     networks:
       - prisoner_content_hub
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+  opensearch:
+    image: opensearchproject/opensearch:2.7.0
     environment:
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "discovery.type=single-node"
-      - xpack.security.enabled=false
+      - discovery.type=single-node
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - '9200:9200'
     ulimits:
       memlock:
         soft: -1
         hard: -1
-    ports:
-      - 9200:9200
+      nofile:
+        soft: 65536
+        hard: 65536
     networks:
       - prisoner_content_hub
+
   chrome:
     image: previousnext/chrome-headless:65
     ports:

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessSearchApiTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessSearchApiTest.php
@@ -62,7 +62,7 @@ class PrisonerHubQueryAccessSearchApiTest extends PrisonerHubQueryAccessTestBase
       $this->bundles = array_merge($this->bundles, array_keys($datasource->getBundles()));
     }
     $this->jsonApiUrl = Url::fromUri('internal:/jsonapi/prison/' . $this->prisonTerm->get('machine_name')->getValue()[0]['value'] . '/index/content_for_search');
-    $cluster = Cluster::load('elasticsearch');
+    $cluster = Cluster::load('opensearch');
     $this->client = $this->container->get('elasticsearch_connector.client_manager')->getClientForCluster($cluster);
   }
 

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -123,6 +123,7 @@ $settings['entity_update_backup'] = TRUE;
 $settings['file_public_base_url'] = getenv('FILE_PUBLIC_BASE_URL', TRUE);
 $elasticsearch_cluster = getenv("ELASTICSEARCH_CLUSTER", TRUE);
 $config['elasticsearch_connector.cluster.' . $elasticsearch_cluster]['url'] = getenv("ELASTICSEARCH_HOST", TRUE);
+$config['elasticsearch_connector.cluster.opensearch']['url'] = getenv('OPENSEARCH_HOST', TRUE);
 
 // Raven (sentry integration) module allows for setting values via environment
 // variables.  See https://git.drupalcode.org/project/raven/-/blob/14ddb8158b480c2e65884b4d4c561a14c17acf2b/README.md#L109

--- a/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-backend/templates/_envs.tpl
@@ -65,6 +65,11 @@ env:
     value: {{ .Values.application.config.elasticsearchCluster }}
   - name: ELASTICSEARCH_HOST
     value: {{ include "prisoner-content-hub-backend.elasticsearchServiceHost" . }}
+  - name: OPENSEARCH_HOST
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.application.openSearchSecretName }}
+        key: proxy_url
   - name: SENTRY_DSN
     value: {{ .Values.application.sentry_dsn }}
   - name: SENTRY_ENVIRONMENT

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -35,6 +35,7 @@ application:
     cnameIsBucket: true
   redisSecretName: drupal-redis
   govUkSecretName: govuknotify
+  openSearchSecretName: pfs-opensearch-proxy-url
 
 volumes:
   - name: apache-cache

--- a/prisoner-content-hub-backend.env
+++ b/prisoner-content-hub-backend.env
@@ -12,6 +12,7 @@ PHP_POST_MAX_SIZE=500M
 
 ELASTICSEARCH_CLUSTER=elasticsearch
 ELASTICSEARCH_HOST=http://elasticsearch:9200
+OPENSEARCH_HOST=http://opensearch-proxy-service-cloud-platform-39c81394.prisoner-content-hub-development.svc.cluster.local:8080
 
 SIMPLETEST_BASE_URL=http://drupal:8080
 SIMPLETEST_DB=mysql://hubdb_user:unsecurepassword@database/hubdb

--- a/prisoner-content-hub-backend.env
+++ b/prisoner-content-hub-backend.env
@@ -12,7 +12,7 @@ PHP_POST_MAX_SIZE=500M
 
 ELASTICSEARCH_CLUSTER=elasticsearch
 ELASTICSEARCH_HOST=http://elasticsearch:9200
-OPENSEARCH_HOST=http://opensearch-proxy-service-cloud-platform-39c81394.prisoner-content-hub-development.svc.cluster.local:8080
+OPENSEARCH_HOST=http://opensearch:9200
 
 SIMPLETEST_BASE_URL=http://drupal:8080
 SIMPLETEST_DB=mysql://hubdb_user:unsecurepassword@database/hubdb


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-272

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

Switch out Elasticsearch for Opensearch, as Elasticsearch is no longer supported by cloud platform team. 

> What changes are introduced by this PR that correspond to the above card?

Disables existing elasticsearch cluster (this will be removed at a later date)
Adds an opensearch cluster
Move existing search index configuration to the new server
Update docker configuration to use opensearch in local and CI environments

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

This must be deployed in tandem with corresponding cloud platform changes. See https://github.com/ministryofjustice/cloud-platform-environments/pull/16616 as an example for dev environment.

The index must be manually rebuilt after deploy. This takes a few minutes. Search will be unavailable at this time. DCMs should be forwarned before this is done on prod.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
