### PR TITLE
LNP-626: fix deprecated CircleCI docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.17
+          version: default
           docker_layer_caching: true
       - run:
           name: Build docker images with docker compose
@@ -100,7 +100,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.17
+          version: default
           docker_layer_caching: true
       - hmpps/create_app_version
       - run:
@@ -123,7 +123,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.17
+          version: default
           docker_layer_caching: true
       - hmpps/create_app_version
       - run:


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-626

> If this is an issue, do we have steps to reproduce?

Push a branch and watch CircleCI fail to build.

This must be done in one of the brown out times outlined in https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176 or after the deprecation date of 30/09/24.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Swap the deprecated docker image used by CircleCI for the default, which should never be deprecated.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
