### PR TITLE
LNP-1140: ⚡️ add php-spx to local docker build to allow application profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,18 @@ RUN pecl install xdebug-3.3.2 \
 
 RUN echo 'opcache.enable=0' > /usr/local/etc/php/conf.d/opcache-disable.ini
 
+# Install php-spx and dependencies for profiling.
+RUN apt-get update && apt-get install -y \
+  zlib1g-dev
+
+RUN git clone https://github.com/NoiseByNorthwest/php-spx.git \
+    && cd php-spx \
+    && git checkout release/latest \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install
+
 # Set to www-data user.
 USER 33
 ###########################################################################################

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - .:/var/www/html
       - ./php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+      - ./php/spx.ini:/usr/local/etc/php/conf.d/spx.ini
       - ~/.kube:/var/www/.kube
     env_file:
       - prisoner-content-hub-backend.env

--- a/php/spx.ini
+++ b/php/spx.ini
@@ -1,0 +1,4 @@
+extension=spx.so
+spx.http_enabled=1
+spx.http_key="dev"
+spx.http_ip_whitelist="192.168.65.1"


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1140

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

Add the php-spx extension into the local docker container running Drupal.
This allows us to profile the application to identify potential areas to improve performance.

> What changes are introduced by this PR that correspond to the above card?

Compiles and includes the latest release of php-spx when building the local docker container.
Configures it to allow local connection.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
