### PR TITLE
LNP-1127: ⏰  do not run cron jobs in dev when the RDS instance is shut down overnight.

### DIFF
--- a/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.cron.schedule | quote }}
+  schedule: {{ .Values.cron.drupal.schedule | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-cache-rebuild-cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-cache-rebuild-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
-  schedule: "1 3 * * *"
+  schedule: {{ .Values.cron.cacheRebuild.schedule | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/helm_deploy/prisoner-content-hub-backend/templates/drupal-scheduler-cronjob.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/templates/drupal-scheduler-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "prisoner-content-hub-backend.labels" . | nindent 4 }}
 spec:
-  schedule: "*/5 * * * *"
+  schedule: {{ .Values.cron.scheduler.schedule | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/helm_deploy/prisoner-content-hub-backend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.development.yaml
@@ -20,3 +20,11 @@ application:
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-launchpad-nonprod
+
+cron:
+  cache-rebuild:
+    schedule: "1 7 * * *"
+  drupal:
+    schedule: "0 8,10,12,14,16,18,20 * * *"
+  scheduler:
+    schedule:  "*/5 7-22 * * *"

--- a/helm_deploy/prisoner-content-hub-backend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-backend/values.yaml
@@ -91,7 +91,12 @@ ingress:
       external-dns.alpha.kubernetes.io/aws-weight: "100"
 
 cron:
-  schedule: "0 */2 * * *"
+  cacheRebuild:
+    schedule: "1 3 * * *"
+  drupal:
+    schedule: "0 */2 * * *"
+  scheduler:
+    schedule:  "*/5 * * * *"
 
 dbBackup:
   enabled: false


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1127

> If this is an issue, do we have steps to reproduce?

Look in the [launchpad-alerts-nonprod](https://mojdt.slack.com/archives/C05KNP1606R/p1739866649049389) slack channel.

### Intent

> What changes are introduced by this PR that correspond to the above card?

* moves all the cron schedules into Values so they can be overridden
* change the dev cron schedule to not run from 2200 to 0600.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
