### PR TITLE
Lnp 1521 | Add urgent banner creation e2e coverage

### DIFF
--- a/tests/e2e/pages/nodeCreation/NodeCreationFormPOM.ts
+++ b/tests/e2e/pages/nodeCreation/NodeCreationFormPOM.ts
@@ -74,6 +74,30 @@ export class NodeCreationFormPOM {
       .first();
   }
 
+  unpublishOnDateField(): Locator {
+    return this.page
+      .locator(
+        [
+          '#edit-unpublish-on-0-value-date',
+          'input[name="unpublish_on[0][value][date]"]',
+          'input[data-drupal-selector="edit-unpublish-on-0-value-date"]',
+          'input[id*="unpublish-on"][type="date"]',
+          '[data-drupal-selector*="edit-unpublish-on"] input[type="date"]',
+        ].join(', ')
+      )
+      .first();
+  }
+
+  revisionLogMessageField(): Locator {
+    return this.page
+      .getByRole('textbox', { name: /revision log message/i })
+      .first();
+  }
+
+  detailsSummary(label: string): Locator {
+    return this.page.getByRole('button', { name: new RegExp(label, 'i') }).first();
+  }
+
   prisonCheckboxes(): Locator {
     return this.page.locator('input[type="checkbox"][name^="field_prisons"]');
   }
@@ -181,6 +205,13 @@ export class NodeCreationFormPOM {
     const bodyByLabel = this.page.getByRole('textbox', { name: /main body content|body/i }).first();
     if ((await bodyByLabel.count()) > 0) {
       await bodyByLabel.fill(body);
+    }
+  }
+
+  async fillUnpublishOnDate(date: string): Promise<void> {
+    const unpublishOnDateField = this.unpublishOnDateField();
+    if ((await unpublishOnDateField.count()) > 0) {
+      await unpublishOnDateField.fill(date);
     }
   }
 

--- a/tests/e2e/pages/nodeCreation/NodeCreationTaxonomyPOM.ts
+++ b/tests/e2e/pages/nodeCreation/NodeCreationTaxonomyPOM.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 
 const defaultPreferredCategory = process.env.PLAYWRIGHT_E2E_CATEGORY_TERM ?? 'Animated shorts';
+const defaultPreferredPrisonOwner = process.env.PLAYWRIGHT_E2E_PRISON_OWNER_TERM ?? 'Bedford';
 
 export class NodeCreationTaxonomyPOM {
   constructor(private readonly page: Page) {}
@@ -227,7 +228,13 @@ export class NodeCreationTaxonomyPOM {
       return true;
     }
 
-    return this.hasCategoryOrSeriesSelection();
+    return (await this.hasSelectionInGroup(group)) || this.hasCategoryOrSeriesSelection();
+  }
+
+  async selectPrisonOwner(preferredValue = defaultPreferredPrisonOwner): Promise<void> {
+    if (!(await this.selectFromTaxonomyGroup(/^Prison owner$/i, preferredValue))) {
+      throw new Error(`Unable to select prison owner "${preferredValue}" on the create form.`);
+    }
   }
 
   async selectFirstCategory(preferredValue = defaultPreferredCategory): Promise<void> {

--- a/tests/e2e/pages/nodeCreation/UrgentBannerCreationPOM.ts
+++ b/tests/e2e/pages/nodeCreation/UrgentBannerCreationPOM.ts
@@ -1,0 +1,60 @@
+import { Page } from '@playwright/test';
+import { NodeCreationFormPOM } from './NodeCreationFormPOM';
+import { NodeCreationNavigationPOM } from './NodeCreationNavigationPOM';
+import { NodeCreationTaxonomyPOM } from './NodeCreationTaxonomyPOM';
+
+export class UrgentBannerCreationPOM {
+  private readonly form: NodeCreationFormPOM;
+  private readonly navigation: NodeCreationNavigationPOM;
+  private readonly taxonomy: NodeCreationTaxonomyPOM;
+
+  constructor(page: Page) {
+    this.form = new NodeCreationFormPOM(page);
+    this.navigation = new NodeCreationNavigationPOM(page);
+    this.taxonomy = new NodeCreationTaxonomyPOM(page);
+  }
+
+  async expectCreatePageAccessible(): Promise<void> {
+    await this.navigation.expectCreatePageAccessible('urgent_banner');
+  }
+
+  async fillTitle(title: string): Promise<void> {
+    await this.form.fillTitle(title);
+  }
+
+  async fillUnpublishOnDate(date: string): Promise<void> {
+    await this.form.fillUnpublishOnDate(date);
+  }
+
+  revisionLogMessageField() {
+    return this.form.revisionLogMessageField();
+  }
+
+  detailsSummary(label: string) {
+    return this.form.detailsSummary(label);
+  }
+
+  prisonGroup() {
+    return this.form.prisonGroup();
+  }
+
+  async selectFirstPrison(): Promise<void> {
+    await this.form.selectFirstPrison();
+  }
+
+  async getPrisonSelectionCount(): Promise<number> {
+    return await this.form.getPrisonSelectionCount();
+  }
+
+  async selectPrisonOwner(preferredValue?: string): Promise<void> {
+    await this.taxonomy.selectPrisonOwner(preferredValue);
+  }
+
+  async save(): Promise<void> {
+    await this.form.save();
+  }
+
+  async expectNodeViewPage(title: string): Promise<void> {
+    await this.navigation.expectNodeViewPage(title);
+  }
+}

--- a/tests/e2e/tests/create_functions/contentListingPage/content-listing.page.spec.ts
+++ b/tests/e2e/tests/create_functions/contentListingPage/content-listing.page.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../actions/authActions';
 import { BasicPageCreationPOM } from '../../../pages/nodeCreation/BasicPageCreationPOM';
 import { PdfPageCreationPOM } from '../../../pages/nodeCreation/PdfPageCreationPOM';
+import { UrgentBannerCreationPOM } from '../../../pages/nodeCreation/UrgentBannerCreationPOM';
 import { appSettings } from '../../../config/appSettings';
 
 const loginRole = appSettings.roles.lcmTest;
@@ -125,6 +126,53 @@ test.describe('content listing', () => {
 
       await runStep('filter by content type: PDF', async () => {
         await page.selectOption('select[name="type"]', 'moj_pdf_item');
+        await page.click('input[type="submit"][value="Filter"]');
+        await expect(page.locator('table')).toContainText(uniqueTitle);
+      });
+    });
+  });
+
+  test('newly created urgent banner appears in content listing', async ({ page }, testInfo) => {
+    const runStep = createStepRunner(page, testInfo);
+    const uniqueTitle = `Playwright urgent listing ${Date.now()}`;
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+    await runWithTemporaryUser(loginRole, async (user) => {
+      const urgentBanner = new UrgentBannerCreationPOM(page);
+
+      await loginViaUi(page, user.username, user.password, runStep);
+
+      await runStep('open urgent banner create form', async () => {
+        await urgentBanner.expectCreatePageAccessible();
+      });
+
+      await runStep('fill urgent banner content fields', async () => {
+        await urgentBanner.fillTitle(uniqueTitle);
+        await urgentBanner.fillUnpublishOnDate(tomorrow);
+        await urgentBanner.selectFirstPrison();
+      });
+
+      await runStep('save urgent banner content', async () => {
+        await urgentBanner.save();
+      });
+
+      await runStep('verify urgent banner was created before listing checks', async () => {
+        await urgentBanner.expectNodeViewPage(uniqueTitle);
+      });
+
+      await runStep('visit content listing', async () => {
+        await page.goto('/admin/content');
+        await expect(page).toHaveURL(/\/admin\/content/);
+      });
+
+      await runStep('verify new urgent banner appears in listing', async () => {
+        await page.fill('input[name="title"]', uniqueTitle);
+        await page.click('input[type="submit"][value="Filter"]');
+        await expect(page.locator('table')).toContainText(uniqueTitle);
+      });
+
+      await runStep('filter by content type: Urgent banner', async () => {
+        await page.selectOption('select[name="type"]', 'urgent_banner');
         await page.click('input[type="submit"][value="Filter"]');
         await expect(page.locator('table')).toContainText(uniqueTitle);
       });

--- a/tests/e2e/tests/create_functions/urgent_banner/create.urgent.banner.spec.ts
+++ b/tests/e2e/tests/create_functions/urgent_banner/create.urgent.banner.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { createStepRunner } from '../../../helpers/stepScreenshots';
+import { loginViaUi, runWithTemporaryUser } from '../../../actions/authActions';
+import { UrgentBannerCreationPOM } from '../../../pages/nodeCreation/UrgentBannerCreationPOM';
+import { appSettings } from '../../../config/appSettings';
+
+const loginRole = appSettings.roles.lcmTest;
+
+test.describe('urgent banner create', () => {
+  test.describe.configure({ mode: 'serial', timeout: 120000 });
+
+  test('local content manager can create urgent banner content', async ({ page }, testInfo) => {
+    const runStep = createStepRunner(page, testInfo);
+    const uniqueTitle = `Playwright urgent banner ${Date.now()}`;
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+    await runWithTemporaryUser(loginRole, async (user) => {
+      const urgentBanner = new UrgentBannerCreationPOM(page);
+
+      await loginViaUi(page, user.username, user.password, runStep);
+
+      await runStep('open urgent banner create form', async () => {
+        await urgentBanner.expectCreatePageAccessible();
+      });
+
+      await runStep('verify prison list renders', async () => {
+        await expect(urgentBanner.prisonGroup()).toBeVisible();
+        const prisonInputs = urgentBanner.prisonGroup().locator('input[name^="field_prisons"]');
+        expect(await prisonInputs.count()).toBeGreaterThan(0);
+      });
+
+      await runStep('verify details sections and revision fields render', async () => {
+        await expect(urgentBanner.detailsSummary('Prison owner')).toBeVisible();
+        await expect(urgentBanner.detailsSummary('Published date')).toBeVisible();
+        await expect(urgentBanner.detailsSummary('Authoring information')).toBeVisible();
+        await expect(urgentBanner.revisionLogMessageField()).toBeVisible();
+      });
+
+      await runStep('fill urgent banner content fields', async () => {
+        await urgentBanner.fillTitle(uniqueTitle);
+        await urgentBanner.fillUnpublishOnDate(tomorrow);
+      });
+
+      await runStep('select an urgent banner prison', async () => {
+        await urgentBanner.selectFirstPrison();
+        expect(await urgentBanner.getPrisonSelectionCount()).toBeGreaterThan(0);
+      });
+
+      await runStep('save urgent banner content', async () => {
+        await urgentBanner.save();
+      });
+
+      await runStep('verify created urgent banner content', async () => {
+        await urgentBanner.expectNodeViewPage(uniqueTitle);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?
https://dsdmoj.atlassian.net/browse/LNP-1521
> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Test coverage for urgent banner creation
- Validating banner creation on content listing table
> Would this PR benefit from screenshots?
<img width="1914" height="1029" alt="image" src="https://github.com/user-attachments/assets/000bef33-9db1-4ed0-af27-687d768b248b" />

### Considerations

> Is there any additional information that would help when reviewing this PR?
N/A
> Are there any steps required when merging/deploying this PR?
N/A
### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] This deployment has been tested [for cache invalidation](https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/3757342835/Caching+in+Drupal#Testing-if-a-deployment-will-stop-pages-being-served-from-cache)
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
