### PR TITLE
LNP-1017: 🐛  content could not be filtered by Urgent Banner.

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -16,6 +16,7 @@ dependencies:
     - node.type.moj_radio_item
     - node.type.moj_video_item
     - node.type.page
+    - node.type.urgent_banner
     - taxonomy.vocabulary.moj_categories
     - taxonomy.vocabulary.prisons
     - taxonomy.vocabulary.series
@@ -983,9 +984,10 @@ display:
             moj_radio_item: moj_radio_item
             page: page
             help_page: help_page
-            link: link
             homepage: homepage
+            link: link
             moj_pdf_item: moj_pdf_item
+            urgent_banner: urgent_banner
             moj_video_item: moj_video_item
           group: 1
           exposed: true
@@ -1007,6 +1009,7 @@ display:
               moj_local_content_manager: '0'
               local_administrator: '0'
               administrator: '0'
+              comms_live_service_hq: '0'
             reduce: true
           is_grouped: false
           group_info:


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1017

> If this is an issue, do we have steps to reproduce?

* Go to /admin/content.
* Try to filter content by Urgent Banner content type.
* Fail because that option doesn't exist

### Intent

> What changes are introduced by this PR that correspond to the above card?

Adds Urgent Banner to content type filter option.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
