### PR TITLE
LNP-1047: 🛂  remove permissions from administrator role that were mov…

### DIFF
--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -114,8 +114,6 @@ permissions:
   - 'execute entity:save_action user'
   - 'execute entity:unpublish_action node'
   - 'execute entity:unpublish_action taxonomy_term'
-  - 'execute node_assign_owner_action node'
-  - 'execute node_unpublish_by_keyword_action node'
   - 'execute user_add_role_action user'
   - 'execute user_block_user_action user'
   - 'execute user_remove_role_action user'


### PR DESCRIPTION
…ed into the Actions UI module (that we do not have enabled). See https://www.drupal.org/node/3413949. This can cause a fatal error with some permission operations, for example, when uninstalling the toolbar module.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1047

> If this is an issue, do we have steps to reproduce?

Uninstall the toolbar module. Fatal error happens.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Removes two permissions from the administrator role. These permissions have been moved to a module that we do not have enabled, and therefore when recalculating permissions can cause the site to crash.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
