### PR TITLE
LNP-1107: 🏴󠁧󠁢󠁥󠁮󠁧󠁿  serve English content from entrypoint of /en/jsonapi rather than /jsonapi, to match Welsh.

### DIFF
--- a/config/sync/language.negotiation.yml
+++ b/config/sync/language.negotiation.yml
@@ -5,7 +5,7 @@ session:
 url:
   source: path_prefix
   prefixes:
-    en: ''
+    en: en
     cy: cy
   domains:
     en: ''

--- a/requests/front end requests.http
+++ b/requests/front end requests.http
@@ -12,7 +12,7 @@
 @radio_uuid = 02bb3b40-9d1a-4194-ad8c-1054b7b3b1d8
 @search_text = prison
 # English
-@language =
+@language = /en
 # Welsh
 #@language = /cy
 


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1107

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Config change to language negotiation for english content.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

⚠️ This must be deployed in tandem with front end change https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/735 and will cause the vast majority of the page cache to become invalid. Therefore a cache warming strategy must be considered and a Service Now outage negotiated.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
