### PR TITLE
LNP-879 PHPStan level 1 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
           command: |
             set -x
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make coding-standards
+            docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make php-stan
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make install-drupal
             docker-compose -f << parameters.docker-compose-filename >> exec << parameters.docker-image-name-backend >> make run-tests
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ ENV PATH="/var/www/html/vendor/bin:/var/www/.local/bin:$PATH"
 
 # Copy Project files.
 # Copy with chown as otherwise files are owned by root.
-COPY --chown=www-data:www-data composer.json composer.lock Makefile ./
+COPY --chown=www-data:www-data composer.json composer.lock Makefile phpstan.neon ./
 COPY --chown=www-data:www-data patches patches
 COPY --chown=www-data:www-data docroot docroot
 COPY --chown=www-data:www-data config config

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ install-drupal:
 coding-standards:
 	vendor/bin/phpcs --standard=Drupal,DrupalPractice --extensions=php,module,theme,css,js docroot/modules/custom/ docroot/themes/custom/ docroot/sites/default/settings.php
 
+php-stan:
+	vendor/bin/phpstan.phar
+
 run-tests:
 	echo "Running tests on existing site"
 	vendor/bin/phpunit --testsuite=existing-site --log-junit ~/phpunit/junit-existing-site.xml --verbose

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ coding-standards:
 	vendor/bin/phpcs --standard=Drupal,DrupalPractice --extensions=php,module,theme,css,js docroot/modules/custom/ docroot/themes/custom/ docroot/sites/default/settings.php
 
 php-stan:
-	vendor/bin/phpstan.phar
+	vendor/bin/phpstan analyze -c ./phpstan.neon
 
 run-tests:
 	echo "Running tests on existing site"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ coding-standards:
 	vendor/bin/phpcs --standard=Drupal,DrupalPractice --extensions=php,module,theme,css,js docroot/modules/custom/ docroot/themes/custom/ docroot/sites/default/settings.php
 
 php-stan:
-	vendor/bin/phpstan analyze -c ./phpstan.neon
+	vendor/bin/phpstan analyze
 
 run-tests:
 	echo "Running tests on existing site"

--- a/composer.json
+++ b/composer.json
@@ -218,8 +218,12 @@
     "require-dev": {
         "dmore/chrome-mink-driver": "^2.7",
         "drupal/core-dev": "^10",
+        "mglaman/phpstan-drupal": "^1.2",
         "palantirnet/drupal-rector": "^0.15.1",
         "phpspec/prophecy-phpunit": "^2",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
         "weitzman/drupal-test-traits": "^2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80556dfabb85c8caae56de3c9e6609c9",
+    "content-hash": "7d087f99af3e9695918bfedb035f0ea5",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -14284,16 +14284,16 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.2.10",
+            "version": "1.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "cdafb3285beeb5fadf25a43e18fee6f80bb14575"
+                "reference": "e624a4b64de5b91a0c56852635af2115e9a6e08c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/cdafb3285beeb5fadf25a43e18fee6f80bb14575",
-                "reference": "cdafb3285beeb5fadf25a43e18fee6f80bb14575",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/e624a4b64de5b91a0c56852635af2115e9a6e08c",
+                "reference": "e624a4b64de5b91a0c56852635af2115e9a6e08c",
                 "shasum": ""
             },
             "require": {
@@ -14308,10 +14308,10 @@
                 "behat/mink": "^1.8",
                 "composer/installers": "^1.9",
                 "drupal/core-recommended": "^10",
-                "drush/drush": "^10.0 || ^11 || ^12",
+                "drush/drush": "^10.0 || ^11 || ^12 || ^13@beta",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^8.5 || ^9",
+                "phpunit/phpunit": "^8.5 || ^9 || ^10 || ^11",
                 "slevomat/coding-standard": "^7.1",
                 "squizlabs/php_codesniffer": "^3.3",
                 "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0 || ^7.0"
@@ -14368,7 +14368,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.10"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.11"
             },
             "funding": [
                 {
@@ -14384,7 +14384,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-02T17:27:29+00:00"
+            "time": "2024-05-10T17:22:10+00:00"
         },
         {
             "name": "micheh/phpcs-gitlab",
@@ -15437,16 +15437,16 @@
         },
         {
             "name": "phpstan/extension-installer",
-            "version": "1.3.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a"
+                "reference": "f6b87faf9fc7978eab2f7919a8760bc9f58f9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f45734bfb9984c6c56c4486b71230355f066a58a",
-                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f6b87faf9fc7978eab2f7919a8760bc9f58f9203",
+                "reference": "f6b87faf9fc7978eab2f7919a8760bc9f58f9203",
                 "shasum": ""
             },
             "require": {
@@ -15475,9 +15475,9 @@
             "description": "Composer plugin for automatic installation of PHPStan extensions",
             "support": {
                 "issues": "https://github.com/phpstan/extension-installer/issues",
-                "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.1"
             },
-            "time": "2023-05-24T08:59:17+00:00"
+            "time": "2024-06-10T08:20:49+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -15528,16 +15528,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.11.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "e370bcddadaede0c1716338b262346f40d296f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e370bcddadaede0c1716338b262346f40d296f82",
+                "reference": "e370bcddadaede0c1716338b262346f40d296f82",
                 "shasum": ""
             },
             "require": {
@@ -15582,29 +15582,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2024-08-01T16:25:18+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "1.1.4",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa"
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa",
-                "reference": "089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10.3"
+                "phpstan/phpstan": "^1.11"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-php-parser": "^1.1",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^9.5"
             },
@@ -15628,9 +15627,9 @@
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.1.4"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
             },
-            "time": "2023-08-05T09:02:04+00:00"
+            "time": "2024-04-20T06:39:48+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
+++ b/docroot/modules/custom/prisoner_hub_prison_access/tests/src/ExistingSite/PrisonerHubQueryAccessTestBase.php
@@ -43,7 +43,7 @@ abstract class PrisonerHubQueryAccessTestBase extends ExistingSiteBase {
    * @param array $values
    *   An array of field values.
    *
-   * @return int
+   * @return null|string
    *   The uuid of the created entity.
    */
   protected function createEntity(string $entity_type_id, string $bundle, array $values) {

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -13,9 +13,7 @@ use Drupal\jsonapi\Query\OffsetPage;
 use Drupal\jsonapi\ResourceResponse;
 use Drupal\jsonapi\ResourceType\ResourceType;
 use Drupal\jsonapi_resources\Resource\EntityResourceBase;
-use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
@@ -192,7 +190,7 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
     $query->range(0, $size);
     $results = $this->executeQueryInRenderContext($query);
     foreach ($results as $result) {
-      $term = Term::load($result['field_moj_series_target_id']);
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($result['field_moj_series_target_id']);
       if ($term) {
         $timestamps_and_entities[] = [
           'published_at' => (int) $result['published_at_max'],
@@ -250,7 +248,7 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
     $query->sort('published_at', 'DESC');
     $query->range(0, $size);
     $result = $this->executeQueryInRenderContext($query);
-    $nodes = Node::loadMultiple($result);
+    $nodes = $this->entityTypeManager->getStorage('taxonomy_term')->loadMultiple($result);
     foreach ($nodes as $node) {
       $timestamps_and_entities[] = [
         'published_at' => (int) $node->get('published_at')->value,

--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -248,7 +248,7 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
     $query->sort('published_at', 'DESC');
     $query->range(0, $size);
     $result = $this->executeQueryInRenderContext($query);
-    $nodes = $this->entityTypeManager->getStorage('taxonomy_term')->loadMultiple($result);
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($result);
     foreach ($nodes as $node) {
       $timestamps_and_entities[] = [
         'published_at' => (int) $node->get('published_at')->value,

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -3,9 +3,11 @@
 namespace Drupal\prisoner_hub_sub_terms\Resource;
 
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Http\Exception\CacheableBadRequestHttpException;
 use Drupal\Core\Render\RenderContext;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\jsonapi\JsonApiResource\Link;
 use Drupal\jsonapi\JsonApiResource\LinkCollection;
@@ -15,6 +17,7 @@ use Drupal\jsonapi_resources\Resource\EntityResourceBase;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 
@@ -26,7 +29,23 @@ use Symfony\Component\Routing\Route;
  *
  * @internal
  */
-class SubTerms extends EntityResourceBase {
+class SubTerms extends EntityResourceBase implements ContainerInjectionInterface {
+
+  /**
+   * Returns a new SubTerms resource.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   Renderer.
+   */
+  public function __construct(protected RendererInterface $renderer) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('renderer'));
+  }
+
 
   /**
    * Process the resource request.
@@ -245,7 +264,7 @@ class SubTerms extends EntityResourceBase {
    */
   protected function executeQueryInRenderContext(QueryInterface $query) {
     $context = new RenderContext();
-    return \Drupal::service('renderer')->executeInRenderContext($context, function () use ($query) {
+    return $this->renderer->executeInRenderContext($context, function () use ($query) {
       return $query->accessCheck(TRUE)->execute();
     });
   }

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -46,7 +46,6 @@ class SubTerms extends EntityResourceBase implements ContainerInjectionInterface
     return new static($container->get('renderer'));
   }
 
-
   /**
    * Process the resource request.
    *

--- a/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
+++ b/docroot/modules/custom/prisoner_hub_sub_terms/src/Resource/SubTerms.php
@@ -15,7 +15,6 @@ use Drupal\jsonapi\Query\OffsetPage;
 use Drupal\jsonapi\ResourceResponse;
 use Drupal\jsonapi_resources\Resource\EntityResourceBase;
 use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -122,7 +121,7 @@ class SubTerms extends EntityResourceBase implements ContainerInjectionInterface
 
     $results = $this->executeQueryInRenderContext($query);
     $taxonomy_ids = $this->getTaxonomyIdsFromQueryResults($results);
-    $entities = Term::loadMultiple($taxonomy_ids);
+    $entities = $this->entityTypeManager->getStorage('taxonomy_term')->loadMultiple($taxonomy_ids);
     $processed_entities = $this->filterClosestSubCategoriesAndSeries($entities, $taxonomy_term);
 
     $result_entities = array_slice($processed_entities, $pagination->getOffset(), $pagination->getSize());
@@ -194,7 +193,7 @@ class SubTerms extends EntityResourceBase implements ContainerInjectionInterface
       }
       $top_level_id = $this->findClosestSubCategory($category_id, $top_parent_entity->id());
       if (!isset($processed_entities[$top_level_id]) && $top_level_id) {
-        $top_level_entity = $entities[$top_level_id] ?? Term::load($top_level_id);
+        $top_level_entity = $entities[$top_level_id] ?? $this->entityTypeManager->getStorage('taxonomy_term')->load($top_level_id);
         $processed_entities[$top_level_id] = $top_level_entity;
       }
     }

--- a/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/tests/src/ExistingSiteJavascript/TaxonomyFieldsFormStatesTest.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_field_ux/tests/src/ExistingSiteJavascript/TaxonomyFieldsFormStatesTest.php
@@ -69,7 +69,7 @@ class TaxonomyFieldsFormStatesTest extends ExistingSiteSelenium2DriverTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->studioAdministrator = User::create([
@@ -199,7 +199,7 @@ class TaxonomyFieldsFormStatesTest extends ExistingSiteSelenium2DriverTestBase {
   /**
    * Remove the users we created for the test.
    */
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
     $this->studioAdministrator->delete();
     $this->localContentManagerUser->delete();

--- a/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/EntityPreSave.php
+++ b/docroot/modules/custom/prisoner_hub_taxonomy_sorting/src/EntityPreSave.php
@@ -81,6 +81,9 @@ class EntityPreSave {
           $calculated_sort_value = 0;
         }
         break;
+
+      default:
+        $calculated_sort_value = 0;
     }
 
     // If the sorting is descending, cast this as a negative number to invert

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,6 @@ parameters:
     paths:
         - docroot/modules/custom
         - docroot/themes/custom
+    ignoreErrors:
+    # new static() is a best practice in Drupal, so we cannot fix that.
+    - "#^Unsafe usage of new static#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 1
+    paths:
+        - docroot/modules/custom
+        - docroot/themes/custom


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-879

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

* adds phpstan-drupal and its dependencies to the dev requirements in composer, to make phpstan available in local and CI environments
* adds a command to the Makefile for running phpstan
* adds a configuration file for phpstan, and makes sure it is copied to docker environments in the Dockerfile
* adds running of phpstan to the run-tests section of the CircleCI configuration
* fixes all issues in the current codebase identified by phpstan running at level 1
  * incompatible overridden methods, eg where explicit return types are missing
  * removal of use of potentially uninitialised variables
  * remedy of all instances of \Drupal::service() method in favour of dependency injection
  * remedy of use of static methods to load entities in favour of injected entity type manager

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
