### PR TITLE
LNP-975: 🗃️  mysqladmin cant connect during refresh

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
@@ -24,6 +24,12 @@ echo "user=${HUB_DB_ENV_MYSQL_USER}" >> ~/.my.cnf
 echo "password=${HUB_DB_ENV_MYSQL_PASSWORD}" >> ~/.my.cnf
 echo "host=${HUB_DB_PORT_3306_TCP_ADDR}" >> ~/.my.cnf
 
+echo "[mysqladmin]" >> ~/.my.cnf
+echo "user=${HUB_DB_ENV_MYSQL_USER}" >> ~/.my.cnf
+echo "password=${HUB_DB_ENV_MYSQL_PASSWORD}" >> ~/.my.cnf
+echo "host=${HUB_DB_PORT_3306_TCP_ADDR}" >> ~/.my.cnf
+
+
 # Make 8 maximum attempts to connect to the database.  This mitigates intermittent DNS issues.
 # See https://mojdt.slack.com/archives/C57UPMZLY/p1664264969450269
 # See https://mojdt.slack.com/archives/C57UPMZLY/p1666708074467369
@@ -41,8 +47,8 @@ done
 # Drop and recreate the database before importing the backup.
 # This ensures any tables in the current database that don't exist in the
 # backup are removed.
-mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f -h "${HUB_DB_PORT_3306_TCP_ADDR}"
-mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f -h "${HUB_DB_PORT_3306_TCP_ADDR}"
+mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f
+mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f
 mysql ${HUB_DB_ENV_MYSQL_DATABASE} < ~/${filenameExtracted}
 rm ~/${filenameExtracted}
 echo "Successfully imported database ${filenameExtracted}"

--- a/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
@@ -41,8 +41,8 @@ done
 # Drop and recreate the database before importing the backup.
 # This ensures any tables in the current database that don't exist in the
 # backup are removed.
-mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f
-mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f
+mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f -u "${HUB_DB_PORT_3306_TCP_ADDR}"
+mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f -u "${HUB_DB_PORT_3306_TCP_ADDR}"
 mysql ${HUB_DB_ENV_MYSQL_DATABASE} < ~/${filenameExtracted}
 rm ~/${filenameExtracted}
 echo "Successfully imported database ${filenameExtracted}"

--- a/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
+++ b/helm_deploy/prisoner-content-hub-backend/db-refresh.sh
@@ -41,8 +41,8 @@ done
 # Drop and recreate the database before importing the backup.
 # This ensures any tables in the current database that don't exist in the
 # backup are removed.
-mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f -u "${HUB_DB_PORT_3306_TCP_ADDR}"
-mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f -u "${HUB_DB_PORT_3306_TCP_ADDR}"
+mysqladmin drop ${HUB_DB_ENV_MYSQL_DATABASE} -f -h "${HUB_DB_PORT_3306_TCP_ADDR}"
+mysqladmin create ${HUB_DB_ENV_MYSQL_DATABASE} -f -h "${HUB_DB_PORT_3306_TCP_ADDR}"
 mysql ${HUB_DB_ENV_MYSQL_DATABASE} < ~/${filenameExtracted}
 rm ~/${filenameExtracted}
 echo "Successfully imported database ${filenameExtracted}"


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

[LNP-975](https://dsdmoj.atlassian.net/browse/LNP-975)
Note there was a previous merge to main for this ticket, which did not fix the problem that has only been pushed as far as staging.

> If this is an issue, do we have steps to reproduce?

Imports of the database backup to environments currently fail.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Adds the username, password, and host to a new [mysqladmin] section in the temporary my.conf used when importing backups. This allows mysqladmin to drop and recreate the target database before importing the dump.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development


[LNP-975]: https://dsdmoj.atlassian.net/browse/LNP-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ