### PR TITLE
Bug/LNP-835: duplicate prison field values

### DIFF
--- a/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.services.yml
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.services.yml
@@ -1,0 +1,4 @@
+services:
+  logger.channel.prisoner_hub_bulk_updater:
+    parent: logger.channel_base
+    arguments: ['prisoner_hub_bulk_updater']

--- a/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.services.yml
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.services.yml
@@ -1,4 +1,0 @@
-services:
-  logger.channel.prisoner_hub_bulk_updater:
-    parent: logger.channel_base
-    arguments: ['prisoner_hub_bulk_updater']

--- a/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
@@ -55,8 +55,8 @@ final class PrisonerHubBulkUpdaterCommands extends DrushCommands {
     'status' => 'Status',
   ])]
   #[CLI\DefaultTableFields(fields: ['nid', 'status'])]
-  #[CLI\Usage(name: 'prisoner_hub_bulk_updater:apply-red-list chelmsford cookhamwood_red_nids.csv', description: 'Usage description')]
-  public function commandName($prison, $list): RowsOfFields {
+  #[CLI\Usage(name: 'prisoner_hub_bulk_updater:apply-red-list chelmsford cookhamwood_red_nids.csv', description: 'Specify a prison machine name and a csv file of node IDs to exclude all the content in the CSV from given prison.')]
+  public function applyRedList($prison, $list): RowsOfFields {
     // First check we have a valid prison, and a readable csv file.
     $module_path = $this->extensionListModule->getPath('prisoner_hub_bulk_updater');
     $red_csv_path = "{$module_path}/files/{$list}";

--- a/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
@@ -185,7 +185,7 @@ final class PrisonerHubBulkUpdaterCommands extends DrushCommands {
         }, $unique_prisons));
         $n->set('field_exclude_from_prison', array_map(function ($prison) {
           return ['target_id' => $prison->id()];
-        }, $excluded_prisons));
+        }, $unique_excluded_prisons));
         $n->save();
       }
     }

--- a/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/src/Drush/Commands/PrisonerHubBulkUpdaterCommands.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,7 +25,6 @@ final class PrisonerHubBulkUpdaterCommands extends DrushCommands {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TimeInterface $time,
     private readonly Connection $database,
-    private readonly LoggerInterface $logger,
   ) {
     parent::__construct();
   }
@@ -40,7 +38,6 @@ final class PrisonerHubBulkUpdaterCommands extends DrushCommands {
       $container->get('entity_type.manager'),
       $container->get('datetime.time'),
       $container->get('database'),
-      $container->get('logger.channel.prisoner_hub_bulk_updater'),
     );
   }
 
@@ -168,7 +165,8 @@ final class PrisonerHubBulkUpdaterCommands extends DrushCommands {
 
     // These two sets will overlap, so remove duplicates and sort so that the
     // order of operation is predictable.
-    $nids = sort(array_unique(array_merge($duplicate_prison_node_ids, $duplicate_prison_exclusion_ids)), SORT_NUMERIC);
+    $nids = array_unique(array_merge($duplicate_prison_node_ids, $duplicate_prison_exclusion_ids));
+    sort($nids, SORT_NUMERIC);
 
     $this->logger->info("Found @count nodes requiring deduping", ['@count' => count($nids)]);
     $this->logger->info("Nodes to dedupe are: @nids", ['@nids' => print_r($nids, TRUE)]);

--- a/docroot/modules/custom/prisoner_hub_prison_access_cms/prisoner_hub_prison_access_cms.module
+++ b/docroot/modules/custom/prisoner_hub_prison_access_cms/prisoner_hub_prison_access_cms.module
@@ -91,6 +91,14 @@ function prisoner_hub_prison_access_cms_field_widget_single_element_form_alter(&
  * This function checks to see if there are any that should be added back in.
  */
 function prisoner_hub_prison_access_cms_entity_presave(EntityInterface $entity) {
+  // This whole logic only applies when saving via the form.
+  // Nodes can also be saved programmatically, and applying this logic then
+  // causes nodes to be included and excluded from the same prison multiple
+  // times in the database.
+  if (\Drupal::routeMatch()->getRouteName() != 'entity.node.edit_form') {
+    return;
+  }
+
   $entity_edit_access = \Drupal::service('prisoner_hub_prison_access_cms.entity_edit_access');
   $prison_field_names = [
     \Drupal::getContainer()->getParameter('prisoner_hub_prison_access.exclude_from_prison_field_name'),


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-835

> If this is an issue, do we have steps to reproduce?

View the admin/content screen - you will see content that is attributed to the same prison multiple times.

### Intent

> What changes are introduced by this PR that correspond to the above card?

* Fixes the implementation of hook_entity_presave() that caused the duplication of items in the relevant prison fields.
* Implements a drush command `drush phdpf` that identifies all nodes in the database with this problem, and resaves them with deduped fields.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

The drush command requires running manually after the deployment is complete.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
