### PR TITLE
LNP-718: 🐛  fix bug in recently-added endpoint

### DIFF
--- a/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
+++ b/docroot/modules/custom/prisoner_hub_recently_added/src/Resource/RecentlyAdded.php
@@ -112,6 +112,12 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
       return $b['published_at'] <=> $a['published_at'];
     });
 
+    // Because the series entities and content entities have been independently
+    // loaded, we may have too many entries in the
+    // $priority_timestamps_and_entities array. Make sure we have
+    // $priority_count at most.
+    $priority_timestamps_and_entities = array_slice($priority_timestamps_and_entities, 0, $priority_count);
+
     // Then get the content non-priority content.
     $non_priority_timestamps_and_entities = [];
     $non_priority_count = $pagination->getSize() - count($priority_timestamps_and_entities);
@@ -154,6 +160,10 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function loadSeriesEntities(array &$timestamps_and_entities, int $size, bool $priority) {
+    if ($size == 0) {
+      return;
+    }
+
     // Use aggregateQuery instead of standard entity query, so that we can group
     // by series (to remove duplicates).
     $query = $this->entityTypeManager->getStorage('node')->getAggregateQuery()->accessCheck(TRUE);
@@ -216,6 +226,10 @@ class RecentlyAdded extends EntityResourceBase implements ContainerInjectionInte
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function loadContentEntities(array &$timestamps_and_entities, int $size, bool $priority) {
+    if ($size == 0) {
+      return;
+    }
+
     $query = $this->entityTypeManager->getStorage('node')->getQuery();
     $query->condition('type', self::$contentTypes, 'IN');
 


### PR DESCRIPTION
trim priority content to half the required value before loading non-priority content. This fixes the issue where non-priority content tries to load 0 entries and then crashes.

Also return early if trying to load 0 items in the recently-added endpoint. This can still happen despite the above if the requested page size is 1 - this leads to 1 item of priority content (if there is any) and 0 items of non-priority content.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-952

> If this is an issue, do we have steps to reproduce?

Prioritise lots of content. Attempt to load a prison home page.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Trims the size of the set of prioritised content before working how much non-prioritised content to load.
This protects against against trying to load 0 non-prioritised items which was the condition that triggered the error.

However it is also possible to trigger the error when the end point is called with a size limit of 1 if there is 1 piece of prioritised content. Therefore both load functions in the class return early when asked to load 0 items.


> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
