### PR TITLE
Story/LNP-820 recently added hq priority content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -192,6 +192,9 @@
             },
             "drupal/search_api": {
                 "Issue #3313569: Warning: Could not load the following items on index": "patches/3313569-10--referenced_entity_tracking_translations.patch"
+            },
+            "drupal/field_permissions": {
+                "Issue #3411976: 500 error with JSONAPI on Base Entity Fields": "patches/file_permissions.3411976-25.patch"
             }
         },
         "patches-ignore": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/entity": "^1.2",
         "drupal/entity_clone": "^2.0@beta",
         "drupal/field_group": "^3.1",
+        "drupal/field_permissions": "^1.3",
         "drupal/file_mime_validator": "^2.0",
         "drupal/flood_control": "^2.3",
         "drupal/flysystem": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "866aacaf3eb34e3a1c7f28309023058b",
+    "content-hash": "80556dfabb85c8caae56de3c9e6609c9",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -2973,6 +2973,70 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/field_group",
                 "issues": "https://www.drupal.org/project/issues/field_group"
+            }
+        },
+        {
+            "name": "drupal/field_permissions",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/field_permissions.git",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/field_permissions-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "f3815d21b423c94e800388f3c29237fc1a00189d"
+            },
+            "require": {
+                "drupal/core": ">=8.9 <11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1703264421",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-8.x-1.x": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "mariacha1",
+                    "homepage": "https://www.drupal.org/user/2210776"
+                },
+                {
+                    "name": "markus_petrux",
+                    "homepage": "https://www.drupal.org/user/39593"
+                },
+                {
+                    "name": "RobLoach",
+                    "homepage": "https://www.drupal.org/user/61114"
+                }
+            ],
+            "description": "The Field Permissions module allows site administrators to set field-level permissions to edit, view and create fields on any entity.",
+            "homepage": "https://www.drupal.org/project/field_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/field_permissions",
+                "issues": "https://www.drupal.org/project/issues/field_permissions"
             }
         },
         {

--- a/config/sync/core.entity_form_display.node.link.default.yml
+++ b/config/sync/core.entity_form_display.node.link.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.link.field_moj_thumbnail_image
     - field.field.node.link.field_moj_top_level_categories
     - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prioritise_on_recently_add
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
     - field.field.node.link.field_show_interstitial_page
@@ -187,6 +188,13 @@ content:
   field_not_in_series:
     type: boolean_checkbox
     weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_prioritise_on_recently_add:
+    type: boolean_checkbox
+    weight: 27
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_pdf_item.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.moj_pdf_item.field_moj_thumbnail_image
     - field.field.node.moj_pdf_item.field_moj_top_level_categories
     - field.field.node.moj_pdf_item.field_not_in_series
+    - field.field.node.moj_pdf_item.field_prioritise_on_recently_add
     - field.field.node.moj_pdf_item.field_prison_owner
     - field.field.node.moj_pdf_item.field_prisons
     - field.field.node.moj_pdf_item.field_release_date
@@ -206,6 +207,13 @@ content:
   field_not_in_series:
     type: boolean_checkbox
     weight: 18
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_prioritise_on_recently_add:
+    type: boolean_checkbox
+    weight: 27
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_radio_item.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.moj_radio_item.field_moj_thumbnail_image
     - field.field.node.moj_radio_item.field_moj_top_level_categories
     - field.field.node.moj_radio_item.field_not_in_series
+    - field.field.node.moj_radio_item.field_prioritise_on_recently_add
     - field.field.node.moj_radio_item.field_prison_owner
     - field.field.node.moj_radio_item.field_prisons
     - field.field.node.moj_radio_item.field_release_date
@@ -233,6 +234,13 @@ content:
   field_not_in_series:
     type: boolean_checkbox
     weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_prioritise_on_recently_add:
+    type: boolean_checkbox
+    weight: 27
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_form_display.node.moj_video_item.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.moj_video_item.field_moj_thumbnail_image
     - field.field.node.moj_video_item.field_moj_top_level_categories
     - field.field.node.moj_video_item.field_not_in_series
+    - field.field.node.moj_video_item.field_prioritise_on_recently_add
     - field.field.node.moj_video_item.field_prison_owner
     - field.field.node.moj_video_item.field_prisons
     - field.field.node.moj_video_item.field_release_date
@@ -225,6 +226,13 @@ content:
   field_not_in_series:
     type: boolean_checkbox
     weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_prioritise_on_recently_add:
+    type: boolean_checkbox
+    weight: 27
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.page.field_moj_thumbnail_image
     - field.field.node.page.field_moj_top_level_categories
     - field.field.node.page.field_not_in_series
+    - field.field.node.page.field_prioritise_on_recently_add
     - field.field.node.page.field_prison_owner
     - field.field.node.page.field_prisons
     - field.field.node.page.field_release_date
@@ -224,6 +225,13 @@ content:
   field_not_in_series:
     type: boolean_checkbox
     weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_prioritise_on_recently_add:
+    type: boolean_checkbox
+    weight: 27
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.node.link.default.yml
+++ b/config/sync/core.entity_view_display.node.link.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.link.field_moj_thumbnail_image
     - field.field.node.link.field_moj_top_level_categories
     - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prioritise_on_recently_add
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
     - field.field.node.link.field_show_interstitial_page
@@ -87,6 +88,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 109
+    region: content
+  field_prioritise_on_recently_add:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_release_date:
     type: datetime_default

--- a/config/sync/core.entity_view_display.node.link.teaser.yml
+++ b/config/sync/core.entity_view_display.node.link.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.link.field_moj_thumbnail_image
     - field.field.node.link.field_moj_top_level_categories
     - field.field.node.link.field_not_in_series
+    - field.field.node.link.field_prioritise_on_recently_add
     - field.field.node.link.field_prisons
     - field.field.node.link.field_release_date
     - field.field.node.link.field_show_interstitial_page
@@ -39,6 +40,7 @@ hidden:
   field_moj_thumbnail_image: true
   field_moj_top_level_categories: true
   field_not_in_series: true
+  field_prioritise_on_recently_add: true
   field_prisons: true
   field_release_date: true
   field_show_interstitial_page: true

--- a/config/sync/core.entity_view_display.node.moj_pdf_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_pdf_item.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.moj_pdf_item.field_moj_thumbnail_image
     - field.field.node.moj_pdf_item.field_moj_top_level_categories
     - field.field.node.moj_pdf_item.field_not_in_series
+    - field.field.node.moj_pdf_item.field_prioritise_on_recently_add
     - field.field.node.moj_pdf_item.field_prison_owner
     - field.field.node.moj_pdf_item.field_prisons
     - field.field.node.moj_pdf_item.field_release_date
@@ -99,6 +100,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 18
+    region: content
+  field_prioritise_on_recently_add:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_prison_owner:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_radio_item.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.moj_radio_item.field_moj_thumbnail_image
     - field.field.node.moj_radio_item.field_moj_top_level_categories
     - field.field.node.moj_radio_item.field_not_in_series
+    - field.field.node.moj_radio_item.field_prioritise_on_recently_add
     - field.field.node.moj_radio_item.field_prison_owner
     - field.field.node.moj_radio_item.field_prisons
     - field.field.node.moj_radio_item.field_release_date
@@ -119,6 +120,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 16
+    region: content
+  field_prioritise_on_recently_add:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_prison_owner:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.moj_video_item.default.yml
+++ b/config/sync/core.entity_view_display.node.moj_video_item.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.moj_video_item.field_moj_thumbnail_image
     - field.field.node.moj_video_item.field_moj_top_level_categories
     - field.field.node.moj_video_item.field_not_in_series
+    - field.field.node.moj_video_item.field_prioritise_on_recently_add
     - field.field.node.moj_video_item.field_prison_owner
     - field.field.node.moj_video_item.field_prisons
     - field.field.node.moj_video_item.field_release_date
@@ -120,6 +121,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 19
+    region: content
+  field_prioritise_on_recently_add:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_prison_owner:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.page.field_moj_thumbnail_image
     - field.field.node.page.field_moj_top_level_categories
     - field.field.node.page.field_not_in_series
+    - field.field.node.page.field_prioritise_on_recently_add
     - field.field.node.page.field_prison_owner
     - field.field.node.page.field_prisons
     - field.field.node.page.field_release_date
@@ -117,6 +118,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 16
+    region: content
+  field_prioritise_on_recently_add:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_prison_owner:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.page.search_index.yml
+++ b/config/sync/core.entity_view_display.node.page.search_index.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.page.field_moj_thumbnail_image
     - field.field.node.page.field_moj_top_level_categories
     - field.field.node.page.field_not_in_series
+    - field.field.node.page.field_prioritise_on_recently_add
     - field.field.node.page.field_prison_owner
     - field.field.node.page.field_prisons
     - field.field.node.page.field_release_date
@@ -41,6 +42,7 @@ hidden:
   field_moj_thumbnail_image: true
   field_moj_top_level_categories: true
   field_not_in_series: true
+  field_prioritise_on_recently_add: true
   field_prison_owner: true
   field_prisons: true
   field_release_date: true

--- a/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.page.field_moj_thumbnail_image
     - field.field.node.page.field_moj_top_level_categories
     - field.field.node.page.field_not_in_series
+    - field.field.node.page.field_prioritise_on_recently_add
     - field.field.node.page.field_prison_owner
     - field.field.node.page.field_prisons
     - field.field.node.page.field_release_date
@@ -46,6 +47,7 @@ hidden:
   field_moj_thumbnail_image: true
   field_moj_top_level_categories: true
   field_not_in_series: true
+  field_prioritise_on_recently_add: true
   field_prison_owner: true
   field_prisons: true
   field_release_date: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.page.field_moj_thumbnail_image
     - field.field.node.page.field_moj_top_level_categories
     - field.field.node.page.field_not_in_series
+    - field.field.node.page.field_prioritise_on_recently_add
     - field.field.node.page.field_prison_owner
     - field.field.node.page.field_prisons
     - field.field.node.page.field_release_date
@@ -46,6 +47,7 @@ hidden:
   field_moj_thumbnail_image: true
   field_moj_top_level_categories: true
   field_not_in_series: true
+  field_prioritise_on_recently_add: true
   field_prison_owner: true
   field_prisons: true
   field_release_date: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -80,6 +80,7 @@ module:
   prisoner_hub_explore: 0
   prisoner_hub_linkit_matcher: 0
   prisoner_hub_primary_nav: 0
+  prisoner_hub_priority_content: 0
   prisoner_hub_prison_access: 0
   prisoner_hub_prison_access_cms: 0
   prisoner_hub_prison_context: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -28,6 +28,7 @@ module:
   field: 0
   field_group: 0
   field_group_open_non_empty: 0
+  field_permissions: 0
   field_ui: 0
   file: 0
   file_download_expires_fix: 0

--- a/config/sync/field.field.node.link.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.field.node.link.field_prioritise_on_recently_add.yml
@@ -1,0 +1,21 @@
+uuid: 4e0ad62e-8e44-4675-b8fb-46692acbec67
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prioritise_on_recently_add
+    - node.type.link
+id: node.link.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+bundle: link
+label: 'Prioritise on Recently Added section of home pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.moj_pdf_item.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.field.node.moj_pdf_item.field_prioritise_on_recently_add.yml
@@ -1,0 +1,21 @@
+uuid: 614fb2e8-01a6-4da9-8e84-7cad791e70ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prioritise_on_recently_add
+    - node.type.moj_pdf_item
+id: node.moj_pdf_item.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+bundle: moj_pdf_item
+label: 'Prioritise on Recently Added section of home pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.moj_radio_item.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.field.node.moj_radio_item.field_prioritise_on_recently_add.yml
@@ -1,0 +1,21 @@
+uuid: 13f8d78b-9f78-4e86-a567-90b664162594
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prioritise_on_recently_add
+    - node.type.moj_radio_item
+id: node.moj_radio_item.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+bundle: moj_radio_item
+label: 'Prioritise on Recently Added section of home pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.moj_video_item.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.field.node.moj_video_item.field_prioritise_on_recently_add.yml
@@ -1,0 +1,21 @@
+uuid: 5beaadd7-04bd-4fe7-9bb6-684946b49a46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prioritise_on_recently_add
+    - node.type.moj_video_item
+id: node.moj_video_item.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+bundle: moj_video_item
+label: 'Prioritise on Recently Added section of home pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.page.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.field.node.page.field_prioritise_on_recently_add.yml
@@ -1,0 +1,21 @@
+uuid: c2db1df8-4540-45d0-9b7b-1ae628ecc647
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_prioritise_on_recently_add
+    - node.type.page
+id: node.page.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+bundle: page
+label: 'Prioritise on Recently Added section of home pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.storage.node.field_prioritise_on_recently_add.yml
@@ -1,0 +1,18 @@
+uuid: 783c743b-c2cc-4815-9bf9-22d3181accde
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_prioritise_on_recently_add
+field_name: field_prioritise_on_recently_add
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_prioritise_on_recently_add.yml
+++ b/config/sync/field.storage.node.field_prioritise_on_recently_add.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
+third_party_settings:
+  field_permissions:
+    permission_type: custom
 id: node.field_prioritise_on_recently_add
 field_name: field_prioritise_on_recently_add
 entity_type: node

--- a/config/sync/system.action.user_add_role_action.comms_live_service_hq.yml
+++ b/config/sync/system.action.user_add_role_action.comms_live_service_hq.yml
@@ -1,0 +1,14 @@
+uuid: 087bdfaf-ac27-4558-917c-3ac5c1756c80
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.comms_live_service_hq
+  module:
+    - user
+id: user_add_role_action.comms_live_service_hq
+label: 'Add the Comms &amp; Live Service HQ role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: comms_live_service_hq

--- a/config/sync/system.action.user_remove_role_action.comms_live_service_hq.yml
+++ b/config/sync/system.action.user_remove_role_action.comms_live_service_hq.yml
@@ -1,0 +1,14 @@
+uuid: aff2815c-b743-4167-bfb1-8da90cb4e10d
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.comms_live_service_hq
+  module:
+    - user
+id: user_remove_role_action.comms_live_service_hq
+label: 'Remove the Comms &amp; Live Service HQ role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: comms_live_service_hq

--- a/config/sync/user.role.comms_live_service_hq.yml
+++ b/config/sync/user.role.comms_live_service_hq.yml
@@ -1,9 +1,16 @@
 uuid: d5f4b295-890d-4f83-a8b6-aa3caf743c13
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - field_permissions
 id: comms_live_service_hq
 label: 'Comms & Live Service HQ'
 weight: -5
 is_admin: null
-permissions: {  }
+permissions:
+  - 'create field_prioritise_on_recently_add'
+  - 'edit field_prioritise_on_recently_add'
+  - 'edit own field_prioritise_on_recently_add'
+  - 'view field_prioritise_on_recently_add'
+  - 'view own field_prioritise_on_recently_add'

--- a/config/sync/user.role.comms_live_service_hq.yml
+++ b/config/sync/user.role.comms_live_service_hq.yml
@@ -1,0 +1,9 @@
+uuid: d5f4b295-890d-4f83-a8b6-aa3caf743c13
+langcode: en
+status: true
+dependencies: {  }
+id: comms_live_service_hq
+label: 'Comms & Live Service HQ'
+weight: -5
+is_admin: null
+permissions: {  }

--- a/config/sync/user.role.comms_live_service_hq.yml
+++ b/config/sync/user.role.comms_live_service_hq.yml
@@ -4,11 +4,15 @@ status: true
 dependencies:
   module:
     - field_permissions
+    - role_delegation
 id: comms_live_service_hq
 label: 'Comms & Live Service HQ'
 weight: -5
 is_admin: null
 permissions:
+  - 'assign comms_live_service_hq role'
+  - 'assign local_administrator role'
+  - 'assign moj_local_content_manager role'
   - 'create field_prioritise_on_recently_add'
   - 'edit field_prioritise_on_recently_add'
   - 'edit own field_prioritise_on_recently_add'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -25,7 +25,6 @@ dependencies:
     - prisoner_hub_prison_access_cms
     - publication_date
     - raven
-    - role_delegation
     - scheduler
     - system
     - taxonomy
@@ -48,8 +47,6 @@ permissions:
   - 'administer menu'
   - 'administer nodes'
   - 'administer users'
-  - 'assign local_administrator role'
-  - 'assign moj_local_content_manager role'
   - 'assign prisons to users'
   - 'bypass node access'
   - 'bypass prison ownership edit access'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -19,6 +19,7 @@ dependencies:
     - actions_permissions
     - book
     - entity_clone
+    - field_permissions
     - filter
     - node
     - prisoner_hub_prison_access_cms
@@ -142,12 +143,14 @@ permissions:
   - 'use text format full_html'
   - 'view all revisions'
   - 'view any unpublished content'
+  - 'view field_prioritise_on_recently_add'
   - 'view help_page revisions'
   - 'view homepage revisions'
   - 'view link revisions'
   - 'view moj_pdf_item revisions'
   - 'view moj_radio_item revisions'
   - 'view moj_video_item revisions'
+  - 'view own field_prioritise_on_recently_add'
   - 'view own unpublished content'
   - 'view page revisions'
   - 'view scheduled content'

--- a/config/sync/user.role.moj_local_content_manager.yml
+++ b/config/sync/user.role.moj_local_content_manager.yml
@@ -5,12 +5,14 @@ dependencies:
   config:
     - filter.format.full_html
     - node.type.homepage
+    - node.type.link
     - node.type.moj_pdf_item
     - node.type.moj_radio_item
     - node.type.moj_video_item
     - node.type.page
     - node.type.urgent_banner
   module:
+    - field_permissions
     - filter
     - node
     - publication_date
@@ -59,10 +61,12 @@ permissions:
   - 'view any unpublished moj_video_item content'
   - 'view any unpublished page content'
   - 'view any unpublished urgent_banner content'
+  - 'view field_prioritise_on_recently_add'
   - 'view homepage revisions'
   - 'view moj_pdf_item revisions'
   - 'view moj_radio_item revisions'
   - 'view moj_video_item revisions'
+  - 'view own field_prioritise_on_recently_add'
   - 'view own unpublished content'
   - 'view page revisions'
   - 'view scheduled content'

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 use GuzzleHttp\RequestOptions;
@@ -22,6 +23,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
 
@@ -205,21 +207,6 @@ class PrisonerHubBreadcrumbsTest extends ExistingSiteBase {
       }
       $this->assertEquals($breadcrumbs, $response_document['data']['attributes']['breadcrumbs'], $message);
     }
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  protected function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
+++ b/docroot/modules/custom/prisoner_hub_breadcrumbs/tests/src/ExistingSite/PrisonerHubBreadcrumbsTest.php
@@ -10,7 +10,6 @@ use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;

--- a/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.deploy.php
+++ b/docroot/modules/custom/prisoner_hub_bulk_updater/prisoner_hub_bulk_updater.deploy.php
@@ -479,3 +479,21 @@ function prisoner_hub_bulk_updater_deploy_cleanse_2(array &$sandbox) {
     '@nids' => implode('|', $batch_nids),
   ]);
 }
+
+/**
+ * Deploy hook to assign comms role to specific accounts.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function prisoner_hub_bulk_updater_deploy_assign_comms_roles() {
+  $comms_uids = [1003, 959, 1001, 1010, 1002, 1033];
+  $user_storage = \Drupal::entityTypeManager()->getStorage('user');
+  foreach ($comms_uids as $uid) {
+    /** @var \Drupal\user\UserInterface $user */
+    $user = $user_storage->load($uid);
+    $user->addRole('comms_live_service_hq');
+    $user->save();
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_content_suggestions/tests/src/ExistingSite/PrisonerHubContentSuggestionsTest.php
+++ b/docroot/modules/custom/prisoner_hub_content_suggestions/tests/src/ExistingSite/PrisonerHubContentSuggestionsTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 use GuzzleHttp\RequestOptions;
@@ -22,6 +23,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubContentSuggestionsTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
 
@@ -222,21 +224,6 @@ class PrisonerHubContentSuggestionsTest extends ExistingSiteBase {
         return $data['id'];
       }, $response_document['data']), $message);
     }
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_content_suggestions/tests/src/ExistingSite/PrisonerHubContentSuggestionsTest.php
+++ b/docroot/modules/custom/prisoner_hub_content_suggestions/tests/src/ExistingSite/PrisonerHubContentSuggestionsTest.php
@@ -10,7 +10,6 @@ use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;

--- a/docroot/modules/custom/prisoner_hub_explore/tests/src/ExistingSite/PrisonerHubExploreTest.php
+++ b/docroot/modules/custom/prisoner_hub_explore/tests/src/ExistingSite/PrisonerHubExploreTest.php
@@ -6,7 +6,6 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 

--- a/docroot/modules/custom/prisoner_hub_explore/tests/src/ExistingSite/PrisonerHubExploreTest.php
+++ b/docroot/modules/custom/prisoner_hub_explore/tests/src/ExistingSite/PrisonerHubExploreTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\prisoner_hub_explore\ExistingSite;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
@@ -17,6 +18,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubExploreTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
 
   /**
@@ -39,21 +41,6 @@ class PrisonerHubExploreTest extends ExistingSiteBase {
     $message = 'JSON response returns the correct results on url: ' . $url->toString();
     $this->assertSame(count($response_document['data']), $limit, $message);
 
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_primary_nav/tests/src/ExistingSite/PrisonerHubPrimaryNavTest.php
+++ b/docroot/modules/custom/prisoner_hub_primary_nav/tests/src/ExistingSite/PrisonerHubPrimaryNavTest.php
@@ -10,7 +10,6 @@ use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 

--- a/docroot/modules/custom/prisoner_hub_primary_nav/tests/src/ExistingSite/PrisonerHubPrimaryNavTest.php
+++ b/docroot/modules/custom/prisoner_hub_primary_nav/tests/src/ExistingSite/PrisonerHubPrimaryNavTest.php
@@ -9,6 +9,7 @@ use Drupal\system\Entity\Menu;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
@@ -21,6 +22,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubPrimaryNavTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use TaxonomyCreationTrait;
 
   /**
@@ -132,21 +134,6 @@ class PrisonerHubPrimaryNavTest extends ExistingSiteBase {
         $this->assertSame($menu_item->getUrlObject()->toString(), $last_menu_item_in_response['attributes']['url']);
       }
     }
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_priority_content/README.md
+++ b/docroot/modules/custom/prisoner_hub_priority_content/README.md
@@ -1,0 +1,20 @@
+## INTRODUCTION
+
+The Prisoner hub priority content module contains code to support the handling
+of priority content as designated by the comms team.
+
+This module automatically sets the default value for prioritisation of newly
+created content based on the user having the Comms & Live Service HQ role.
+
+## REQUIREMENTS
+
+None.
+
+## INSTALLATION
+
+Install as you would normally install a contributed Drupal module.
+See: https://www.drupal.org/node/895232 for further information.
+
+## CONFIGURATION
+
+None.

--- a/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.info.yml
+++ b/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.info.yml
@@ -1,0 +1,5 @@
+name: 'Prisoner hub priority content'
+type: module
+description: 'Module for handling special considerations around priority content.'
+package: Custom
+core_version_requirement: ^10

--- a/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
+++ b/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for Prisoner hub priority content module.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Sets the default value for the priority field based on user role.
+ */
+function prisoner_hub_priority_content_form_node_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id){
+  /** @var $node \Drupal\node\NodeInterface */
+  $node = $form_state->getFormObject()->getEntity();
+
+  // We only care about new node.
+  if (!$node->isNew()) {
+    return;
+  }
+
+  // We only care about node types with the priority field.
+  if (!$node->hasField('field_prioritise_on_recently_add')) {
+    return;
+  }
+
+  if (in_array('comms_live_service_hq', \Drupal::currentUser()->getRoles())) {
+    $form['field_prioritise_on_recently_add']['widget']['value']['#default_value'] = TRUE;
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
+++ b/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
@@ -16,7 +16,7 @@ function prisoner_hub_priority_content_form_node_form_alter(&$form, FormStateInt
   /** @var \Drupal\node\NodeInterface $node */
   $node = $form_state->getFormObject()->getEntity();
 
-  // We only care about new node.
+  // We only care about new nodes.
   if (!$node->isNew()) {
     return;
   }

--- a/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
+++ b/docroot/modules/custom/prisoner_hub_priority_content/prisoner_hub_priority_content.module
@@ -5,13 +5,15 @@
  * Primary module hooks for Prisoner hub priority content module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_form_FORM_ID_alter().
  *
  * Sets the default value for the priority field based on user role.
  */
-function prisoner_hub_priority_content_form_node_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id){
-  /** @var $node \Drupal\node\NodeInterface */
+function prisoner_hub_priority_content_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  /** @var \Drupal\node\NodeInterface $node */
   $node = $form_state->getFormObject()->getEntity();
 
   // We only care about new node.

--- a/docroot/modules/custom/prisoner_hub_priority_content/tests/src/ExistingSite/PriorityContentTest.php
+++ b/docroot/modules/custom/prisoner_hub_priority_content/tests/src/ExistingSite/PriorityContentTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Drupal\Tests\prisoner_hub_priority_content;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests for priority content.
+ *
+ * @group prisoner_hub_priority_content
+ */
+class PriorityContentTest extends ExistingSiteBase {
+
+  use NodeCreationTrait;
+  use JsonApiTrait;
+
+  /**
+   * User on the comms team.
+   */
+  protected AccountInterface $commsUser;
+
+  /**
+   * User not on the comms team.
+   */
+  protected AccountInterface $nonCommsUser;
+
+  /**
+   * Admin user.
+   */
+  protected AccountInterface $adminUser;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->commsUser = $this->createUser();
+    $this->commsUser->addRole('comms_live_service_hq');
+    $this->commsUser->addRole('local_administrator');
+    $this->commsUser->save();
+
+    $this->nonCommsUser = $this->createUser();
+    $this->nonCommsUser->addRole('local_administrator');
+    $this->nonCommsUser->save();
+
+    $this->adminUser = $this->createUser();
+    $this->adminUser->addRole('administrator');
+    $this->adminUser->save();
+  }
+
+  /**
+   * Tests comms team can see flag to prioritise content, defaulting to on.
+   */
+  public function testCommsTeamCanPrioritiseContent(): void {
+    $this->drupalLogin($this->commsUser);
+    $this->visit('/node/add/page');
+    $this->assertTrue($this->getCurrentPage()->hasField('Prioritise on Recently Added section of home pages'));
+
+    // Check comms team defaults to being prioritised.
+    $this->assertEquals(1, $this->getCurrentPage()->findField('Prioritise on Recently Added section of home pages')->getValue());
+    $this->drupalLogout();
+  }
+
+  /**
+   * Tests non-comms team cannot see flag to prioritise content.
+   */
+  public function testNonCommsCannotPrioritiseContent(): void {
+    $this->drupalLogin($this->nonCommsUser);
+    $this->visit('/node/add/page');
+    $this->assertFalse($this->getCurrentPage()->hasField('Prioritise on Recently Added section of home pages'));
+    $this->drupalLogout();
+  }
+
+  /**
+   * Tests admin can see the flag, but it defaults to off.
+   */
+  public function testAdminCanPrioritiseContent(): void {
+    $this->drupalLogin($this->adminUser);
+    $this->visit('/node/add/page');
+    $this->assertTrue($this->getCurrentPage()->hasField('Prioritise on Recently Added section of home pages'));
+
+    // Check admin defaults to not being prioritised.
+    $this->assertEquals(0, $this->getCurrentPage()->findField('Prioritise on Recently Added section of home pages')->getValue());
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test comms can see the flag for content created by other users.
+   *
+   * It should not be set.
+   */
+  public function testCommsSeeFlagOnOthersContent(): void {
+    $this->drupalLogin($this->nonCommsUser);
+    $node = $this->createNode();
+    $this->drupalLogout();
+
+    $this->drupalLogin($this->commsUser);
+    $this->visit('/node/' . $node->id() . '/edit');
+    $this->assertEquals(0, $this->getCurrentPage()->findField('Prioritise on Recently Added section of home pages')->getValue());
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test prioritised content is returned first in the recently added endpoint.
+   *
+   * Also tests that the prioritised content is no more than 50% of the
+   * returned content, even when more is available.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testPrioritisedContentIsPrioritised(): void {
+    // Create 4 priority nodes.
+    for ($index = 1; $index < 5; $index++) {
+      $node = $this->createNode([
+        'title' => "Priority Node $index",
+        'field_prioritise_on_recently_add' => 1,
+        'field_prisons' => ['1603'],
+      ]);
+      $node->save();
+    }
+
+    // Create 4 non-priority nodes.
+    for ($index = 1; $index < 5; $index++) {
+      $node = $this->createNode([
+        'title' => "Non-Priority Node $index",
+        'field_prioritise_on_recently_add' => 0,
+        'field_prisons' => ['1603'],
+      ]);
+      $node->save();
+    }
+
+    $url = Url::fromUri('internal:/jsonapi/prison/thestudio/recently-added?page[limit]=4');
+    $response = $this->getJsonApiResponse($url);
+    $response_document = Json::decode((string) $response->getBody());
+    $this->assertEquals(4, count($response_document['data']));
+    // Check first two data elements are priority content, and second two are
+    // not.
+    $this->assertStringStartsWith('Priority Node ', $response_document['data'][0]['attributes']['title']);
+    $this->assertStringStartsWith('Priority Node ', $response_document['data'][1]['attributes']['title']);
+    $this->assertStringStartsWith('Non-Priority Node ', $response_document['data'][2]['attributes']['title']);
+    $this->assertStringStartsWith('Non-Priority Node ', $response_document['data'][3]['attributes']['title']);
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_priority_content/tests/src/ExistingSite/PriorityContentTest.php
+++ b/docroot/modules/custom/prisoner_hub_priority_content/tests/src/ExistingSite/PriorityContentTest.php
@@ -122,7 +122,6 @@ class PriorityContentTest extends ExistingSiteBase {
       $node = $this->createNode([
         'title' => "Priority Node $index",
         'field_prioritise_on_recently_add' => 1,
-        'field_prisons' => ['1603'],
       ]);
       $node->save();
     }
@@ -132,12 +131,11 @@ class PriorityContentTest extends ExistingSiteBase {
       $node = $this->createNode([
         'title' => "Non-Priority Node $index",
         'field_prioritise_on_recently_add' => 0,
-        'field_prisons' => ['1603'],
       ]);
       $node->save();
     }
 
-    $url = Url::fromUri('internal:/jsonapi/prison/thestudio/recently-added?page[limit]=4');
+    $url = Url::fromUri('internal:/jsonapi/recently-added?page[limit]=4');
     $response = $this->getJsonApiResponse($url);
     $response_document = Json::decode((string) $response->getBody());
     $this->assertEquals(4, count($response_document['data']));

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
@@ -9,7 +9,6 @@ use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
@@ -8,6 +8,7 @@ use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
@@ -20,6 +21,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
   use PrisonerHubPrisonAccessTestTrait;
@@ -248,21 +250,6 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
         return $data['id'];
       }, $response_document['data']), $message);
     }
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
@@ -38,7 +38,7 @@ class PrisonerHubPrisonAccessCmsTest extends ExistingSiteBase {
   /**
    * Name of the field denoting the prison that owns the content.
    */
-  protected string $prisonerOwnerFieldName;
+  protected string $prisonOwnerFieldName;
 
   /**
    * Name of the field denoting to which prison a user belongs.

--- a/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access_cms/tests/src/ExistingSite/PrisonerHubPrisonAccessCmsTest.php
@@ -36,6 +36,16 @@ class PrisonerHubPrisonAccessCmsTest extends ExistingSiteBase {
   protected $user;
 
   /**
+   * Name of the field denoting the prison that owns the content.
+   */
+  protected string $prisonerOwnerFieldName;
+
+  /**
+   * Name of the field denoting to which prison a user belongs.
+   */
+  protected string $userPrisonFieldName;
+
+  /**
    * Create prison taxonomy terms and a user to test with.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -66,7 +66,7 @@ class RecentlyAdded extends EntityResourceBase {
 
     $pagination = $this->getPagination($request);
     if ($pagination->getOffset() != 0) {
-      throw new CacheableBadRequestHttpException($cacheability, 'This resource does not currently support and offset greater than 0.');
+      throw new CacheableBadRequestHttpException($cacheability, 'This resource does not currently support an offset greater than 0.');
     }
     if ($pagination->getSize() <= 0) {
       throw new CacheableBadRequestHttpException($cacheability, 'The page size needs to be a positive integer.');
@@ -74,18 +74,33 @@ class RecentlyAdded extends EntityResourceBase {
 
     // Multidimensional array, each item containing a 'published_at' timestamp
     // and a 'entity' key.
-    $timestamps_and_entities = [];
+    $priority_timestamps_and_entities = [];
 
     // Load in series and content entities separately.
     // We are unable to run everything in one db query, due to the different
     // rules for content in a series.
-    $this->loadSeriesEntities($timestamps_and_entities, $pagination->getSize());
-    $this->loadContentEntities($timestamps_and_entities, $pagination->getSize());
+    // First half of the content (rounding up) should be priority content.
+    $priority_count = (int) ceil($pagination->getSize() / 2);
+    $this->loadSeriesEntities($priority_timestamps_and_entities, $priority_count, TRUE);
+    $this->loadContentEntities($priority_timestamps_and_entities, $priority_count, TRUE);
 
     // Sort the $timestamps_and_entities array.
-    usort($timestamps_and_entities, function ($a, $b) {
+    usort($priority_timestamps_and_entities, function ($a, $b) {
       return $b['published_at'] <=> $a['published_at'];
     });
+
+    // Then get the content non-priority content.
+    $non_priority_timestamps_and_entities = [];
+    $non_priority_count = $pagination->getSize() - count($priority_timestamps_and_entities);
+    $this->loadSeriesEntities($non_priority_timestamps_and_entities, $non_priority_count, FALSE);
+    $this->loadContentEntities($non_priority_timestamps_and_entities, $non_priority_count, FALSE);
+
+    // Sort the $timestamps_and_entities array.
+    usort($non_priority_timestamps_and_entities, function ($a, $b) {
+      return $b['published_at'] <=> $a['published_at'];
+    });
+
+    $timestamps_and_entities = array_merge($priority_timestamps_and_entities, $non_priority_timestamps_and_entities);
 
     // Extract the "entity" key from the array.
     $entities = array_column($timestamps_and_entities, 'entity');
@@ -108,11 +123,14 @@ class RecentlyAdded extends EntityResourceBase {
    *   The array of content entities, passed in by reference, to be appended to.
    * @param int $size
    *   The size requested.
+   * @param bool $priority
+   *   TRUE - only return prioritised content.
+   *   FALSE - only return non-prioritised content.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  protected function loadSeriesEntities(array &$timestamps_and_entities, int $size) {
+  protected function loadSeriesEntities(array &$timestamps_and_entities, int $size, bool $priority) {
     // Use aggregateQuery instead of standard entity query, so that we can group
     // by series (to remove duplicates).
     $query = $this->entityTypeManager->getStorage('node')->getAggregateQuery()->accessCheck(TRUE);
@@ -127,6 +145,18 @@ class RecentlyAdded extends EntityResourceBase {
     // Note that prison category rules are automatically applied to the query.
     // @see \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber.
     $query->condition('status', NodeInterface::PUBLISHED);
+
+    if ($priority) {
+      $query->condition('field_prioritise_on_recently_add', TRUE);
+    }
+    else {
+      // Non-prioritised content has value NULL or FALSE, depending on if it
+      // existed before the field_prioritise_on_recently_add field existed.
+      $orCondition = $query->orConditionGroup()
+        ->condition('field_prioritise_on_recently_add', NULL, 'IS NULL')
+        ->condition('field_prioritise_on_recently_add', FALSE);
+      $query->condition($orCondition);
+    }
 
     // If already have enough entities set, ensure we only query for newer
     // content. (This avoids having to unnecessarily load entities).
@@ -155,11 +185,14 @@ class RecentlyAdded extends EntityResourceBase {
    *   appended to.
    * @param int $size
    *   The size requested.
+   * @param bool $priority
+   *   TRUE - only return prioritised content.
+   *   FALSE - only return non-prioritised content.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  protected function loadContentEntities(array &$timestamps_and_entities, int $size) {
+  protected function loadContentEntities(array &$timestamps_and_entities, int $size, bool $priority) {
     $query = $this->entityTypeManager->getStorage('node')->getQuery();
     $query->condition('type', self::$contentTypes, 'IN');
 
@@ -170,6 +203,18 @@ class RecentlyAdded extends EntityResourceBase {
     // Note that prison category rules are automatically applied to the query.
     // @see \Drupal\prisoner_hub_prison_access\EventSubscriber\QueryAccessSubscriber.
     $query->condition('status', NodeInterface::PUBLISHED);
+
+    if ($priority) {
+      $query->condition('field_prioritise_on_recently_add', TRUE);
+    }
+    else {
+      // Non-prioritised content has value NULL or FALSE, depending on if it
+      // existed before the field_prioritise_on_recently_add field existed.
+      $orCondition = $query->orConditionGroup()
+        ->condition('field_prioritise_on_recently_add', NULL, 'IS NULL')
+        ->condition('field_prioritise_on_recently_add', FALSE);
+      $query->condition($orCondition);
+    }
 
     // If already have enough entities set, ensure we only query for newer
     // content. (This avoids having to unnecessarily load entities).

--- a/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/tests/src/ExistingSite/PrisonerHubRecentlyAddedTest.php
@@ -6,6 +6,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
@@ -19,6 +20,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
 
@@ -81,7 +83,22 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
    * Test the resource returns the correct entities, in the correct order.
    */
   public function testRecentlyAddedCorrectSorting() {
-    $this->assertJsonResponse($this->correctOrderUuids);
+    // Up to 50% of the response from the end point may come from prioritised
+    // content, rather than new content. So all we can test is that two of
+    // our test pieces of content are present and in the right order.
+    $response = $this->getJsonApiResponse($this->jsonApiUrl);
+    $this->assertSame(200, $response->getStatusCode());
+
+    $response_document = Json::decode((string) $response->getBody());
+    $this->assertEquals(4, count($response_document['data']));
+
+    $response_ids = array_map(static function (array $data) {
+      return $data['id'];
+    }, $response_document['data']);
+
+    $this->assertContains($this->correctOrderUuids[0], $response_ids);
+    $this->assertContains($this->correctOrderUuids[1], $response_ids);
+    $this->assertGreaterThan(array_search($this->correctOrderUuids[0], $response_ids), array_search($this->correctOrderUuids[1], $response_ids));
   }
 
   /**
@@ -100,25 +117,13 @@ class PrisonerHubRecentlyAddedTest extends ExistingSiteBase {
       'field_not_in_series' => 1,
       'published_at' => strtotime('+1 second'),
     ]);
-    $this->correctOrderUuids = array_merge([$new_entity->uuid()], array_slice($this->correctOrderUuids, 0, 3));
-    $this->assertJsonResponse($this->correctOrderUuids);
-  }
 
-  /**
-   * Asserts the jsonapi response.
-   *
-   * @param array $correct_order_uuids
-   *   An array of uuids, in the correct order, to check for.
-   */
-  protected function assertJsonResponse(array $correct_order_uuids) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    $response = $this->request('GET', $this->jsonApiUrl, $request_options);
-    $this->assertSame(200, $response->getStatusCode());
+    $response = $this->getJsonApiResponse($this->jsonApiUrl);
     $response_document = Json::decode((string) $response->getBody());
-    $this->assertEquals($correct_order_uuids, array_map(static function (array $data) {
+    $response_ids = array_map(static function (array $data) {
       return $data['id'];
-    }, $response_document['data']));
+    }, $response_document['data']);
+    $this->assertContains($new_entity->uuid(), $response_ids);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -6,19 +6,21 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
- * Test the the content suggestions JSON:API resource works correctly.
+ * Test that the content suggestions JSON:API resource works correctly.
  *
  * @group prisoner_hub_content_suggestions
  */
 class PrisonerHubSubTermsTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
 
@@ -287,21 +289,6 @@ class PrisonerHubSubTermsTest extends ExistingSiteBase {
     $invalidation_count = \Drupal::service('cache_tags.invalidator.checksum')->getCurrentChecksum(['prisoner_hub_sub_terms:' . $new_category->id()]);
     $this->assertSame(1, $invalidation_count, 'Cache tag has been cleared exactly one time.');
 
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/tests/src/ExistingSite/PrisonerHubSubTermsTest.php
@@ -7,7 +7,6 @@ use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;

--- a/docroot/modules/custom/prisoner_hub_taxonomy_access/tests/src/ExistingSite/PrisonerHubTaxonomyAccessTest.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_access/tests/src/ExistingSite/PrisonerHubTaxonomyAccessTest.php
@@ -6,9 +6,9 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use Drupal\Tests\prisoner_hub_test_traits\Traits\JsonApiTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
-use GuzzleHttp\RequestOptions;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
@@ -21,6 +21,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class PrisonerHubTaxonomyAccessTest extends ExistingSiteBase {
 
   use JsonApiRequestTestTrait;
+  use JsonApiTrait;
   use NodeCreationTrait;
   use TaxonomyCreationTrait;
 
@@ -196,21 +197,6 @@ class PrisonerHubTaxonomyAccessTest extends ExistingSiteBase {
     $url = Url::fromUri('internal:/jsonapi/taxonomy_term/' . $category->bundle() . '/' . $category->uuid());
     $response = $this->getJsonApiResponse($url);
     $this->assertSame(200, $response->getStatusCode(), $url->toString() . ' returns a 200 response.');
-  }
-
-  /**
-   * Get a response from a JSON:API url.
-   *
-   * @param \Drupal\Core\Url $url
-   *   The url object to use for the JSON:API request.
-   *
-   * @return \Psr\Http\Message\ResponseInterface
-   *   The response object.
-   */
-  public function getJsonApiResponse(Url $url) {
-    $request_options = [];
-    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
-    return $this->request('GET', $url, $request_options);
   }
 
 }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/tests/src/ExistingSite/SeriesSortByTest.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/tests/src/ExistingSite/SeriesSortByTest.php
@@ -30,6 +30,11 @@ class SeriesSortByTest extends ExistingSiteBase {
   protected $seriesTerm;
 
   /**
+   * URL for calling JSON:API page endpoint.
+   */
+  protected Url $jsonApiUrl;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() : void {

--- a/docroot/modules/custom/prisoner_hub_test_traits/prisoner_hub_test_traits.info.yml
+++ b/docroot/modules/custom/prisoner_hub_test_traits/prisoner_hub_test_traits.info.yml
@@ -1,0 +1,5 @@
+name: 'Prisoner Hub Test Traits'
+type: module
+description: 'Traits for common functionality in Prisoner Hub automated tests'
+package: Custom
+core_version_requirement: ^10

--- a/docroot/modules/custom/prisoner_hub_test_traits/tests/src/Traits/JsonApiTrait.php
+++ b/docroot/modules/custom/prisoner_hub_test_traits/tests/src/Traits/JsonApiTrait.php
@@ -22,7 +22,7 @@ trait JsonApiTrait {
    * @return \Psr\Http\Message\ResponseInterface
    *   The response object.
    */
-  public function getJsonApiResponse(Url $url) {
+  protected function getJsonApiResponse(Url $url) {
     $request_options = [];
     $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
     return $this->request('GET', $url, $request_options);

--- a/docroot/modules/custom/prisoner_hub_test_traits/tests/src/Traits/JsonApiTrait.php
+++ b/docroot/modules/custom/prisoner_hub_test_traits/tests/src/Traits/JsonApiTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\Tests\prisoner_hub_test_traits\Traits;
+
+use Drupal\Core\Url;
+use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
+use GuzzleHttp\RequestOptions;
+
+/**
+ * Trait for JSON:API manipulation in test classes.
+ */
+trait JsonApiTrait {
+
+  use JsonApiRequestTestTrait;
+
+  /**
+   * Get a response from a JSON:API url.
+   *
+   * @param \Drupal\Core\Url $url
+   *   The url object to use for the JSON:API request.
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   *   The response object.
+   */
+  public function getJsonApiResponse(Url $url) {
+    $request_options = [];
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    return $this->request('GET', $url, $request_options);
+  }
+
+}

--- a/patches/file_permissions.3411976-25.patch
+++ b/patches/file_permissions.3411976-25.patch
@@ -1,0 +1,27 @@
+From 70593e694ee9f245efb777fbb63fdd7bb3fe0519 Mon Sep 17 00:00:00 2001
+From: Camilo Ernesto Escobar Bedoya <escobar@urbaninsight.com>
+Date: Wed, 10 Jan 2024 23:42:23 -0500
+Subject: [PATCH] field_permissions_jsonapi_entity_field_filter_access -
+ Drupal\field_permissions\FieldPermissionsService::fieldGetPermissionType():
+ Argument #1 () must be of type Drupal\field\FieldStorageConfigInterface
+
+---
+ field_permissions.module | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/field_permissions.module b/field_permissions.module
+index 84c5e78..48cf0a7 100644
+--- a/field_permissions.module
++++ b/field_permissions.module
+@@ -47,7 +47,7 @@ function field_permissions_entity_field_access($operation, FieldDefinitionInterf
+  * Implements hook_jsonapi_entity_field_filter_access().
+  */
+ function field_permissions_jsonapi_entity_field_filter_access(FieldDefinitionInterface $field_definition, AccountInterface $account) {
+-  if (!$field_definition->isDisplayConfigurable('view')) {
++  if (!$field_definition->isDisplayConfigurable('view') || !is_a($field_definition->getFieldStorageDefinition(), '\Drupal\field\FieldStorageConfigInterface')) {
+     return AccessResult::neutral();
+   }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-820

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

* Introduces a new role exclusively for the comms team
* Creates a new boolean field to prioritise the 5 main prisoner facing content types
* Restricts access to that field to admin and those with the new comms role
* Defaults the priority field to be set to true when members of the comms role create content
* Adjusts the Recently Added JSON:API resource, and hence the Recently Added section of homepages, to return half prioritised content, half unprioritised content, with the prioritised content showing first. 

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development

This PR does include some changes not directly associated with the story; since upgrading to PHP 8.3, use of undeclared class properties became deprecated. This raises a lot of noise in test runs, and as we were writing new tests, it was appropriate to add property declarations to remove the deprecation warnings.

Also there was duplicated code in the test classes for a function getJsonApiResponse(). As we needed something similar for the new tests, this was refactored into a trait and the duplicate code removed from all test classes, rather than duplicate the code one more time and exacerbating the problem.