### PR TITLE
LNP-975 account for different db names when refreshing db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ sync:
 	# Downloading latest db backup from S3
 	docker-compose exec drupal scripts/downloadDBFromBackup.sh
 	# Download complete
+	# Clearing Drupal db of existing data
+	docker-compose exec -it drupal drush sql-drop -y
 	# Importing db backup to Drupal DB
 	docker-compose exec drupal scripts/importDBFromBackup.sh
 	# Import complete

--- a/helm_deploy/prisoner-content-hub-backend/db-backup.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-backup.sh
@@ -27,7 +27,7 @@ do
 done
 
 filename="db_backup_$(date +"%F-%H%M%S").sql.gz"
-mysqldump --add-drop-database --databases ${HUB_DB_ENV_MYSQL_DATABASE} | gzip -9 -c > ~/${filename}
+mysqldump ${HUB_DB_ENV_MYSQL_DATABASE} | gzip -9 -c > ~/${filename}
 
 mkdir ~/.aws/
 echo "[default]" > ~/.aws/credentials

--- a/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
@@ -38,6 +38,11 @@ do
   fi
 done
 
+# Drop and recreate the database before importing the backup.
+# This ensures any tables in the current database that don't exist in the
+# backup are removed.
+mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f
+mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f
 mysql ${HUB_DB_ENV_MYSQL_DATABASE} < ~/${filenameExtracted}
 rm ~/${filenameExtracted}
 echo "Successfully imported database ${filenameExtracted}"


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-975

> If this is an issue, do we have steps to reproduce?

Try to run make-sync locally. The script will try to delete a database with the same name as the prod database, and fail.

### Intent

In LNP-968, we addressed the problem that during a database refresh, tables that were on the target system but not in the database dump would still be present after refresh.

That change built the dropping and recreation of the target database into the dump file. However, because that embeds the database name, and the database name is different across environments, this would not work.

> What changes are introduced by this PR that correspond to the above card?

This PR refactors that to move the dropping and recreation of the target database to the db-refresh.sh script for AWS environments, and to the Makefile for local environments.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
