### PR TITLE
Task/LNP:-843: Update PHP from 8.1.11 to  8.1.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 # Specify amd64 platform, as otherwise M1 macs will download an arm version, which won't be compatible with some
 # of the things we run, like kubectl.
-FROM --platform=linux/amd64 php:8.1.29-apache-buster AS base
+FROM --platform=linux/amd64 php:8.1.29-apache-bookworm AS base
 
 # install the PHP extensions we need
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN set -eux; \
 	apt-mark manual $savedAptMark; \
 	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
 		| awk '/=>/ { print $3 }' \
+    | awk '{print $1} {system("realpath " $1)}' \
 		| sort -u \
 		| xargs -r dpkg-query -S \
 		| cut -d: -f1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 # Specify amd64 platform, as otherwise M1 macs will download an arm version, which won't be compatible with some
 # of the things we run, like kubectl.
-FROM --platform=linux/amd64 php:8.1.11-apache-buster AS base
+FROM --platform=linux/amd64 php:8.1.29-apache-buster AS base
 
 # install the PHP extensions we need
 RUN set -eux; \


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-834

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Updates the version of PHP used by the Drupal Apache/PHP docker image from 8.1.11 to the latest 8.1.29.
Also updates the underlying version of Debian from Buster to Bookworm as PHP 8.1.29 is not available on Buster.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
