### PR TITLE
LNP-584: 🎉  add new view for searching for specific tags in body cont…

### DIFF
--- a/config/sync/views.view.searching_for_tags_linked_in_content.yml
+++ b/config/sync/views.view.searching_for_tags_linked_in_content.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - search_api.index.content_for_search
+    - system.menu.admin
     - user.role.administrator
     - user.role.local_administrator
   module:
@@ -27,7 +28,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Searching for tags linked in content'
+      title: 'Content with tag links'
       fields:
         title:
           id: title
@@ -441,11 +442,11 @@ display:
         filter_groups: false
       display_extenders:
         views_ef_fieldset: {  }
-      path: searching-for-tags-linked-in-content-export
+      path: admin/content/content-with-tag-links-export
       filename: content-with-tags.csv
-      automatic_download: false
+      automatic_download: true
       export_limit: 1000
-      export_filesystem: public
+      export_filesystem: s3
       custom_redirect_path: false
       redirect_to_display: none
       include_query_params: false
@@ -468,7 +469,16 @@ display:
     display_options:
       display_extenders:
         views_ef_fieldset: {  }
-      path: searching-for-tags-linked-in-content
+      path: admin/content/content-with-tag-links
+      menu:
+        type: normal
+        title: 'Content with tag links'
+        description: 'Shows all content that links to tags (for example categories or series) in rich text'
+        weight: 100
+        expanded: false
+        menu_name: admin
+        parent: 'views_view:views.taxonomy_overview.page_1'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.searching_for_tags_linked_in_content.yml
+++ b/config/sync/views.view.searching_for_tags_linked_in_content.yml
@@ -1,0 +1,483 @@
+uuid: 38e39c30-8c39-4a1d-8def-35008b41215b
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.content_for_search
+    - user.role.administrator
+    - user.role.local_administrator
+  module:
+    - csv_serialization
+    - rest
+    - search_api
+    - serialization
+    - user
+    - views_data_export
+id: searching_for_tags_linked_in_content
+label: 'Searching for tags linked in content'
+module: views
+description: 'This view is to help find content that links to tags in body content.'
+tag: ''
+base_table: search_api_index_content_for_search
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Searching for tags linked in content'
+      fields:
+        title:
+          id: title
+          table: search_api_datasource_content_for_search_entity_node
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        nid:
+          id: nid
+          table: search_api_datasource_content_for_search_entity_node
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: 'Content ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_numeric
+          fallback_options:
+            set_precision: false
+            precision: 0
+            decimal: .
+            separator: ','
+            format_plural: false
+            format_plural_string: !!binary MQNAY291bnQ=
+            prefix: ''
+            suffix: ''
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            format_plural_values:
+              - '1'
+              - '@count'
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            local_administrator: local_administrator
+            administrator: administrator
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_content_for_search
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: tags
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields:
+            - field_description
+            - field_moj_stand_first
+            - field_summary
+        search_api_fulltext_1:
+          id: search_api_fulltext_1
+          table: search_api_index_content_for_search
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_1_op
+            label: 'Numeric Category ID'
+            description: 'Specify the number of the tag you wish to search. Leave blank to search for all embedded tags.'
+            use_operator: false
+            operator: search_api_fulltext_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext_1
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moj_local_content_manager: '0'
+              local_administrator: '0'
+              administrator: '0'
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: search_api_fulltext_1_searched_fields
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:search_api.index.content_for_search'
+        - 'search_api_list:content_for_search'
+  data_export_1:
+    id: data_export_1
+    display_title: 'Data export'
+    display_plugin: data_export
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1000
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_content_for_search
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: tags
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields:
+            - field_description
+            - field_moj_stand_first
+            - field_summary
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders:
+        views_ef_fieldset: {  }
+      path: searching-for-tags-linked-in-content-export
+      filename: content-with-tags.csv
+      automatic_download: false
+      export_limit: 1000
+      export_filesystem: public
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:search_api.index.content_for_search'
+        - 'search_api_list:content_for_search'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        views_ef_fieldset: {  }
+      path: searching-for-tags-linked-in-content
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:search_api.index.content_for_search'
+        - 'search_api_list:content_for_search'

--- a/config/sync/views.view.searching_for_tags_linked_in_content.yml
+++ b/config/sync/views.view.searching_for_tags_linked_in_content.yml
@@ -289,7 +289,7 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_1_op
-            label: 'Numeric Category ID'
+            label: 'Numeric Tag ID'
             description: 'Specify the number of the tag you wish to search. Leave blank to search for all embedded tags.'
             use_operator: false
             operator: search_api_fulltext_1_op
@@ -336,6 +336,19 @@ display:
           query_tags: {  }
       relationships: {  }
       header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<p>This view shows all published content that contains links to tags in rich text.</p>\r\n<p>If you want to search for content that links to specific tags, then enter it in the Numeric Tag ID section below.\r\nThis is useful to find content linking to a specific category before deleting it, to avoid broken links.</p>"
+            format: basic_html
+          tokenize: false
         result:
           id: result
           table: views

--- a/config/sync/views.view.searching_for_tags_linked_in_content.yml
+++ b/config/sync/views.view.searching_for_tags_linked_in_content.yml
@@ -222,7 +222,7 @@ display:
             local_administrator: local_administrator
             administrator: administrator
       cache:
-        type: none
+        type: search_api_tag
         options: {  }
       empty: {  }
       sorts: {  }
@@ -443,7 +443,10 @@ display:
       display_extenders:
         views_ef_fieldset: {  }
       path: admin/content/content-with-tag-links-export
-      filename: content-with-tags.csv
+      displays:
+        page_1: page_1
+        default: '0'
+      filename: 'content-with-tags-export-[date:html_datetime].csv'
       automatic_download: true
       export_limit: 1000
       export_filesystem: s3


### PR DESCRIPTION
…ent links, and export of content containing tags in body copy.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-584

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?

This change introduces a view with two displays
* one that lists all the content containing tags in the body copy, with an optional exposed filter to look for content with a specific tag
* another that exports all content with tags in body copy to CSV 

These will be very useful to the comms team to mitigate broken links when making changes to taxonomy.

> Would this PR benefit from screenshots?

No.

Well, yes, but they contain non-public info, so they're in the JIRA ticket.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
