### PR TITLE
LNP-1565 log users being granted administrator

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -75,6 +75,7 @@ module:
   path_alias: 0
   pathologic: 0
   phpass: 0
+  prisoner_hub_audit_logs: 0
   prisoner_hub_breadcrumbs: 0
   prisoner_hub_bulk_updater: 0
   prisoner_hub_cache_warmer: 0

--- a/docroot/modules/custom/prisoner_hub_audit_logs/README.md
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/README.md
@@ -1,0 +1,30 @@
+## INTRODUCTION
+
+The Prisoner content hub audit logs module is a DESCRIBE_THE_MODULE_HERE.
+
+The primary use case for this module is:
+
+- Use case #1
+- Use case #2
+- Use case #3
+
+## REQUIREMENTS
+
+DESCRIBE_MODULE_DEPENDENCIES_HERE
+
+## INSTALLATION
+
+Install as you would normally install a contributed Drupal module.
+See: https://www.drupal.org/node/895232 for further information.
+
+## CONFIGURATION
+- Configuration step #1
+- Configuration step #2
+- Configuration step #3
+
+## MAINTAINERS
+
+Current maintainers for Drupal 10:
+
+- FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
+

--- a/docroot/modules/custom/prisoner_hub_audit_logs/README.md
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/README.md
@@ -1,16 +1,6 @@
 ## INTRODUCTION
 
-The Prisoner content hub audit logs module is a DESCRIBE_THE_MODULE_HERE.
-
-The primary use case for this module is:
-
-- Use case #1
-- Use case #2
-- Use case #3
-
-## REQUIREMENTS
-
-DESCRIBE_MODULE_DEPENDENCIES_HERE
+The Prisoner content hub audit logs module adds logs as requested by Audit function.
 
 ## INSTALLATION
 
@@ -18,13 +8,4 @@ Install as you would normally install a contributed Drupal module.
 See: https://www.drupal.org/node/895232 for further information.
 
 ## CONFIGURATION
-- Configuration step #1
-- Configuration step #2
-- Configuration step #3
-
-## MAINTAINERS
-
-Current maintainers for Drupal 10:
-
-- FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
-
+No configuration required.

--- a/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.info.yml
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.info.yml
@@ -1,0 +1,7 @@
+name: 'Prisoner content hub audit logs'
+type: module
+description: 'Adds additional logs as required for audit.'
+package: Custom
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:user

--- a/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.module
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Contains hooks for prisoner_hub_audit_logs module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_user_insert().
+ *
+ * Logs if a new user is granted the administrator role.
+ */
+function prisoner_hub_audit_logs_user_insert(UserInterface $user) {
+  if ($user->hasRole('administrator')) {
+    /** @var \Drupal\prisoner_hub_audit_logs\LogGenerator $log_generator */
+    $log_generator = \Drupal::service('prisoner_hub_audit_logs.log_generator');
+    $log_generator->logUserGrantedAdministratorRole($user);
+  }
+}
+
+/**
+ * Implements hook_user_update().
+ *
+ * Logs if an existing user is granted the administrator role.
+ */
+function prisoner_hub_audit_logs_user_update(UserInterface $user) {
+  if ($user->hasRole('administrator') && !$user->original->hasRole('administrator')) {
+    /** @var \Drupal\prisoner_hub_audit_logs\LogGenerator $log_generator */
+    $log_generator = \Drupal::service('prisoner_hub_audit_logs.log_generator');
+    $log_generator->logUserGrantedAdministratorRole($user, $user->original->getRoles(TRUE));
+  }
+}

--- a/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.services.yml
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.services.yml
@@ -1,4 +1,7 @@
 services:
   prisoner_hub_audit_logs.log_generator:
     class: Drupal\prisoner_hub_audit_logs\LogGenerator
-    arguments: ['@current_user', '@logger.channel.user']
+    arguments: ['@current_user', '@logger.channel.prisoner_hub_audit_logs']
+  logger.channel.prisoner_hub_audit_logs:
+    parent: logger.channel_base
+    arguments: ['prisoner_hub_audit_logs']

--- a/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.services.yml
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/prisoner_hub_audit_logs.services.yml
@@ -1,0 +1,4 @@
+services:
+  prisoner_hub_audit_logs.log_generator:
+    class: Drupal\prisoner_hub_audit_logs\LogGenerator
+    arguments: ['@current_user', '@logger.channel.user']

--- a/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\prisoner_hub_audit_logs;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Generates logs for events that require auditing.
+ */
+final readonly class LogGenerator {
+
+  /**
+   * Constructs a LogGenerator object.
+   */
+  public function __construct(
+    private AccountProxyInterface $currentUser,
+    private LoggerChannelInterface $loggerChannel,
+  ) {}
+
+  /**
+   * Log that a user has been granted the administrator role.
+   */
+  public function logUserGrantedAdministratorRole(UserInterface $adminUser, array $previousRoles = []): void {
+    $context = [
+      '%granting_user_email' => $this->currentUser->getEmail(),
+      '%granting_user_name' => $this->currentUser->getDisplayName(),
+      '%granting_user_id' => $this->currentUser->id(),
+      '%granted_user_email' => $adminUser->getEmail(),
+      '%granted_user_name' => $adminUser->getDisplayName(),
+      '%granted_user_id' => $adminUser->id(),
+      '%admin_user_roles' => implode(', ', $adminUser->getRoles()),
+      '%admin_user_previous_roles' => implode(', ', $previousRoles),
+    ];
+    $this->loggerChannel->log('INFO', 'User %granted_user_name with email address %granted_user_email and ID %granted_user_id has been granted the administrator role. They were granted that role by %granting_user_name with email address %granting_user_email and ID %granting_user_id. Their full set of roles is now %admin_user_roles. Their previous full set of roles was %admin_user_previous_roles.', $context);
+  }
+
+}

--- a/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
@@ -25,8 +25,9 @@ final readonly class LogGenerator {
    * Log that a user has been granted the administrator role.
    */
   public function logUserGrantedAdministratorRole(UserInterface $adminUser, array $previousRoles = []): void {
-    $newRoles = sort($adminUser->getRoles(TRUE));
-    $previousRoles = sort($previousRoles);
+    $newRoles = $adminUser->getRoles(TRUE);
+    sort($newRoles);
+    sort($previousRoles);
     $context = [
       '%granting_user_email' => $this->currentUser->getEmail(),
       '%granting_user_name' => $this->currentUser->getDisplayName(),

--- a/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
@@ -25,6 +25,8 @@ final readonly class LogGenerator {
    * Log that a user has been granted the administrator role.
    */
   public function logUserGrantedAdministratorRole(UserInterface $adminUser, array $previousRoles = []): void {
+    $newRoles = sort($adminUser->getRoles(TRUE));
+    $previousRoles = sort($previousRoles);
     $context = [
       '%granting_user_email' => $this->currentUser->getEmail(),
       '%granting_user_name' => $this->currentUser->getDisplayName(),
@@ -32,7 +34,7 @@ final readonly class LogGenerator {
       '%granted_user_email' => $adminUser->getEmail(),
       '%granted_user_name' => $adminUser->getDisplayName(),
       '%granted_user_id' => $adminUser->id(),
-      '%admin_user_roles' => implode(', ', $adminUser->getRoles()),
+      '%admin_user_roles' => implode(', ', $newRoles),
       '%admin_user_previous_roles' => implode(', ', $previousRoles),
     ];
     $this->loggerChannel->log('INFO', 'User %granted_user_name with email address %granted_user_email and ID %granted_user_id has been granted the administrator role. They were granted that role by %granting_user_name with email address %granting_user_email and ID %granting_user_id. Their full set of roles is now %admin_user_roles. Their previous full set of roles was %admin_user_previous_roles.', $context);

--- a/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
+++ b/docroot/modules/custom/prisoner_hub_audit_logs/src/LogGenerator.php
@@ -38,7 +38,7 @@ final readonly class LogGenerator {
       '%admin_user_roles' => implode(', ', $newRoles),
       '%admin_user_previous_roles' => implode(', ', $previousRoles),
     ];
-    $this->loggerChannel->log('INFO', 'User %granted_user_name with email address %granted_user_email and ID %granted_user_id has been granted the administrator role. They were granted that role by %granting_user_name with email address %granting_user_email and ID %granting_user_id. Their full set of roles is now %admin_user_roles. Their previous full set of roles was %admin_user_previous_roles.', $context);
+    $this->loggerChannel->info('User %granted_user_name with email address %granted_user_email and ID %granted_user_id has been granted the administrator role. They were granted that role by %granting_user_name with email address %granting_user_email and ID %granting_user_id. Their full set of roles is now %admin_user_roles. Their previous full set of roles was %admin_user_previous_roles.', $context);
   }
 
 }


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1565

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Creates and enables a new module.
This module hooks into hook_ENTITY_TYPE_insert and hook_ENTITY_TYPE_update for ENTITY_TYPE user.
If either hook shows a user has been granted the administrator role, it logs that fact alongside the details requested by the audit team.

> Would this PR benefit from screenshots?

No.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No.

> Are there any steps required when merging/deploying this PR?

No.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
