### PR TITLE
LNP-968: 🔥  drop target database before importing database dump.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,6 @@ sync:
 	# Downloading latest db backup from S3
 	docker-compose exec drupal scripts/downloadDBFromBackup.sh
 	# Download complete
-	# Clearing Drupal db of existing data
-	docker-compose exec -it drupal drush sql-drop -y
 	# Importing db backup to Drupal DB
 	docker-compose exec drupal scripts/importDBFromBackup.sh
 	# Import complete

--- a/helm_deploy/prisoner-content-hub-backend/db-backup.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-backup.sh
@@ -27,7 +27,7 @@ do
 done
 
 filename="db_backup_$(date +"%F-%H%M%S").sql.gz"
-mysqldump ${HUB_DB_ENV_MYSQL_DATABASE} | gzip -9 -c > ~/${filename}
+mysqldump --add-drop-database --databases ${HUB_DB_ENV_MYSQL_DATABASE} | gzip -9 -c > ~/${filename}
 
 mkdir ~/.aws/
 echo "[default]" > ~/.aws/credentials


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-968

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?

Adds flags to the mysqldump command run to take exports from production, so that when the dump is imported into other environments, the existing database will be dropped and recreated before the exported data is imported.

This ensures that any tables that exist eg in dev but not prod are removed on import. This stops issues where for example Drupal tries to create a table in a post-install action and fails because it unexpectedly exists.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
