### PR TITLE
LNP-1095: 💄  remove empty field groups from translated forms.

### DIFF
--- a/docroot/themes/custom/prisconhub/prisconhub.theme
+++ b/docroot/themes/custom/prisconhub/prisconhub.theme
@@ -5,6 +5,8 @@
  * Functions to support theming in the Prisconhub custom theme.
  */
 
+use Drupal\Core\Entity\ContentEntityFormInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 
 /**
@@ -39,4 +41,24 @@ function prisconhub_preprocess_field_multiple_value_form(&$variables) {
     $build['#attributes']['class'] = ['form-item__help-page-link'];
     $variables['table']['#header'][0]['data']['#suffix'] = \Drupal::service('renderer')->render($build);
   }
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * We use this to remove some field groups from non-default language forms.
+ * The form elements within these field groups are non-translatable, so are
+ * automatically removed. However the field groups themselves are not.
+ */
+function prisconhub_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form_object = $form_state->getFormObject();
+  if (!$form_object instanceof ContentEntityFormInterface) {
+    return;
+  }
+  if (!$form_object->isDefaultFormLangcode($form_state)) {
+    unset($form['#fieldgroups']['group_series']);
+    unset($form['#fieldgroups']['group_prisons']);
+    unset($form['#fieldgroups']['group_prison_categories']);
+  }
+
 }


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1095

> If this is an issue, do we have steps to reproduce?

Edit a translated node or taxonomy term.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Implements a form alter hook to the administration theme that will remove specific named field groups from content editing forms when editing in the non-default language.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
