### PR TITLE
LNP-1701: 🔧  update pathologic configuration to be aware of the new domains for new content hub production.

### DIFF
--- a/config/sync/pathologic.settings.yml
+++ b/config/sync/pathologic.settings.yml
@@ -6,5 +6,5 @@ scheme_allow_list:
   - files
   - internal
 protocol_style: path
-local_paths: 'https://*content-hub.prisoner.service.justice.gov.uk'
+local_paths: "https://*content-hub.prisoner.service.justice.gov.uk\r\nhttps://content-hub.hmpps.service.justice.gov.uk\r\nhttps://staff.content-hub.hmpps.service.justice.gov.uk"
 keep_language_prefix: false


### PR DESCRIPTION

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1701

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Adds the new front end production domains to pathologic configuration.
This means that if any paths starting with these domains are entered into HTML in Drupal, the paths will be stripped when sent to the front end, and links will be relative.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
