### PR TITLE
LNP-893: ⬆️   update file_mime_validator to 3.0.0 for Drupal 11 compa…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/entity_clone": "^2.0@beta",
         "drupal/field_group": "^4",
         "drupal/field_permissions": "^1.3",
-        "drupal/file_mime_validator": "^2.0",
+        "drupal/file_mime_validator": "^3",
         "drupal/flood_control": "^2.3",
         "drupal/flysystem": "^2.2",
         "drupal/flysystem_s3": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "946af99c312067e125392dc882e4dc0d",
+    "content-hash": "07cdee660939c8c3375306cd2cd03278",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -3174,26 +3174,26 @@
         },
         {
             "name": "drupal/file_mime_validator",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/file_mime_validator.git",
-                "reference": "8.x-2.0"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/file_mime_validator-8.x-2.0.zip",
-                "reference": "8.x-2.0",
-                "shasum": "ba1393cbd2abcef6bd459039a4d4cf5de6f075bc"
+                "url": "https://ftp.drupal.org/files/projects/file_mime_validator-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "deade98e99d6f20019a9b30df60c10f656a22e7f"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0",
-                    "datestamp": "1674850860",
+                    "version": "3.0.0",
+                    "datestamp": "1759988434",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
…tibility.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-893

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Updates the version constraint on file_mime_validator to the 3.x branch, which is compatible with Drupal 10 and 11, and updates the installed version specifically to 3.0.0.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
