### PR TITLE
LNP-1084: 🥃  set xdebug port explicitly in ini file.

### DIFF
--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -1,4 +1,6 @@
+zend_extension=xdebug
 xdebug.mode=debug
 xdebug.discover_client_host=0
 xdebug.idekey=PHPSTORM
 xdebug.client_host=host.docker.internal
+xdebug.client_port=9000

--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=xdebug
+;zend_extension=xdebug
 xdebug.mode=debug
 xdebug.discover_client_host=0
 xdebug.idekey=PHPSTORM


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1084

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

* Adds the zend_extension line to the ini as a comment so it's easier to turn xdebug on and off
* Sets the xdebug port explicitly to 9000

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
