### PR TITLE
LNP-685: 🐛  fix region inheritance in prisconhub theme.

### DIFF
--- a/config/sync/block.block.prisconhub_breadcrumbs.yml
+++ b/config/sync/block.block.prisconhub_breadcrumbs.yml
@@ -1,0 +1,20 @@
+uuid: 35ed1b58-2777-4b8d-a56b-44e791ee320c
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - prisconhub
+id: prisconhub_breadcrumbs
+theme: prisconhub
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.prisconhub_secondary_local_tasks.yml
+++ b/config/sync/block.block.prisconhub_secondary_local_tasks.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: QeZBeCilQfeET3GeW6ZtJkEiwROADTZktFgKWwPieD4
 id: prisconhub_secondary_local_tasks
 theme: prisconhub
-region: sidebar_first
-weight: 0
+region: pre_content
+weight: -3
 provider: null
 plugin: local_tasks_block
 settings:

--- a/docroot/themes/custom/prisconhub/prisconhub.info.yml
+++ b/docroot/themes/custom/prisconhub/prisconhub.info.yml
@@ -7,3 +7,16 @@ libraries:
   - prisconhub/global-styling
 
 base theme: claro
+
+regions:
+  header: Header
+  pre_content: Pre-content
+  breadcrumb: Breadcrumb
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  page_top: Page top
+  page_bottom: Page bottom
+  sidebar_first: First sidebar
+regions_hidden:
+  - sidebar_first


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-685

> If this is an issue, do we have steps to reproduce?

Visit a page with secondary tasks, for example /admin/config/development/configuration as an administrator and compare it to the same page running with the Claro theme. You will see the Breadcrumbs and secondary tasks (Full archive | Single item) components of the page are missing.

### Intent

> What changes are introduced by this PR that correspond to the above card?

This change manually adds the regions from Claro to the Prisconhub subtheme as per https://www.drupal.org/docs/develop/theming-drupal/creating-sub-themes#s-inheriting-theme-regions

It also moves the secondary tasks to the correct newly available region.

> Would this PR benefit from screenshots?

Yes. Here is a side by side comparison showing the missing UI components on the right, and the restored version on the left.

<img width="1918" alt="image" src="https://github.com/ministryofjustice/prisoner-content-hub-backend/assets/440637/da508452-5db9-4d70-9c3b-de8fd129047e">

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

We should inform comms and the DCM community as they will see new UI elements.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
