### PR TITLE
LNP-1666: ⬇️   downgrade and pin psy/psysh for Drush 12 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "drush/drush": "^12.4",
         "mhor/php-mediainfo": "^5.1.0",
         "npm-asset/select2": "^4.0",
-        "oomphinc/composer-installers-extender": "^2.0"
+        "oomphinc/composer-installers-extender": "^2.0",
+        "psy/psysh": "0.12.21"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "396dcdba4f095d43ec46e5c98c502d7b",
+    "content-hash": "afdff14ebdfd22f7a300f07c6ae02bf1",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -9711,16 +9711,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.22",
+            "version": "v0.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f"
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
-                "reference": "3be75d5b9244936dd4ac62ade2bfb004d13acf0f",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
                 "shasum": ""
             },
             "require": {
@@ -9784,9 +9784,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.22"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.21"
             },
-            "time": "2026-03-22T23:03:24+00:00"
+            "time": "2026-03-06T21:21:28+00:00"
         },
         {
             "name": "ralouphie/getallheaders",


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

LNP-1666

> If this is an issue, do we have steps to reproduce?

Run drush php.

Receive error `Fatal error: Access level to Drush\Psysh\Shell::hasCommand() must be public (as in class Psy\Shell) in /var/www/html/vendor/drush/drush/src/Psysh/Shell.php on line 33`

### Intent

> What changes are introduced by this PR that correspond to the above card?

Downgrade and pin psy/psysh Drush dependency to 0.12.21; see https://github.com/drush-ops/drush/issues/6547

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
