### PR TITLE
LNP-1032: 🩹  patch flysystem to remove deprecation warnings on PHP >=…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/flysystem": {
+                "Issue #3387094 - deprecation warnings on PHP >= 8.2": "patches/flysystem_3387094-add-context.patch"
+            },
             "drupal/flysystem_s3": {
                 "Issue #2772847 - Enable pre-signed links": "patches/flysystem_2772847-68-presigned_urls.patch",
                 "Issue #3248956 - Disable other fields when uploading files": "patches/flysystem_s3-3248956-disable-other-fields-when-uploading-MR.patch",

--- a/patches/flysystem_3387094-add-context.patch
+++ b/patches/flysystem_3387094-add-context.patch
@@ -1,0 +1,36 @@
+From f4cd809d1b77ce11663865cfb13690b0f4f6b862 Mon Sep 17 00:00:00 2001
+From: Elliot Ward <elliot.ward@digital.justice.gov.uk>
+Date: Mon, 28 Oct 2024 15:00:36 +0000
+Subject: [PATCH] #3387094: add $context to FlySystemBridge as required for
+ stream wrappers in PHP. See
+ https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props.context.
+ Without this, PHP warnings are raised as the property is created dynamically.
+ It would be ideal to add this to the parent class
+ \Twistor\FlysystemStreamWrapper, but the PR to add there is being ignored,
+ and that project has no commits since 2019.
+
+---
+ src/FlysystemBridge.php | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/FlysystemBridge.php b/src/FlysystemBridge.php
+index 998c37d..1f4dbce 100644
+--- a/src/FlysystemBridge.php
++++ b/src/FlysystemBridge.php
+@@ -14,6 +14,13 @@ class FlysystemBridge extends FlysystemStreamWrapper implements StreamWrapperInt
+ 
+   use StringTranslationTrait;
+ 
++  /**
++   * PHP-passed stream context.
++   *
++   * @var resource|null
++   */
++  public $context;
++
+   /**
+    * {@inheritdoc}
+    */
+-- 
+GitLab
+


### PR DESCRIPTION
… 8.2.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1032

> If this is an issue, do we have steps to reproduce?

Check logs for warnings of the form

Deprecated: Creation of dynamic property Drupal\flysystem\FlysystemBridge::$context

### Intent

> What changes are introduced by this PR that correspond to the above card?

Patches the flysystem module to include the $context member so that it doesn't get dynamically created and trigger the warning.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
